### PR TITLE
Add custom scheduling controls and curriculum plan shortcuts

### DIFF
--- a/catalog_spider/README.md
+++ b/catalog_spider/README.md
@@ -93,6 +93,7 @@ export interface CurriculumCourse {
 }
 export interface CurriculumRecord {
   id: number;               // 与 curricula 的 key 相同，方便按 id 反查
+  sourceUrl?: string;       // 教务系统执行计划查询页（官方页面不支持单方案 URL）
   name: string;             // 培养方案全名
   grade: string;            // "2023"–"2026"
   trainType: string;        // 主修 / 交叉培养 / 科技英才班 / ...

--- a/scripts/curricula_to_ts.py
+++ b/scripts/curricula_to_ts.py
@@ -23,6 +23,7 @@ TREE_JSON = os.path.join(ROOT, "catalog_spider", "data", "raw", "program_tree.js
 PROGRAMS_JSON = os.path.join(ROOT, "catalog_spider", "data", "index", "programs.json")
 BY_TERM_JSON = os.path.join(ROOT, "catalog_spider", "data", "index", "by_program_term.json")
 OUT_TS = os.path.join(ROOT, "src", "data", "curricula.ts")
+OFFICIAL_PLAN_URL = "https://catalog.ustc.edu.cn/plan"
 
 
 def _load_json(path: str) -> Any:
@@ -56,6 +57,7 @@ def main() -> int:
         pid = str(p["id"])
         records[pid] = {
             "id": p["id"],
+            "sourceUrl": OFFICIAL_PLAN_URL,
             "name": name_by_id.get(pid, ""),
             "grade": p.get("grade"),
             "trainType": p.get("trainType"),
@@ -80,6 +82,7 @@ export interface CurriculumCourse {
 }
 export interface CurriculumRecord {
   id: number;
+  sourceUrl?: string;
   name: string;
   grade: string;
   trainType: string;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import StatsBar from '@/components/StatsBar';
 import ArrangementPanel from '@/components/ArrangementPanel';
 import CourseDetailModal from '@/components/CourseDetailModal';
 import SelectedCoursesModal from '@/components/SelectedCoursesModal';
+import CustomizationModal from '@/components/CustomizationModal';
 import { useConflicts } from '@/hooks/useConflicts';
 import { useFilteredCourses } from '@/hooks/useFilteredCourses';
 import { exportTimetableImage } from '@/utils/exportPrint';
@@ -27,6 +28,11 @@ import {
 } from '@/utils/curriculum';
 import type { WeekSelection } from '@/config/termCalendar';
 import { getWeekLabel } from '@/config/termCalendar';
+import {
+  readCustomScheduleSettings,
+  saveCustomScheduleSettings,
+  type CustomScheduleSettings,
+} from '@/utils/customization';
 
 const EMPTY_FILTER: FilterState = {
   keyword: '',
@@ -85,6 +91,11 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
   const [detailGroupKey, setDetailGroupKey] = useState<string | null>(null);
   const [selectedArrangementId, setSelectedArrangementId] = useState<string | null>(null);
   const [selectedCoursesOpen, setSelectedCoursesOpen] = useState(false);
+  const [selectedCoursesTab, setSelectedCoursesTab] = useState<'current' | 'curriculum'>('current');
+  const [customizationOpen, setCustomizationOpen] = useState(false);
+  const [customSettings, setCustomSettings] = useState<CustomScheduleSettings>(
+    readCustomScheduleSettings,
+  );
   const [curriculumSelection, setCurriculumSelection] = useState<CurriculumSelection>(readInitialCurriculumSelection);
   const [exporting, setExporting] = useState(false);
   const exportRef = useRef<HTMLDivElement>(null);
@@ -107,8 +118,8 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
 
   // 枚举：可能 0 个、1 个（无歧义）、≤8 个（按冲突升序取前 8）
   const arrangements = useMemo(
-    () => enumerateArrangements(allSelectedGroups),
-    [allSelectedGroups],
+    () => enumerateArrangements(allSelectedGroups, customSettings),
+    [allSelectedGroups, customSettings],
   );
 
   // 用户选择有效 → 应用之；否则用默认（最低冲突）
@@ -123,7 +134,7 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
 
   const appliedGroups = appliedArrangement?.groups ?? [];
 
-  const { conflictGroupKeys } = useConflicts(appliedGroups);
+  const { conflictGroupKeys } = useConflicts(appliedGroups, customSettings.blockedSlots);
 
   const stats = useMemo(
     () => computeStats(appliedGroups, conflictGroupKeys),
@@ -145,6 +156,11 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
       // 忽略写入失败（隐私模式）
     }
   }, [curriculumSelection]);
+
+  useEffect(() => {
+    saveCustomScheduleSettings(customSettings);
+    setSelectedArrangementId(null);
+  }, [customSettings]);
 
   // 切换方案时关闭详情弹窗 + 清空排课选择
   useEffect(() => {
@@ -202,6 +218,11 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
     setDetailGroupKey(groupKey);
   };
 
+  const openSelectedCourses = (tab: 'current' | 'curriculum') => {
+    setSelectedCoursesTab(tab);
+    setSelectedCoursesOpen(true);
+  };
+
   return (
     <Layout className="app-layout">
       <Layout.Content className="app-content">
@@ -211,8 +232,9 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
               curriculumOptions={curriculumOptions}
               selectedCurriculumId={curriculumSelection.curriculumId}
               onCurriculumChange={handleCurriculumChange}
+              onManageCurriculum={() => openSelectedCourses('curriculum')}
             />
-            <StatsBar stats={stats} onOpenSelectedCourses={() => setSelectedCoursesOpen(true)} />
+            <StatsBar stats={stats} onOpenSelectedCourses={() => openSelectedCourses('current')} />
           </div>
           {arrangements.length > 1 && (
             <ArrangementPanel
@@ -241,11 +263,14 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
             onToggleTheme={onToggleTheme}
             onExport={handleExport}
             exporting={exporting}
+            blockedSlots={customSettings.blockedSlots}
+            onOpenCustomization={() => setCustomizationOpen(true)}
           />
         </div>
       </Layout.Content>
       <SelectedCoursesModal
         open={selectedCoursesOpen}
+        initialTab={selectedCoursesTab}
         onClose={() => setSelectedCoursesOpen(false)}
         appliedGroups={appliedGroups}
         allSelectedGroups={allSelectedGroups}
@@ -259,6 +284,12 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
         onCurriculumChange={handleCurriculumChange}
         onCurriculumTermChange={handleCurriculumTermChange}
         onOpenDetail={openCourseDetailFromManager}
+      />
+      <CustomizationModal
+        open={customizationOpen}
+        settings={customSettings}
+        onChange={setCustomSettings}
+        onClose={() => setCustomizationOpen(false)}
       />
       <CourseDetailModal
         group={detailGroup}

--- a/src/components/BottomModal.tsx
+++ b/src/components/BottomModal.tsx
@@ -7,12 +7,22 @@ interface Props {
   title: ReactNode;
   children: ReactNode;
   onClose: () => void;
+  className?: string;
   width?: number;
   footer?: ReactNode;
   actions?: ReactNode;
 }
 
-export default function BottomModal({ open, title, children, onClose, width = 720, footer, actions }: Props) {
+export default function BottomModal({
+  open,
+  title,
+  children,
+  onClose,
+  className,
+  width = 720,
+  footer,
+  actions,
+}: Props) {
   const [present, setPresent] = useState(open);
   const pointerStartedOnMask = useRef(false);
 
@@ -33,7 +43,7 @@ export default function BottomModal({ open, title, children, onClose, width = 72
 
   return createPortal(
     <div
-      className="bottom-modal"
+      className={`bottom-modal${className ? ` ${className}` : ''}`}
       data-state={open ? 'open' : 'closed'}
       onPointerDown={(event) => {
         pointerStartedOnMask.current = event.target === event.currentTarget;

--- a/src/components/CourseDetailModal.tsx
+++ b/src/components/CourseDetailModal.tsx
@@ -6,6 +6,7 @@ import { formatWeeks, expandWeeks } from '@/utils/weeks';
 import { DAY_LABELS } from '@/constants/grid';
 import { getIcourseRatingInfo, type IcourseRatingInfo } from '@/utils/icourseRating';
 import { formatScheduleCompact } from '@/utils/scheduleFormat';
+import { formatSectionTeacher, formatTeacherList } from '@/utils/teachers';
 import BottomModal from './BottomModal';
 
 interface Props {
@@ -115,7 +116,7 @@ export default function CourseDetailModal({ group, open, onClose }: Props) {
     .map((s, i) => ({
     key: i,
     id: s.id,
-    teacher: s.teacher || '—',
+    teacher: formatSectionTeacher(s.teacher, '—'),
     // section 顶层不存 room；教室只在 schedule slot 上有。
     // 同 section 的所有 slot 通常同教室，取第一个非空即可。
     room: s.schedule.find((sl) => sl.room)?.room || '—',
@@ -162,7 +163,7 @@ export default function CourseDetailModal({ group, open, onClose }: Props) {
           <Descriptions.Item label="课堂号/班次">{sectionLabel}</Descriptions.Item>
           <Descriptions.Item label="开课单位">{rep?.department.name ?? '—'}（{rep?.department.code ?? ''}）</Descriptions.Item>
           <Descriptions.Item label="授课教师" span={2}>
-            {display.teachers.length ? display.teachers.join('、') : '—'}
+            {formatTeacherList(display.teachers, '—')}
           </Descriptions.Item>
           <Descriptions.Item label="学分 / 学时">{rep?.credits ?? 0} / {rep?.hours ?? 0}</Descriptions.Item>
           <Descriptions.Item label="考核方式">{rep?.examType ?? '—'}</Descriptions.Item>
@@ -187,7 +188,7 @@ export default function CourseDetailModal({ group, open, onClose }: Props) {
           </div>
           <div className="mobile-field">
             <span className="mobile-field__label">授课教师</span>
-            <span className="mobile-field__value">{display.teachers.length ? display.teachers.join('、') : '—'}</span>
+            <span className="mobile-field__value">{formatTeacherList(display.teachers, '—')}</span>
           </div>
           <div className="mobile-field mobile-field--pair">
             <span>

--- a/src/components/CoursePoolItem.tsx
+++ b/src/components/CoursePoolItem.tsx
@@ -4,6 +4,7 @@ import type { CourseGroup } from '@/types';
 import { courseColor } from '@/utils/courseColor';
 import { getIcourseRatingInfo } from '@/utils/icourseRating';
 import { formatScheduleCompact } from '@/utils/scheduleFormat';
+import { formatTeacherList } from '@/utils/teachers';
 
 interface Props {
   group: CourseGroup;
@@ -39,9 +40,7 @@ function CoursePoolItem({ group, selected, conflicting, theme, onToggle, onOpenD
     : group.sectionIds[0];
 
   /** 老师行：多老师时全部 join 出来，单老师直接显示 */
-  const teacherLine = group.teachers.length
-    ? group.teachers.join('、')
-    : '教师未定';
+  const teacherLine = formatTeacherList(group.teachers);
 
   /** icourse 评分：仅单班次组展示，多班次组在详情弹窗里分别展示 */
   const rating = group.sections.length === 1

--- a/src/components/CourseTable.tsx
+++ b/src/components/CourseTable.tsx
@@ -4,6 +4,7 @@ import type { CourseGroup } from '@/types';
 import { DAYS, PERIODS, DAY_LABELS } from '@/constants/grid';
 import { formatWeeks, isWeekInArray } from '@/utils/weeks';
 import { courseColor, type CourseColor } from '@/utils/courseColor';
+import { formatTeacherList } from '@/utils/teachers';
 import {
   formatDateRange,
   formatShortDate,
@@ -14,7 +15,9 @@ import {
   type WeekSelection,
 } from '@/config/termCalendar';
 import { DownloadIcon, MoonIcon, SunIcon, WarningIcon } from './icons';
+import { GearIcon } from './icons';
 import SelectWithChevron from './SelectWithChevron';
+import { blockedSlotKey } from '@/utils/customization';
 
 interface Props {
   weekSelection: WeekSelection;
@@ -26,6 +29,8 @@ interface Props {
   onToggleTheme: () => void;
   onExport: () => void | Promise<void>;
   exporting?: boolean;
+  blockedSlots: string[];
+  onOpenCustomization: () => void;
 }
 
 interface TimetableViewProps {
@@ -34,6 +39,7 @@ interface TimetableViewProps {
   exportMode?: boolean;
   themeMode: 'light' | 'dark';
   onOpenDetail?: (id: string) => void;
+  blockedSlots: string[];
 }
 
 interface TimetableEntry {
@@ -116,7 +122,7 @@ function dateOverlaps(a: TimetableEntry, b: TimetableEntry): boolean {
   return b.activeDates.some((date) => dates.has(date));
 }
 
-function markConflicts(entries: TimetableEntry[]): TimetableEntry[] {
+function markConflicts(entries: TimetableEntry[], blockedSlots: Set<string>): TimetableEntry[] {
   const conflictIds = new Set<string>();
   for (let i = 0; i < entries.length; i += 1) {
     for (let j = i + 1; j < entries.length; j += 1) {
@@ -130,13 +136,20 @@ function markConflicts(entries: TimetableEntry[]): TimetableEntry[] {
       conflictIds.add(b.id);
     }
   }
-  return entries.map((entry) => ({ ...entry, conflict: conflictIds.has(entry.id) }));
+  return entries.map((entry) => ({
+    ...entry,
+    conflict: conflictIds.has(entry.id)
+      || entry.periods.some((period) =>
+        blockedSlots.has(blockedSlotKey(entry.displayDay, period)),
+      ),
+  }));
 }
 
 function buildEntries(
   groups: CourseGroup[],
   weekSelection: WeekSelection,
   themeMode: 'light' | 'dark',
+  blockedSlots: Set<string>,
 ): TimetableEntry[] {
   const dates = getCalendarDatesForSelection(weekSelection, TERM_CALENDAR, {
     includeSpecialDates: weekSelection !== 'all',
@@ -172,7 +185,7 @@ function buildEntries(
               groupKey: group.key,
               sectionLabel: sectionLabelForGroup(group),
               courseName: group.courseName,
-              teachers: group.teachers.join('、') || '教师未定',
+              teachers: formatTeacherList(group.teachers),
               credits: group.sections[0]?.credits ?? 0,
               weeksText: formatWeeks(slot.weeks),
               periodsText: periods.join(','),
@@ -203,7 +216,7 @@ function buildEntries(
     activeDates: [...entry.activeDateSet].sort(),
     specialLabels: [...entry.specialLabelSet],
   }));
-  return markConflicts(normalized);
+  return markConflicts(normalized, blockedSlots);
 }
 
 function buildEntryMaps(entries: TimetableEntry[]) {
@@ -265,11 +278,13 @@ function entryStyle(entry: TimetableEntry): CSSProperties {
 function TimetableCell({
   day,
   entries,
+  blocked,
   rowSpan,
   onOpenDetail,
 }: {
   day: number;
   entries: TimetableEntry[];
+  blocked: boolean;
   rowSpan?: number;
   onOpenDetail?: (id: string) => void;
 }) {
@@ -279,6 +294,7 @@ function TimetableCell({
     'timetable__cell',
     day === 1 ? 'timetable__cell--first-day' : '',
     hasEntries ? 'timetable__cell--has' : 'timetable__cell--empty',
+    blocked ? 'timetable__cell--blocked' : '',
     isConflict ? 'timetable__cell--conflict' : '',
     hasEntries && !isConflict && entries.length === 1 ? 'timetable__cell--single' : '',
     rowSpan ? 'timetable__cell--span' : '',
@@ -288,6 +304,14 @@ function TimetableCell({
     <td className={className} rowSpan={rowSpan}>
       {isConflict ? <WarningIcon className="timetable__warning-icon" /> : null}
       <div className="timetable__courses">
+        {blocked ? (
+          <div
+            className="timetable-course timetable-placeholder"
+            aria-label="自定义占位时间"
+          >
+            <span>有事</span>
+          </div>
+        ) : null}
         {entries.map((entry) => (
           <button
             key={entry.id}
@@ -339,11 +363,19 @@ function DayHead({ day, info }: { day: number; info?: CalendarDateInfo }) {
   );
 }
 
-function TimetableView({ weekSelection, groups, exportMode = false, themeMode, onOpenDetail }: TimetableViewProps) {
+function TimetableView({
+  weekSelection,
+  groups,
+  exportMode = false,
+  themeMode,
+  onOpenDetail,
+  blockedSlots,
+}: TimetableViewProps) {
   const colorTheme = exportMode ? 'light' : themeMode;
+  const blockedSlotSet = useMemo(() => new Set(blockedSlots), [blockedSlots]);
   const entries = useMemo(
-    () => buildEntries(groups, weekSelection, colorTheme),
-    [groups, weekSelection, colorTheme],
+    () => buildEntries(groups, weekSelection, colorTheme, blockedSlotSet),
+    [blockedSlotSet, groups, weekSelection, colorTheme],
   );
   const { starts, covers } = useMemo(() => buildEntryMaps(entries), [entries]);
   const selectedWeekDates = useMemo(
@@ -372,7 +404,11 @@ function TimetableView({ weekSelection, groups, exportMode = false, themeMode, o
             >
               {BAND_STARTS[period] ? (
                 <th scope="row" rowSpan={BAND_STARTS[period].rowSpan} className="timetable__band-cell">
-                  {BAND_STARTS[period].label}
+                  <span className="timetable__band-label">
+                    {[...BAND_STARTS[period].label].map((character) => (
+                      <span key={character}>{character}</span>
+                    ))}
+                  </span>
                 </th>
               ) : null}
               <th scope="row" className="timetable__period-cell">
@@ -390,6 +426,7 @@ function TimetableView({ weekSelection, groups, exportMode = false, themeMode, o
                 const covering = covers.get(cellKey) ?? [];
                 const starting = starts.get(cellKey) ?? [];
                 const rowSpanBlock = getRowSpanEntries(period, covering, starting, covers);
+                const blocked = blockedSlotSet.has(cellKey);
 
                 if (rowSpanBlock) {
                   const [first] = rowSpanBlock.entries;
@@ -401,6 +438,7 @@ function TimetableView({ weekSelection, groups, exportMode = false, themeMode, o
                       key={day}
                       day={day}
                       entries={rowSpanBlock.entries}
+                      blocked={false}
                       rowSpan={rowSpanBlock.span}
                       onOpenDetail={onOpenDetail}
                     />
@@ -412,6 +450,7 @@ function TimetableView({ weekSelection, groups, exportMode = false, themeMode, o
                     key={day}
                     day={day}
                     entries={starting}
+                    blocked={blocked}
                     onOpenDetail={onOpenDetail}
                   />
                 );
@@ -434,6 +473,8 @@ export default function CourseTable({
   onToggleTheme,
   onExport,
   exporting = false,
+  blockedSlots,
+  onOpenCustomization,
 }: Props) {
   const toggleLabel = themeMode === 'dark' ? '切换到亮色模式' : '切换到暗色模式';
   const weekOptions = useMemo(() => getWeekOptions(), []);
@@ -479,10 +520,19 @@ export default function CourseTable({
               : <MoonIcon className="course-table__icon" />}
           </Button>
           <Button
+            className="course-table__customize-button"
+            onClick={onOpenCustomization}
+            aria-label="自定义"
+            icon={<GearIcon className="course-table__button-icon" />}
+          >
+            <span className="course-table__customize-label">自定义</span>
+          </Button>
+          <Button
             className="course-table__export-button"
             type="primary"
             onClick={onExport}
             loading={exporting}
+            aria-label="导出图片"
             icon={<DownloadIcon className="course-table__button-icon" />}
           >
             <span className="course-table__export-label">导出图片</span>
@@ -495,6 +545,7 @@ export default function CourseTable({
           weekSelection={weekSelection}
           groups={groups}
           themeMode={themeMode}
+          blockedSlots={blockedSlots}
           onOpenDetail={onOpenDetail}
         />
       </div>
@@ -505,6 +556,7 @@ export default function CourseTable({
           groups={groups}
           exportMode
           themeMode="light"
+          blockedSlots={blockedSlots}
         />
       </div>
     </div>

--- a/src/components/CustomizationModal.tsx
+++ b/src/components/CustomizationModal.tsx
@@ -1,0 +1,264 @@
+import { App, Button } from 'antd';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { DAYS, PERIODS, DAY_LABELS } from '@/constants/grid';
+import {
+  blockedSlotKey,
+  type CustomScheduleSettings,
+} from '@/utils/customization';
+import BottomModal from './BottomModal';
+
+interface Props {
+  open: boolean;
+  settings: CustomScheduleSettings;
+  onChange: (settings: CustomScheduleSettings) => void;
+  onClose: () => void;
+}
+
+interface AppleToggleProps {
+  checked: boolean;
+  label: string;
+  onChange: (checked: boolean) => void;
+}
+
+function AppleToggle({ checked, label, onChange }: AppleToggleProps) {
+  const pointerRef = useRef<{
+    pointerId: number;
+    startX: number;
+    initial: boolean;
+    moved: boolean;
+    lastValue: boolean;
+  } | null>(null);
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-label={label}
+      aria-checked={checked}
+      className={`apple-toggle${checked ? ' apple-toggle--checked' : ''}`}
+      onPointerDown={(event) => {
+        if (event.button !== 0) return;
+        event.preventDefault();
+        event.currentTarget.setPointerCapture(event.pointerId);
+        pointerRef.current = {
+          pointerId: event.pointerId,
+          startX: event.clientX,
+          initial: checked,
+          moved: false,
+          lastValue: checked,
+        };
+      }}
+      onPointerMove={(event) => {
+        const pointer = pointerRef.current;
+        if (!pointer || pointer.pointerId !== event.pointerId) return;
+        const delta = event.clientX - pointer.startX;
+        if (Math.abs(delta) < 4) return;
+        pointer.moved = true;
+        const next = delta > 0;
+        if (next === pointer.lastValue) return;
+        pointer.lastValue = next;
+        onChange(next);
+      }}
+      onPointerUp={(event) => {
+        const pointer = pointerRef.current;
+        if (!pointer || pointer.pointerId !== event.pointerId) return;
+        if (!pointer.moved) onChange(!pointer.initial);
+        pointerRef.current = null;
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      }}
+      onPointerCancel={() => {
+        pointerRef.current = null;
+      }}
+      onClick={(event) => {
+        if (event.detail === 0) onChange(!checked);
+      }}
+    >
+      <span className="apple-toggle__thumb" />
+    </button>
+  );
+}
+
+export default function CustomizationModal({ open, settings, onChange, onClose }: Props) {
+  const { message } = App.useApp();
+  const [draftBlockedSlots, setDraftBlockedSlots] = useState(settings.blockedSlots);
+  const blockedSlotSet = useMemo(() => new Set(draftBlockedSlots), [draftBlockedSlots]);
+  const dragStateRef = useRef({ active: false, selecting: true, lastKey: '' });
+  const lastGridPointerTypeRef = useRef('');
+
+  useEffect(() => {
+    if (open) setDraftBlockedSlots(settings.blockedSlots);
+  }, [open, settings.blockedSlots]);
+
+  useEffect(() => {
+    const stopDragging = () => {
+      dragStateRef.current.active = false;
+      dragStateRef.current.lastKey = '';
+    };
+    window.addEventListener('pointerup', stopDragging);
+    window.addEventListener('blur', stopDragging);
+    return () => {
+      window.removeEventListener('pointerup', stopDragging);
+      window.removeEventListener('blur', stopDragging);
+    };
+  }, []);
+
+  const setPreferHalfDay = (preferHalfDay: boolean) => {
+    onChange({ ...settings, preferHalfDay });
+    message.success('排课倾向已更新');
+  };
+
+  const setPreferFewerEarlyMornings = (preferFewerEarlyMornings: boolean) => {
+    onChange({ ...settings, preferFewerEarlyMornings });
+    message.success('排课倾向已更新');
+  };
+
+  const toggleBlockedSlot = (day: number, period: number) => {
+    const key = blockedSlotKey(day, period);
+    setDraftBlockedSlots((current) => {
+      const next = new Set(current);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return [...next].sort();
+    });
+  };
+
+  const paintBlockedSlot = (key: string, selecting: boolean) => {
+    setDraftBlockedSlots((current) => {
+      const next = new Set(current);
+      if (next.has(key) === selecting) return current;
+      if (selecting) next.add(key);
+      else next.delete(key);
+      return [...next].sort();
+    });
+  };
+
+  const closeAndApply = () => {
+    if (draftBlockedSlots.join('|') !== settings.blockedSlots.join('|')) {
+      onChange({ ...settings, blockedSlots: draftBlockedSlots });
+    }
+    onClose();
+  };
+
+  return (
+    <BottomModal
+      className="customization-modal"
+      open={open}
+      title="自定义"
+      onClose={closeAndApply}
+      width={820}
+    >
+      <div className="customization">
+        <section className="customization__section">
+          <div className="customization__section-head">
+            <div>
+              <h3>排课倾向</h3>
+              <p>先保证冲突课程尽可能少，再按所选倾向排列方案。</p>
+            </div>
+          </div>
+          <div className="customization__preference-list">
+            <div className="customization__preference-row">
+              <span className="customization__preference-label">优先空出半天</span>
+              <AppleToggle
+                checked={settings.preferHalfDay}
+                label="优先空出半天"
+                onChange={setPreferHalfDay}
+              />
+            </div>
+            <div className="customization__preference-row">
+              <span className="customization__preference-label">优先减少早八天数</span>
+              <AppleToggle
+                checked={settings.preferFewerEarlyMornings}
+                label="优先减少早八天数"
+                onChange={setPreferFewerEarlyMornings}
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className="customization__section">
+          <div className="customization__section-head customization__section-head--inline">
+            <div>
+              <h3>占位</h3>
+              <p>点击或按住鼠标拖动选择时间；从已选格开始拖动可连续取消。</p>
+            </div>
+            <Button
+              disabled={draftBlockedSlots.length === 0}
+              onClick={() => setDraftBlockedSlots([])}
+            >
+              清空占位
+            </Button>
+          </div>
+          <div className="availability-grid-wrap">
+            <table
+              className="availability-grid"
+              onPointerMove={(event) => {
+                const drag = dragStateRef.current;
+                if (!drag.active) return;
+                const target = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-slot-key]');
+                const key = target?.dataset.slotKey;
+                if (!key || drag.lastKey === key) return;
+                drag.lastKey = key;
+                paintBlockedSlot(key, drag.selecting);
+              }}
+            >
+              <thead>
+                <tr>
+                  <th scope="col">节次</th>
+                  {DAYS.map((day) => <th scope="col" key={day}>{DAY_LABELS[day]}</th>)}
+                </tr>
+              </thead>
+              <tbody>
+                {PERIODS.map((period) => (
+                  <tr key={period}>
+                    <th scope="row">{period}</th>
+                    {DAYS.map((day) => {
+                      const selected = blockedSlotSet.has(blockedSlotKey(day, period));
+                      return (
+                        <td key={day}>
+                          <button
+                            type="button"
+                            data-slot-key={blockedSlotKey(day, period)}
+                            className={`availability-grid__cell${selected ? ' availability-grid__cell--selected' : ''}`}
+                            aria-label={`${DAY_LABELS[day]}第 ${period} 节${selected ? '有事' : '空闲'}`}
+                            aria-pressed={selected}
+                            onPointerDown={(event) => {
+                              lastGridPointerTypeRef.current = event.pointerType;
+                              if (event.pointerType !== 'mouse' || event.button !== 0) return;
+                              event.preventDefault();
+                              const key = blockedSlotKey(day, period);
+                              dragStateRef.current = {
+                                active: true,
+                                selecting: !selected,
+                                lastKey: key,
+                              };
+                              paintBlockedSlot(key, !selected);
+                            }}
+                            onClick={(event) => {
+                              if (event.detail === 0 || lastGridPointerTypeRef.current !== 'mouse') {
+                                toggleBlockedSlot(day, period);
+                              }
+                              lastGridPointerTypeRef.current = '';
+                            }}
+                            onDragStart={(event) => event.preventDefault()}
+                          />
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section className="customization__section customization__section--compact">
+          <div>
+            <h3>设置</h3>
+            <p>更多说明与设置入口将在这里提供。</p>
+          </div>
+          <Button disabled>查看网站功能介绍</Button>
+        </section>
+      </div>
+    </BottomModal>
+  );
+}

--- a/src/components/PlanSwitcher.tsx
+++ b/src/components/PlanSwitcher.tsx
@@ -12,12 +12,14 @@ interface Props {
   curriculumOptions: CurriculumOption[];
   selectedCurriculumId: string | null;
   onCurriculumChange: (id: string | null) => void;
+  onManageCurriculum: () => void;
 }
 
 export default function PlanSwitcher({
   curriculumOptions,
   selectedCurriculumId,
   onCurriculumChange,
+  onManageCurriculum,
 }: Props) {
   const { state, activePlan, dispatch } = usePlans();
   const { message } = App.useApp();
@@ -161,19 +163,24 @@ export default function PlanSwitcher({
           </Dropdown>
         </div>
       </div>
-      <SelectWithChevron
-        className="plan-switcher__curriculum-select"
-        showSearch
-        allowClear
-        value={selectedCurriculumId ?? undefined}
-        placeholder="选择或搜索培养方案"
-        options={curriculumOptions}
-        filterOption={filterCurriculumOption}
-        optionFilterProp="label"
-        popupClassName="curriculum-select-dropdown"
-        popupMatchSelectWidth={520}
-        onChange={(value) => onCurriculumChange(typeof value === 'string' ? value : null)}
-      />
+      <div className="plan-switcher__curriculum-row">
+        <SelectWithChevron
+          className="plan-switcher__curriculum-select"
+          showSearch
+          allowClear
+          value={selectedCurriculumId ?? undefined}
+          placeholder="选择或搜索培养方案"
+          options={curriculumOptions}
+          filterOption={filterCurriculumOption}
+          optionFilterProp="label"
+          popupClassName="curriculum-select-dropdown"
+          popupMatchSelectWidth={520}
+          onChange={(value) => onCurriculumChange(typeof value === 'string' ? value : null)}
+        />
+        <Button className="plan-switcher__manage-button" onClick={onManageCurriculum}>
+          管理
+        </Button>
+      </div>
       <BottomModal
         title="重命名方案"
         open={renameOpen}

--- a/src/components/SelectedCoursesModal.tsx
+++ b/src/components/SelectedCoursesModal.tsx
@@ -7,19 +7,25 @@ import { conflictGroupSet, detectConflicts } from '@/utils/conflict';
 import { formatScheduleCompact } from '@/utils/scheduleFormat';
 import {
   ALL_CURRICULUM_TERMS,
+  UNSPECIFIED_CURRICULUM_TERM,
   curriculumOptions,
   filterCurriculumOption,
+  formatCurriculumTerm,
   getCurriculum,
+  getCurriculumSourceUrl,
   getCurriculumTerms,
   isDeferredCurriculumCourse,
 } from '@/utils/curriculum';
+import { formatTeacherList } from '@/utils/teachers';
 import type { CurriculumCourse } from '@/data/curricula';
 import { usePlans } from '@/store/plansContext';
 import BottomModal from './BottomModal';
 import SelectWithChevron from './SelectWithChevron';
+import { ExternalLinkIcon, TrashIcon, WarningIcon } from './icons';
 
 interface Props {
   open: boolean;
+  initialTab: 'current' | 'curriculum';
   onClose: () => void;
   appliedGroups: CourseGroup[];
   allSelectedGroups: CourseGroup[];
@@ -128,6 +134,7 @@ function isInteractiveClick(target: EventTarget | null): boolean {
 
 export default function SelectedCoursesModal({
   open,
+  initialTab,
   onClose,
   appliedGroups,
   allSelectedGroups,
@@ -147,6 +154,8 @@ export default function SelectedCoursesModal({
   const [selectedGroupKeys, setSelectedGroupKeys] = useState<string[]>([]);
   const [candidateCourse, setCandidateCourse] = useState<CurriculumCourse | null>(null);
   const [confirmAction, setConfirmAction] = useState<'batchRemove' | 'clearPlan' | null>(null);
+  const [activeTab, setActiveTab] = useState<'current' | 'all' | 'curriculum'>(initialTab);
+  const [autoAddedIdsByPlan, setAutoAddedIdsByPlan] = useState<Record<string, string[]>>({});
 
   const appliedKeys = useMemo(
     () => new Set(appliedGroups.map((group) => group.key)),
@@ -175,6 +184,7 @@ export default function SelectedCoursesModal({
   );
 
   const selectedCurriculum = getCurriculum(selectedCurriculumId);
+  const selectedCurriculumSourceUrl = getCurriculumSourceUrl(selectedCurriculum);
   const curriculumTerms = useMemo(() => getCurriculumTerms(selectedCurriculum), [selectedCurriculum]);
   const allTermCurriculumCourses = useMemo(
     () => {
@@ -189,14 +199,18 @@ export default function SelectedCoursesModal({
     if (!selectedCurriculum) return [];
     const allVisibleCount = allTermCurriculumCourses
       .filter((course) => !isDeferredCurriculumCourse(course)).length;
+    const orderedTerms = [
+      ...curriculumTerms.filter((term) => term === UNSPECIFIED_CURRICULUM_TERM),
+      ...curriculumTerms.filter((term) => term !== UNSPECIFIED_CURRICULUM_TERM),
+    ];
     return [
       {
         value: ALL_CURRICULUM_TERMS,
         label: `显示全部学期（${allVisibleCount} 门）`,
       },
-      ...curriculumTerms.map((term) => ({
+      ...orderedTerms.map((term) => ({
         value: term,
-        label: `${term}（${
+        label: `${formatCurriculumTerm(term)}（${
           selectedCurriculum.terms[term]?.filter((course) => !isDeferredCurriculumCourse(course)).length ?? 0
         } 门）`,
       })),
@@ -225,16 +239,12 @@ export default function SelectedCoursesModal({
     },
     [selectedCurriculum],
   );
-  const deferredCourseSummary = deferredCurriculumCourses
-    .map((course) => `${course.name}（${course.code}）`)
-    .join('、');
-
   const makeRows = (groups: CourseGroup[]): GroupRow[] => groups.map((group) => ({
     key: group.key,
     group,
     courseName: group.courseName,
     sectionLabel: sectionLabelForGroup(group),
-    teachers: group.teachers.join('、') || '教师未定',
+    teachers: formatTeacherList(group.teachers),
     credits: creditsForGroup(group),
     schedule: formatScheduleCompact(group.schedule),
     applied: appliedKeys.has(group.key),
@@ -252,11 +262,47 @@ export default function SelectedCoursesModal({
     })),
     [visibleCurriculumCourses, groupsByCode, selectedCourseCodes],
   );
+  const requiredCurriculumCourses = useMemo(
+    () => visibleCurriculumCourses.filter((course) => course.compulsory),
+    [visibleCurriculumCourses],
+  );
+  const requiredCourseIds = useMemo(
+    () => dedupe(
+      requiredCurriculumCourses.flatMap((course) =>
+        (groupsByCode.get(course.code) ?? []).flatMap((group) => group.sectionIds),
+      ),
+    ),
+    [groupsByCode, requiredCurriculumCourses],
+  );
+  const unselectedRequiredIds = useMemo(
+    () => requiredCourseIds.filter((id) => !selectedIds.has(id)),
+    [requiredCourseIds, selectedIds],
+  );
+  const currentAutoAddedIds = activePlan ? autoAddedIdsByPlan[activePlan.id] ?? [] : [];
+  const removableAutoAddedIds = currentAutoAddedIds.filter((id) => selectedIds.has(id));
+  const requiredButtonDisabledReason = !activePlan
+    ? '请先新建或选择方案'
+    : !selectedCurriculum
+      ? '请先选择培养方案'
+      : !selectedCurriculumTerm || selectedCurriculumTerm === ALL_CURRICULUM_TERMS
+        ? '请先选择具体学期'
+        : requiredCourseIds.length === 0
+          ? '当前学期必修课程暂无可选课堂'
+          : unselectedRequiredIds.length === 0
+            ? '当前学期可用的必修课程时间组均已选择'
+            : null;
+  const clearRequiredDisabledReason = removableAutoAddedIds.length === 0
+    ? '暂无由一键选择新增且仍在方案中的课堂'
+    : null;
 
   useEffect(() => {
     const validKeys = new Set(allRows.map((row) => row.key));
     setSelectedGroupKeys((keys) => keys.filter((key) => validKeys.has(key)));
   }, [allRows]);
+
+  useEffect(() => {
+    if (open) setActiveTab(initialTab);
+  }, [initialTab, open]);
 
   useEffect(() => {
     if (!open) {
@@ -321,6 +367,30 @@ export default function SelectedCoursesModal({
     }
     dispatch({ type: 'addCourses', courseIds: group.sectionIds });
     message.success(`已加入「${group.courseName}」`);
+  };
+
+  const addCurrentTermRequiredCourses = () => {
+    if (!activePlan || requiredButtonDisabledReason) return;
+    dispatch({ type: 'addCourses', courseIds: unselectedRequiredIds });
+    setAutoAddedIdsByPlan((current) => ({
+      ...current,
+      [activePlan.id]: dedupe([
+        ...(current[activePlan.id] ?? []),
+        ...unselectedRequiredIds,
+      ]),
+    }));
+    message.success(`已加入 ${unselectedRequiredIds.length} 个必修课程课堂`);
+  };
+
+  const clearAutoAddedRequiredCourses = () => {
+    if (!activePlan || clearRequiredDisabledReason) return;
+    dispatch({ type: 'removeCourses', courseIds: removableAutoAddedIds });
+    setAutoAddedIdsByPlan((current) => {
+      const next = { ...current };
+      delete next[activePlan.id];
+      return next;
+    });
+    message.success(`已清除一键选择新增的 ${removableAutoAddedIds.length} 个课堂`);
   };
 
   const openDetail = (group: CourseGroup) => {
@@ -406,8 +476,8 @@ export default function SelectedCoursesModal({
       },
     },
     {
-      title: '已选',
-      width: 80,
+      title: '选择状态',
+      width: 96,
       render: (_, row) => (row.selected ? <Tag color="green">已选</Tag> : <Tag>未选</Tag>),
     },
     {
@@ -448,7 +518,7 @@ export default function SelectedCoursesModal({
               setCandidateCourse(row.course);
             }}
           >
-            选择时间组
+            {row.selected ? '修改时间组' : '选择时间组'}
           </Button>
         );
       },
@@ -458,7 +528,7 @@ export default function SelectedCoursesModal({
   const candidateGroups = candidateCourse ? groupsByCode.get(candidateCourse.code) ?? [] : [];
   const candidateColumns: TableProps<CourseGroup>['columns'] = [
     { title: '课堂号/班次', width: 130, render: (_, group) => sectionLabelForGroup(group) },
-    { title: '教师', width: 160, render: (_, group) => group.teachers.join('、') || '教师未定' },
+    { title: '教师', width: 160, render: (_, group) => formatTeacherList(group.teachers) },
     { title: '学分', width: 70, render: (_, group) => creditsForGroup(group) },
     { title: '时间地点', render: (_, group) => formatScheduleCompact(group.schedule) },
     {
@@ -596,7 +666,9 @@ export default function SelectedCoursesModal({
                 <Button size="small" type="primary" onClick={() => addGroup(row.matches[0])}>加入</Button>
               )
             ) : (
-              <Button size="small" type="primary" onClick={() => setCandidateCourse(row.course)}>选择时间组</Button>
+              <Button size="small" type="primary" onClick={() => setCandidateCourse(row.course)}>
+                {row.selected ? '修改时间组' : '选择时间组'}
+              </Button>
             )}
           </div>
         </article>
@@ -626,7 +698,7 @@ export default function SelectedCoursesModal({
             </div>
             <div className="selected-courses-card__meta">
               <span>{creditsForGroup(group)} 学分</span>
-              <span>{group.teachers.join('、') || '教师未定'}</span>
+              <span>{formatTeacherList(group.teachers)}</span>
             </div>
             <div className="selected-courses-card__schedule">{formatScheduleCompact(group.schedule)}</div>
             <div className="selected-courses-card__actions" onClick={(event) => event.stopPropagation()}>
@@ -672,6 +744,8 @@ export default function SelectedCoursesModal({
         </div>
         <Tabs
           className="selected-courses-tabs"
+          activeKey={activeTab}
+          onChange={(key) => setActiveTab(key as 'current' | 'all' | 'curriculum')}
           items={[
             {
               key: 'current',
@@ -744,14 +818,52 @@ export default function SelectedCoursesModal({
                       disabled={!selectedCurriculum}
                       onChange={(value) => onCurriculumTermChange(typeof value === 'string' ? value : null)}
                     />
+                    <div className="selected-courses-required-actions">
+                      <span
+                        className="selected-courses-button-hint"
+                        title={requiredButtonDisabledReason ?? undefined}
+                      >
+                        <Button
+                          className="selected-courses-required-button"
+                          type="primary"
+                          disabled={requiredButtonDisabledReason !== null}
+                          onClick={addCurrentTermRequiredCourses}
+                        >
+                          一键选择当前学期必修课程
+                        </Button>
+                      </span>
+                      <span
+                        className="selected-courses-button-hint selected-courses-button-hint--icon"
+                        title={clearRequiredDisabledReason ?? '清除一键选择新增的课程'}
+                      >
+                        <Button
+                          className="selected-courses-required-clear-button"
+                          aria-label="清除一键选择新增的课程"
+                          danger
+                          disabled={clearRequiredDisabledReason !== null}
+                          icon={<TrashIcon />}
+                          onClick={clearAutoAddedRequiredCourses}
+                        />
+                      </span>
+                    </div>
+                    <Button
+                      className="selected-courses-source-button"
+                      href={selectedCurriculumSourceUrl ?? undefined}
+                      target="_blank"
+                      rel="noreferrer"
+                      disabled={!selectedCurriculumSourceUrl}
+                      icon={<ExternalLinkIcon />}
+                    >
+                      前往教务系统
+                    </Button>
                   </div>
                   {deferredCurriculumCourses.length > 0 ? (
                     <div className="selected-courses-deferred">
-                      <Tag>暂不展示</Tag>
-                      <span>
-                        {deferredCourseSummary}
-                        暂不进入培养方案课程表（{deferredCurriculumCourses.length} 门）。体育课程未在此处展示。
-                      </span>
+                      <WarningIcon className="selected-courses-deferred__warning-icon" />
+                      <div className="selected-courses-deferred__text">
+                        <span>毕业论文（THESIS）、军事理论（MIL1001）、军事技能（MIL1002）、艺术实践（HS1003）、基础体育（PE00001）未在此处展示</span>
+                        <span>此处培养方案课程信息仅供参考，请务必参照教务系统上的信息进行核查。</span>
+                      </div>
                     </div>
                   ) : null}
                   {selectedCurriculum && selectedCurriculumTerm ? (
@@ -811,7 +923,9 @@ export default function SelectedCoursesModal({
 
       <BottomModal
         open={!!candidateCourse}
-        title={candidateCourse ? `选择时间组：${candidateCourse.name}` : '选择时间组'}
+        title={candidateCourse
+          ? `${selectedCourseCodes.has(candidateCourse.code) ? '修改' : '选择'}时间组：${candidateCourse.name}`
+          : '选择时间组'}
         onClose={() => setCandidateCourse(null)}
         width={900}
       >

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -132,3 +132,38 @@ export function MoreIcon(props: IconProps) {
     </svg>
   );
 }
+
+export function ExternalLinkIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" {...props}>
+      <path
+        d="M14.25 6.25h3.5v3.5M17.75 6.25l-7.5 7.5"
+        stroke="currentColor"
+        strokeWidth="1.9"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M12.25 7H7.5C6.67 7 6 7.67 6 8.5v8c0 .83.67 1.5 1.5 1.5h8c.83 0 1.5-.67 1.5-1.5v-4.75"
+        stroke="currentColor"
+        strokeWidth="1.9"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function GearIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" {...props}>
+      <path
+        d="M9.75 3.75h4.5l.45 2.12c.54.22 1.05.52 1.5.87l2.06-.67 2.25 3.86-1.62 1.46a7.4 7.4 0 0 1 0 1.74l1.62 1.46-2.25 3.86-2.06-.67c-.45.35-.96.65-1.5.87l-.45 2.12h-4.5l-.45-2.12a7.5 7.5 0 0 1-1.5-.87l-2.06.67-2.25-3.86 1.62-1.46a7.4 7.4 0 0 1 0-1.74L3.49 9.93l2.25-3.86 2.06.67c.45-.35.96-.65 1.5-.87l.45-2.12Z"
+        stroke="currentColor"
+        strokeWidth="1.65"
+        strokeLinejoin="round"
+      />
+      <circle cx="12" cy="12.25" r="2.75" stroke="currentColor" strokeWidth="1.65" />
+    </svg>
+  );
+}

--- a/src/hooks/useConflicts.ts
+++ b/src/hooks/useConflicts.ts
@@ -1,14 +1,23 @@
 import { useMemo } from 'react';
 import type { CourseGroup } from '@/types';
-import { detectConflicts, conflictGroupSet, type ConflictMap } from '@/utils/conflict';
+import {
+  blockedConflictGroupSet,
+  detectConflicts,
+  conflictGroupSet,
+  type ConflictMap,
+} from '@/utils/conflict';
 
 /** 返回 groups 内部的冲突信息 */
-export function useConflicts(groups: CourseGroup[]): {
+export function useConflicts(groups: CourseGroup[], blockedSlots: string[] = []): {
   conflicts: ConflictMap;
   conflictGroupKeys: Set<string>;
 } {
   return useMemo(() => {
     const conflicts = detectConflicts(groups);
-    return { conflicts, conflictGroupKeys: conflictGroupSet(conflicts) };
-  }, [groups]);
+    const conflictGroupKeys = conflictGroupSet(conflicts);
+    for (const key of blockedConflictGroupSet(groups, blockedSlots)) {
+      conflictGroupKeys.add(key);
+    }
+    return { conflicts, conflictGroupKeys };
+  }, [blockedSlots, groups]);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2208,26 +2208,57 @@ html {
 
 .selected-courses-toolbar--filters {
   display: grid;
-  grid-template-columns: minmax(260px, 1fr) minmax(120px, 180px);
+  grid-template-columns: minmax(260px, 1fr) minmax(120px, 180px) max-content;
   align-items: center;
 }
 
 .selected-courses-deferred {
-  display: flex;
-  align-items: center;
+  display: grid;
+  grid-template-columns: 15px minmax(0, 1fr);
+  align-items: start;
   gap: 6px;
   padding: 8px 10px;
   color: var(--text-sub);
   font-size: 13px;
-  background: color-mix(in srgb, var(--text) 3%, transparent);
-  border: 1px solid var(--border);
+  background: #fff;
+  border: 1px solid #f2b400;
   border-radius: var(--radius-md);
+}
+
+.selected-courses-deferred__text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.selected-courses-deferred__warning-icon {
+  width: 15px;
+  height: 15px;
+  margin-top: 1px;
+  color: #f2b400;
+  flex-shrink: 0;
 }
 
 .selected-courses-curriculum-select,
 .selected-courses-term-select {
   width: 100%;
   min-width: 0;
+}
+
+#root .selected-courses-source-button.ant-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  min-width: 128px;
+  height: var(--control-height);
+  border-radius: var(--radius-md);
+}
+
+.selected-courses-source-button svg {
+  width: 15px;
+  height: 15px;
 }
 
 .selected-courses-table .ant-table-cell {
@@ -2627,6 +2658,10 @@ html.theme-transitioning *::after {
     grid-template-columns: 1fr;
   }
 
+  #root .selected-courses-source-button.ant-btn {
+    width: 100%;
+  }
+
   .selected-courses-card__actions .ant-btn {
     flex: 1 1 120px;
   }
@@ -2767,7 +2802,529 @@ html.theme-transitioning *::after {
   }
 
   .theme-toggle,
+  .course-table__customize-button,
   .course-table__export-button {
     flex: 0 0 auto;
+  }
+}
+
+/* ============================================================
+ * Curriculum management and customization
+ * ============================================================ */
+.plan-switcher__curriculum-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+#root .plan-switcher__curriculum-select.ant-select {
+  height: 32px !important;
+  min-height: 32px !important;
+}
+
+#root .plan-switcher__manage-button.ant-btn {
+  height: 32px !important;
+  min-height: 32px !important;
+  font-size: 14px !important;
+  line-height: 30px !important;
+  white-space: nowrap;
+}
+
+.selected-courses-toolbar--filters {
+  grid-template-columns:
+    minmax(250px, 1fr)
+    minmax(120px, 168px)
+    max-content
+    max-content;
+}
+
+.selected-courses-deferred {
+  align-items: center;
+  background: var(--panel-bg);
+}
+
+.selected-courses-deferred__warning-icon {
+  margin-top: 0;
+}
+
+#root .selected-courses-required-button.ant-btn,
+#root .selected-courses-source-button.ant-btn {
+  min-height: var(--control-height);
+  white-space: nowrap;
+}
+
+.selected-courses-required-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.selected-courses-button-hint {
+  display: inline-flex;
+  min-width: 0;
+}
+
+.selected-courses-button-hint:first-child {
+  flex: 1 1 auto;
+}
+
+.selected-courses-button-hint > .ant-btn:disabled {
+  pointer-events: none;
+}
+
+.selected-courses-required-button {
+  width: 100%;
+  white-space: nowrap;
+}
+
+.selected-courses-button-hint--icon,
+.selected-courses-required-clear-button {
+  width: 32px;
+  min-width: 32px;
+  flex: 0 0 32px;
+}
+
+.selected-courses-required-clear-button.ant-btn {
+  height: 32px;
+  min-height: 32px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.selected-courses-required-clear-button svg {
+  display: block;
+  width: 17px;
+  height: 17px;
+}
+
+.selected-courses-source-button svg {
+  display: block;
+  width: 21px;
+  height: 21px;
+}
+
+.selected-courses-source-button.ant-btn .ant-btn-icon,
+#root .course-table__customize-button.ant-btn .ant-btn-icon {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
+  height: 21px;
+  line-height: 0 !important;
+}
+
+.selected-courses-source-button.ant-btn .ant-btn-icon svg,
+#root .course-table__customize-button.ant-btn .ant-btn-icon svg {
+  display: block !important;
+  margin: 0;
+  vertical-align: middle !important;
+}
+
+.timetable__band-cell {
+  writing-mode: horizontal-tb;
+  text-orientation: mixed;
+}
+
+.timetable__band-label {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  writing-mode: horizontal-tb;
+  line-height: 1.05;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+.timetable__cell--blocked {
+  background: var(--timetable-cell-bg, color-mix(in srgb, var(--panel-bg) 96%, #fff));
+}
+
+.timetable__cell--blocked.timetable__cell--conflict {
+  background: var(--conflict-bg);
+}
+
+.timetable-placeholder {
+  --block-stripe: color-mix(in srgb, var(--text-sub) 76%, var(--panel-bg));
+  --block-bg: color-mix(in srgb, var(--text-sub) 22%, var(--panel-bg));
+  --block-fg: var(--text-sub);
+  min-height: 0;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-left: 4px solid var(--block-stripe);
+  border-radius: 0 4px 4px 0;
+  background: var(--block-bg);
+  color: var(--block-fg);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: default;
+}
+
+.timetable__cell--blocked .timetable__courses {
+  position: relative;
+  z-index: 0;
+}
+
+.course-table__customize-button .course-table__button-icon {
+  width: 16px;
+  height: 16px;
+}
+
+#root .course-table__customize-button.ant-btn {
+  font-size: 14px !important;
+}
+
+#root .course-table__actions > .ant-btn {
+  height: 32px !important;
+  min-height: 32px !important;
+}
+
+.customization {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.customization__section {
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--text) 2%, var(--panel-bg));
+}
+
+.customization__section--compact,
+.customization__section-head--inline {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.customization__section h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 15px;
+}
+
+.customization__section p {
+  margin: 4px 0 0;
+  color: var(--text-sub);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.customization__preference-list {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.customization__preference-row {
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.customization__preference-row:last-child {
+  border-bottom: 0;
+}
+
+.customization__preference-label {
+  color: var(--text);
+  font-size: 15px;
+  line-height: 1.4;
+}
+
+.apple-toggle {
+  position: relative;
+  width: 51px;
+  height: 31px;
+  min-width: 51px;
+  padding: 0;
+  flex: 0 0 51px;
+  border: 1px solid #e9e9ea;
+  border-radius: 999px;
+  background: #e9e9ea;
+  box-shadow: none;
+  cursor: pointer;
+  touch-action: none;
+  transition: background-color 0.18s ease, border-color 0.18s ease;
+}
+
+.apple-toggle--checked {
+  border-color: #34c759;
+  background: #34c759;
+}
+
+.apple-toggle__thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 25px;
+  height: 25px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.28);
+  pointer-events: none;
+  transition: transform 0.18s ease, background-color 0.18s ease;
+}
+
+.apple-toggle--checked .apple-toggle__thumb {
+  background: #fff;
+  transform: translateX(20px);
+}
+
+.apple-toggle:focus-visible {
+  outline: 3px solid color-mix(in srgb, #34c759 35%, transparent);
+  outline-offset: 2px;
+}
+
+.apple-toggle:active .apple-toggle__thumb {
+  width: 27px;
+}
+
+.availability-grid-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.availability-grid {
+  width: 100%;
+  min-width: 560px;
+  border: 1px solid var(--border-strong);
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.availability-grid th {
+  height: 28px;
+  color: var(--text-sub);
+  font-size: 11px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.availability-grid th:first-child {
+  width: 38px;
+}
+
+.availability-grid thead th {
+  border-bottom: 2px solid var(--border-strong);
+}
+
+.availability-grid thead th + th,
+.availability-grid tbody th + td,
+.availability-grid tbody td + td {
+  border-left: 1px dashed var(--border);
+}
+
+.availability-grid tbody tr > * {
+  border-top: 1px dashed var(--border);
+}
+
+.availability-grid tbody tr:first-child > * {
+  border-top: 0;
+}
+
+.availability-grid tbody tr:nth-child(6) > *,
+.availability-grid tbody tr:nth-child(11) > * {
+  border-top: 2px solid var(--border-strong);
+}
+
+.availability-grid td {
+  height: 28px;
+  padding: 3px;
+}
+
+.availability-grid__cell {
+  width: 100%;
+  height: 22px;
+  padding: 0;
+  display: block;
+  border: 0;
+  border-radius: 2px;
+  background: transparent;
+  cursor: crosshair;
+}
+
+.availability-grid__cell:hover,
+.availability-grid__cell:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--panel-bg));
+}
+
+.availability-grid__cell--selected {
+  background: color-mix(in srgb, var(--text-sub) 28%, var(--panel-bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-sub) 62%, var(--border));
+}
+
+.availability-grid__cell--selected:hover {
+  outline: 0;
+  background: color-mix(in srgb, var(--text-sub) 28%, var(--panel-bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-sub) 62%, var(--border));
+}
+
+@media (max-width: 900px) {
+  .selected-courses-toolbar--filters {
+    grid-template-columns: minmax(220px, 1fr) minmax(120px, 168px);
+  }
+
+  #root .selected-courses-required-button.ant-btn,
+  #root .selected-courses-source-button.ant-btn {
+    width: 100%;
+  }
+
+  .selected-courses-required-actions {
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .selected-courses-toolbar--filters {
+    grid-template-columns: 1fr;
+  }
+
+  .customization__section {
+    padding: 12px;
+  }
+
+  .customization__section--compact {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .customization-modal .customization__section--compact .ant-btn {
+    width: 100%;
+  }
+
+  .customization__section-head--inline {
+    align-items: flex-start;
+    flex-direction: row;
+  }
+
+  .customization__preference-row {
+    min-height: 56px;
+  }
+
+  .customization-modal {
+    --bottom-modal-mobile-inset: 12px;
+    padding: var(--bottom-modal-mobile-inset);
+  }
+
+  .customization-modal .bottom-modal__panel {
+    width: 100% !important;
+    max-height: calc(100dvh - (var(--bottom-modal-mobile-inset) * 2));
+    border-radius: 16px;
+  }
+
+  .customization-modal .bottom-modal__header {
+    align-items: center;
+    padding: 14px 14px 8px;
+  }
+
+  .customization-modal .bottom-modal__title {
+    font-size: 20px;
+  }
+
+  .customization-modal .bottom-modal__body {
+    padding: 0 12px 12px;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+  }
+
+  .customization {
+    gap: 10px;
+  }
+
+  .customization__section {
+    gap: 10px;
+    border-radius: 10px;
+  }
+
+  .customization__section h3 {
+    font-size: 16px;
+  }
+
+  .customization__section p {
+    line-height: 1.45;
+  }
+
+  .customization__preference-row {
+    min-height: 52px;
+    gap: 12px;
+  }
+
+  .customization__section-head--inline {
+    gap: 8px;
+  }
+
+  .customization__section-head--inline > div {
+    min-width: 0;
+  }
+
+  .customization__section-head--inline .ant-btn {
+    padding-inline: 8px;
+    flex: 0 0 auto;
+  }
+
+  .availability-grid-wrap {
+    overflow-x: hidden;
+  }
+
+  .availability-grid {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .availability-grid th {
+    height: 27px;
+    font-size: 10px;
+  }
+
+  .availability-grid th:first-child {
+    width: 28px;
+  }
+
+  .availability-grid td {
+    height: 27px;
+    padding: 2px;
+  }
+
+  .availability-grid__cell {
+    height: 22px;
+  }
+}
+
+@media (max-width: 520px) {
+  .course-table__customize-label {
+    display: none;
+  }
+
+  #root .course-table__customize-button.ant-btn {
+    width: 32px;
+    min-width: 32px;
+    padding-inline: 0;
   }
 }

--- a/src/utils/arrangement.ts
+++ b/src/utils/arrangement.ts
@@ -1,5 +1,10 @@
 import type { Arrangement, CourseGroup } from '@/types';
 import { expandWeeks } from './weeks';
+import {
+  blockedSlotKey,
+  DEFAULT_CUSTOM_SETTINGS,
+  type CustomScheduleSettings,
+} from './customization';
 
 /**
  * 返回出现 ≥2 次的 courseCode 列表（首次出现顺序）
@@ -21,7 +26,7 @@ export function findAmbiguousCodes(groups: CourseGroup[]): string[] {
 }
 
 /** 用 slotKey 计数冲突，2 个以上不同 group 撞同一 slotKey 算 1 个冲突 group */
-function countConflicts(groups: CourseGroup[]): number {
+function countConflicts(groups: CourseGroup[], blockedSlots: Set<string>): number {
   const occ = new Map<string, Set<string>>();
   for (const g of groups) {
     for (const slot of g.schedule) {
@@ -42,7 +47,60 @@ function countConflicts(groups: CourseGroup[]): number {
   for (const s of occ.values()) {
     if (s.size >= 2) for (const k of s) seen.add(k);
   }
+  if (blockedSlots.size > 0) {
+    for (const group of groups) {
+      if (group.schedule.some((slot) =>
+        slot.periods.some((period) => blockedSlots.has(blockedSlotKey(slot.day, period))),
+      )) {
+        seen.add(group.key);
+      }
+    }
+  }
   return seen.size;
+}
+
+function occupiedPeriodsByDay(groups: CourseGroup[], blockedSlots: Set<string>): Map<number, Set<number>> {
+  const occupied = new Map<number, Set<number>>();
+  for (let day = 1; day <= 7; day += 1) occupied.set(day, new Set());
+  for (const group of groups) {
+    for (const slot of group.schedule) {
+      const periods = occupied.get(slot.day);
+      if (!periods) continue;
+      for (const period of slot.periods) periods.add(period);
+    }
+  }
+  for (const key of blockedSlots) {
+    const [day, period] = key.split('-').map(Number);
+    occupied.get(day)?.add(period);
+  }
+  return occupied;
+}
+
+function halfDayScore(groups: CourseGroup[], blockedSlots: Set<string>): number {
+  const occupied = occupiedPeriodsByDay(groups, blockedSlots);
+  let best = 0;
+  for (let day = 1; day <= 5; day += 1) {
+    const periods = occupied.get(day) ?? new Set<number>();
+    const afternoonAndEveningEmpty = Array.from({ length: 8 }, (_, index) => index + 6)
+      .every((period) => !periods.has(period));
+    if (afternoonAndEveningEmpty) best = Math.max(best, 2);
+    else {
+      const afternoonEmpty = Array.from({ length: 5 }, (_, index) => index + 6)
+        .every((period) => !periods.has(period));
+      if (afternoonEmpty) best = Math.max(best, 1);
+    }
+  }
+  return best;
+}
+
+function earlyMorningDayCount(groups: CourseGroup[]): number {
+  const days = new Set<number>();
+  for (const group of groups) {
+    for (const slot of group.schedule) {
+      if (slot.periods.some((period) => period === 1 || period === 2)) days.add(slot.day);
+    }
+  }
+  return days.size;
 }
 
 function sumCredits(groups: CourseGroup[]): number {
@@ -88,8 +146,12 @@ function cartesian<T>(lists: T[][]): T[][] {
  * - 无歧义时返回 1 个 Arrangement（唯一视图）
  * - 输入空数组返回 []
  */
-export function enumerateArrangements(groups: CourseGroup[]): Arrangement[] {
+export function enumerateArrangements(
+  groups: CourseGroup[],
+  settings: CustomScheduleSettings = DEFAULT_CUSTOM_SETTINGS,
+): Arrangement[] {
   if (groups.length === 0) return [];
+  const blockedSlots = new Set(settings.blockedSlots);
 
   // 按 courseCode 桶
   const byCode = new Map<string, CourseGroup[]>();
@@ -121,7 +183,7 @@ export function enumerateArrangements(groups: CourseGroup[]): Arrangement[] {
     return {
       id: arrangementId(allGroups),
       groups: allGroups,
-      conflictCount: countConflicts(allGroups),
+      conflictCount: countConflicts(allGroups, blockedSlots),
       courseCount: allGroups.length,
       totalCredits: sumCredits(allGroups),
       totalHours: sumHours(allGroups),
@@ -131,6 +193,14 @@ export function enumerateArrangements(groups: CourseGroup[]): Arrangement[] {
   // 排序：(冲突数 asc, groupKeys 字典序 asc, 总学分 desc) 稳定
   arrs.sort((a, b) => {
     if (a.conflictCount !== b.conflictCount) return a.conflictCount - b.conflictCount;
+    if (settings.preferHalfDay) {
+      const scoreDelta = halfDayScore(b.groups, blockedSlots) - halfDayScore(a.groups, blockedSlots);
+      if (scoreDelta !== 0) return scoreDelta;
+    }
+    if (settings.preferFewerEarlyMornings) {
+      const earlyDelta = earlyMorningDayCount(a.groups) - earlyMorningDayCount(b.groups);
+      if (earlyDelta !== 0) return earlyDelta;
+    }
     const aKeys = a.groups.map((g) => g.key).sort().join('|');
     const bKeys = b.groups.map((g) => g.key).sort().join('|');
     if (aKeys !== bKeys) return aKeys < bKeys ? -1 : 1;

--- a/src/utils/conflict.ts
+++ b/src/utils/conflict.ts
@@ -1,5 +1,6 @@
 import type { CourseGroup } from '@/types';
 import { expandWeeks } from './weeks';
+import { blockedSlotKey } from './customization';
 
 /** slotKey = `${week}-${day}-${period}` */
 export type ConflictMap = Map<string, Set<string>>;
@@ -42,6 +43,24 @@ export function conflictGroupSet(conflicts: ConflictMap): Set<string> {
     for (const key of set) s.add(key);
   }
   return s;
+}
+
+/** 返回与用户占位时间相撞的课程组；同一课程撞多个占位仍只计一次。 */
+export function blockedConflictGroupSet(
+  groups: CourseGroup[],
+  blockedSlots: Iterable<string>,
+): Set<string> {
+  const blocked = blockedSlots instanceof Set ? blockedSlots : new Set(blockedSlots);
+  const conflictGroups = new Set<string>();
+  if (blocked.size === 0) return conflictGroups;
+  for (const group of groups) {
+    if (group.schedule.some((slot) =>
+      slot.periods.some((period) => blocked.has(blockedSlotKey(slot.day, period))),
+    )) {
+      conflictGroups.add(group.key);
+    }
+  }
+  return conflictGroups;
 }
 
 /** slotKey 是否处于冲突 */

--- a/src/utils/curriculum.ts
+++ b/src/utils/curriculum.ts
@@ -7,6 +7,21 @@ export interface CurriculumOption {
 }
 
 export const ALL_CURRICULUM_TERMS = '__all_terms__';
+export const UNSPECIFIED_CURRICULUM_TERM = '未指定学期';
+const CURRICULUM_SOURCE_URL = 'https://catalog.ustc.edu.cn/plan';
+
+const CURRICULUM_TERM_LABELS: Record<string, string> = {
+  [UNSPECIFIED_CURRICULUM_TERM]: '学期未定',
+};
+
+export function formatCurriculumTerm(term: string): string {
+  return CURRICULUM_TERM_LABELS[term] ?? term;
+}
+
+export function getCurriculumSourceUrl(record: CurriculumRecord | null): string | null {
+  if (!record) return null;
+  return record.sourceUrl ?? CURRICULUM_SOURCE_URL;
+}
 
 function compareText(a: string, b: string): number {
   return a.localeCompare(b, 'zh-Hans-CN');
@@ -88,7 +103,7 @@ export function filterCurriculumOption(input: string, option?: unknown): boolean
   return terms.length > 0 && terms.every((term) => compactOptionText.includes(term));
 }
 
-const DEFERRED_CURRICULUM_CODES = new Set(['MIL1001', 'MIL1002', 'PE00001', 'THESIS', 'THESIS-M']);
+const DEFERRED_CURRICULUM_CODES = new Set(['HS1003', 'MIL1001', 'MIL1002', 'PE00001', 'THESIS', 'THESIS-M']);
 const DEFERRED_CURRICULUM_NAMES = new Set(['军事理论', '军事技能', '艺术实践', '基础体育', '毕业论文']);
 
 export function isDeferredCurriculumCourse(course: CurriculumCourse): boolean {
@@ -104,10 +119,19 @@ export function getCurriculum(id: string | null): CurriculumRecord | null {
 
 export function getCurriculumTerms(record: CurriculumRecord | null): string[] {
   if (!record) return [];
-  return Object.entries(record.terms)
-    .filter(([, courses]) => courses.some((course) => !isDeferredCurriculumCourse(course)))
+  const terms = Object.entries(record.terms)
+    .filter(([term, courses]) =>
+      term === UNSPECIFIED_CURRICULUM_TERM
+        ? courses.length > 0
+        : courses.some((course) => !isDeferredCurriculumCourse(course)),
+    )
     .map(([term]) => term)
     .sort(compareCurriculumTerms);
+  const regularTerms = terms.filter((term) => term !== UNSPECIFIED_CURRICULUM_TERM);
+  if (!terms.includes(UNSPECIFIED_CURRICULUM_TERM)) return regularTerms;
+  return regularTerms.length
+    ? [regularTerms[0], UNSPECIFIED_CURRICULUM_TERM, ...regularTerms.slice(1)]
+    : [UNSPECIFIED_CURRICULUM_TERM];
 }
 
 export function getDefaultCurriculumTerm(id: string | null): string | null {

--- a/src/utils/customization.ts
+++ b/src/utils/customization.ts
@@ -1,0 +1,54 @@
+export interface CustomScheduleSettings {
+  preferHalfDay: boolean;
+  preferFewerEarlyMornings: boolean;
+  blockedSlots: string[];
+}
+
+export const CUSTOM_SETTINGS_KEY = 'class-arrange:v1:custom-settings';
+
+export const DEFAULT_CUSTOM_SETTINGS: CustomScheduleSettings = {
+  preferHalfDay: false,
+  preferFewerEarlyMornings: true,
+  blockedSlots: [],
+};
+
+export function blockedSlotKey(day: number, period: number): string {
+  return `${day}-${period}`;
+}
+
+function isBlockedSlot(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  const match = /^([1-7])-(1[0-3]|[1-9])$/.exec(value);
+  return Boolean(match);
+}
+
+export function readCustomScheduleSettings(): CustomScheduleSettings {
+  try {
+    const raw = localStorage.getItem(CUSTOM_SETTINGS_KEY);
+    if (!raw) return DEFAULT_CUSTOM_SETTINGS;
+    const parsed = JSON.parse(raw) as Partial<CustomScheduleSettings> & {
+      schedulePreference?: unknown;
+    };
+    return {
+      preferHalfDay: typeof parsed.preferHalfDay === 'boolean'
+        ? parsed.preferHalfDay
+        : parsed.schedulePreference === 'half-day',
+      preferFewerEarlyMornings: typeof parsed.preferFewerEarlyMornings === 'boolean'
+        ? parsed.preferFewerEarlyMornings
+        : DEFAULT_CUSTOM_SETTINGS.preferFewerEarlyMornings,
+      blockedSlots: Array.isArray(parsed.blockedSlots)
+        ? [...new Set(parsed.blockedSlots.filter(isBlockedSlot))].sort()
+        : [],
+    };
+  } catch {
+    return DEFAULT_CUSTOM_SETTINGS;
+  }
+}
+
+export function saveCustomScheduleSettings(settings: CustomScheduleSettings): void {
+  try {
+    localStorage.setItem(CUSTOM_SETTINGS_KEY, JSON.stringify(settings));
+  } catch {
+    // 隐私模式或存储空间不足时保留本次会话状态
+  }
+}

--- a/src/utils/grid.ts
+++ b/src/utils/grid.ts
@@ -1,6 +1,7 @@
 import type { CourseGroup, ScheduleSlot } from '@/types';
 import { isWeekInArray } from './weeks';
 import { formatWeeks } from './weeks';
+import { formatTeacherList } from './teachers';
 
 export interface GridEntry {
   /** 选课单元 key（同组多班次合并后只剩一个 entry） */
@@ -61,7 +62,7 @@ export function buildWeekGrid(groups: CourseGroup[], week: number): GridCell[][]
           groupKey: g.key,
           sectionLabel: sectionLabelForGroup(g),
           courseName: g.courseName,
-          teachers: g.teachers.join('、') || '教师未定',
+          teachers: formatTeacherList(g.teachers),
           credits: g.sections[0]?.credits ?? 0,
           weeksText: formatWeeks(slot.weeks),
           periodsText: slot.periods.join(','),

--- a/src/utils/teachers.ts
+++ b/src/utils/teachers.ts
@@ -1,0 +1,11 @@
+export function formatSectionTeacher(teacher: string, fallback = ''): string {
+  const normalized = teacher.trim().replace(/\s*,\s*/g, '、');
+  return normalized || fallback;
+}
+
+export function formatTeacherList(teachers: string[], fallback = '教师未定'): string {
+  const formatted = teachers
+    .map((teacher) => formatSectionTeacher(teacher))
+    .filter(Boolean);
+  return formatted.length ? formatted.join(' / ') : fallback;
+}


### PR DESCRIPTION
## Summary

This PR adds custom scheduling controls and improves curriculum-plan course selection workflows.

## Changes

- Added a new “Custom” settings modal with:
  - Apple-style switches for scheduling preferences
  - “Prefer free half-day” scheduling preference
  - “Prefer fewer early mornings” scheduling preference
  - Interactive occupied-time grid for marking unavailable slots
  - Drag-to-select support in the occupied-time grid
  - Mobile-specific layout optimizations

- Integrated occupied-time slots into scheduling:
  - Occupied slots are rendered on the timetable as “Busy” blocks
  - Courses overlapping occupied slots are counted as conflicts
  - Conflict detection now includes user-defined occupied slots

- Improved arrangement ranking:
  - Preserves minimum-conflict priority
  - Adds preference scoring for free half-days
  - Adds early-morning minimization based on original course times

- Improved curriculum-plan course management:
  - Added a “Manage” shortcut next to the curriculum selector
  - Added one-click required-course selection for the selected curriculum term
  - Added a trash icon button to remove only courses added by the one-click action
  - Added disabled-state hints and success notifications
  - Renamed selected-state heading from “Selected” to “Selection Status”
  - Changes selected multi-time-group action text to “Modify Time Group”

- UI fixes and polish:
  - Adjusted external academic-system button icon sizing and alignment
  - Removed unwanted hover tooltip on the academic-system button
  - Fixed warning icon vertical alignment
  - Fixed Safari timetable period-label writing direction
  - Matched button sizes and typography across toolbar actions
  - Improved mobile custom-settings layout

- Data and formatting updates:
  - Added curriculum source URL support
  - Added support for unspecified curriculum terms
  - Improved teacher-name formatting across course cards, details, and timetable entries

## Validation

- Ran `pnpm build` successfully.