### PR TITLE
[codex] Hide class marker stars in details

### DIFF
--- a/src/components/CourseDetailModal.tsx
+++ b/src/components/CourseDetailModal.tsx
@@ -38,6 +38,10 @@ function firstPeriod(periods: number[]): number {
   return periods[0] ?? 999;
 }
 
+function formatClassLabels(classes: string[]): string {
+  return classes.map((label) => label.replace(/\*+$/, '')).join('，');
+}
+
 export default function CourseDetailModal({ group, open, onClose }: Props) {
   // 缓存最后一次非 null 的组，保证关闭动画期间内容不消失。
   const [cached, setCached] = useState<CourseGroup | null>(null);
@@ -85,7 +89,7 @@ export default function CourseDetailModal({ group, open, onClose }: Props) {
     capacity: s.capacity,
     enrolled: s.enrolled,
     time: formatScheduleCompact(s.schedule),
-    classes: s.classes.length ? s.classes.join('，') : '—',
+    classes: s.classes.length ? formatClassLabels(s.classes) : '—',
     rating: getIcourseRatingInfo(s.id),
   }));
 


### PR DESCRIPTION
## Summary

- Hide trailing `*` markers from class labels in the course detail modal.
- Preserve the original generated course data, so source Excel/imported markers remain unchanged.

## Root Cause

Some `上课班级` values in the source Excel contain class labels ending with `*`. The detail modal previously rendered those raw labels directly, so the marker appeared in the UI.

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm build`