### PR TITLE
Add onboarding guide

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { ConfigProvider, Layout, theme, App as AntApp } from 'antd';
 import zhCN from 'antd/locale/zh_CN';
@@ -17,8 +17,16 @@ import ArrangementPanel from '@/components/ArrangementPanel';
 import CourseDetailModal from '@/components/CourseDetailModal';
 import SelectedCoursesModal from '@/components/SelectedCoursesModal';
 import CustomizationModal from '@/components/CustomizationModal';
+import OnboardingWizard from '@/components/onboarding/OnboardingWizard';
+import SpotlightTour from '@/components/onboarding/SpotlightTour';
 import { useConflicts } from '@/hooks/useConflicts';
 import { useFilteredCourses } from '@/hooks/useFilteredCourses';
+import {
+  readOnboardingState,
+  useOnboarding,
+  type OnboardingPreferences,
+} from '@/onboarding/useOnboarding';
+import type { TourStep } from '@/onboarding/tourSteps';
 import { exportTimetableImage } from '@/utils/exportPrint';
 import {
   curriculumOptions,
@@ -54,6 +62,7 @@ interface CurriculumSelection {
 }
 
 function readInitialTheme(): Theme {
+  if (!readOnboardingState().wizardCompleted) return 'light';
   try {
     const stored = localStorage.getItem(THEME_KEY);
     if (stored === 'light' || stored === 'dark') return stored;
@@ -96,6 +105,7 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
   const [customSettings, setCustomSettings] = useState<CustomScheduleSettings>(
     readCustomScheduleSettings,
   );
+  const onboarding = useOnboarding();
   const [curriculumSelection, setCurriculumSelection] = useState<CurriculumSelection>(readInitialCurriculumSelection);
   const [exporting, setExporting] = useState(false);
   const exportRef = useRef<HTMLDivElement>(null);
@@ -218,9 +228,61 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
     setDetailGroupKey(groupKey);
   };
 
-  const openSelectedCourses = (tab: 'current' | 'curriculum') => {
+  const openSelectedCourses = useCallback((tab: 'current' | 'curriculum') => {
     setSelectedCoursesTab(tab);
     setSelectedCoursesOpen(true);
+  }, []);
+
+  const handleWizardComplete = (preferences: OnboardingPreferences, startTour: boolean) => {
+    setCustomSettings((current) => ({
+      ...current,
+      preferHalfDay: preferences.preferHalfDay,
+      preferFewerEarlyMornings: preferences.preferFewerEarlyMornings,
+    }));
+    message.success('排课倾向已同步到自定义设置');
+    onboarding.finishWizard(preferences, startTour);
+  };
+
+  const handleRestartOnboarding = () => {
+    setDetailGroupKey(null);
+    setCustomizationOpen(false);
+    window.setTimeout(() => onboarding.startTour(), 220);
+  };
+
+  const handleTourStepAction = useCallback((action: NonNullable<TourStep['action']>) => {
+    setDetailGroupKey(null);
+    if (action === 'openSelectedCoursesCurriculum') {
+      setCustomizationOpen(false);
+      openSelectedCourses('curriculum');
+      return;
+    }
+    if (action === 'closeSelectedCourses') {
+      setSelectedCoursesOpen(false);
+      setCustomizationOpen(false);
+      return;
+    }
+    if (action === 'openCustomization') {
+      setSelectedCoursesOpen(false);
+      setCustomizationOpen(true);
+      return;
+    }
+    if (action === 'closeCustomization') {
+      setCustomizationOpen(false);
+    }
+  }, [openSelectedCourses]);
+
+  const handleTourFinish = () => {
+    setDetailGroupKey(null);
+    setSelectedCoursesOpen(false);
+    setCustomizationOpen(false);
+    onboarding.finishTour();
+  };
+
+  const handleTourSkip = () => {
+    setDetailGroupKey(null);
+    setSelectedCoursesOpen(false);
+    setCustomizationOpen(false);
+    onboarding.skipTour();
   };
 
   return (
@@ -243,14 +305,16 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
               onSelect={handleArrangementChange}
             />
           )}
-          <FilterBar filter={filter} setFilter={setFilter} resultCount={filteredGroups.length} />
-          <CoursePool
-            groups={filteredGroups}
-            selectedIds={selectedIds}
-            conflictGroupKeys={conflictGroupKeys}
-            themeMode={themeMode}
-            onOpenDetail={setDetailGroupKey}
-          />
+          <div className="course-search-tour-target" data-tour="course-search-area">
+            <FilterBar filter={filter} setFilter={setFilter} resultCount={filteredGroups.length} />
+            <CoursePool
+              groups={filteredGroups}
+              selectedIds={selectedIds}
+              conflictGroupKeys={conflictGroupKeys}
+              themeMode={themeMode}
+              onOpenDetail={setDetailGroupKey}
+            />
+          </div>
         </div>
         <div className="table-panel">
           <CourseTable
@@ -290,11 +354,25 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
         settings={customSettings}
         onChange={setCustomSettings}
         onClose={() => setCustomizationOpen(false)}
+        onRestartOnboarding={handleRestartOnboarding}
       />
       <CourseDetailModal
         group={detailGroup}
         open={!!detailGroup}
         onClose={() => setDetailGroupKey(null)}
+      />
+      <OnboardingWizard
+        open={onboarding.stage === 'wizard'}
+        preferences={onboarding.state.preferences}
+        onComplete={handleWizardComplete}
+        onSkip={onboarding.skipWizard}
+      />
+      <SpotlightTour
+        open={onboarding.stage === 'tour'}
+        entryMode={onboarding.tourEntryMode}
+        onFinish={handleTourFinish}
+        onSkip={handleTourSkip}
+        onStepAction={handleTourStepAction}
       />
     </Layout>
   );

--- a/src/components/CoursePool.tsx
+++ b/src/components/CoursePool.tsx
@@ -146,7 +146,7 @@ export default function CoursePool({ groups, selectedIds, conflictGroupKeys, the
 
   // rowProps 一旦变化需要被 List 自动观察到（react-window 2.x 自动）
   return (
-    <div className="panel-inner course-pool no-print">
+    <div className="panel-inner course-pool no-print" data-tour="search-results">
       {groups.length === 0 ? (
         <Empty description="无匹配课程" style={{ marginTop: 40 }} />
       ) : (

--- a/src/components/CourseTable.tsx
+++ b/src/components/CourseTable.tsx
@@ -481,7 +481,7 @@ export default function CourseTable({
   const sliderWeek = typeof weekSelection === 'number' ? weekSelection : 1;
 
   return (
-    <div className="panel-inner course-table-wrap">
+    <div className="panel-inner course-table-wrap" data-tour="timetable-area">
       <div className="course-table__header no-print">
         <span className="course-table__header-label">当前周次</span>
         <div className="week-slider-wrap">
@@ -523,6 +523,7 @@ export default function CourseTable({
             className="course-table__customize-button"
             onClick={onOpenCustomization}
             aria-label="自定义"
+            data-tour="customization"
             icon={<GearIcon className="course-table__button-icon" />}
           >
             <span className="course-table__customize-label">自定义</span>
@@ -533,6 +534,7 @@ export default function CourseTable({
             onClick={onExport}
             loading={exporting}
             aria-label="导出图片"
+            data-tour="export"
             icon={<DownloadIcon className="course-table__button-icon" />}
           >
             <span className="course-table__export-label">导出图片</span>
@@ -540,7 +542,7 @@ export default function CourseTable({
         </div>
       </div>
 
-      <div className="course-table__scroll">
+      <div className="course-table__scroll" data-tour="timetable">
         <TimetableView
           weekSelection={weekSelection}
           groups={groups}

--- a/src/components/CustomizationModal.tsx
+++ b/src/components/CustomizationModal.tsx
@@ -12,6 +12,7 @@ interface Props {
   settings: CustomScheduleSettings;
   onChange: (settings: CustomScheduleSettings) => void;
   onClose: () => void;
+  onRestartOnboarding: () => void;
 }
 
 interface AppleToggleProps {
@@ -78,7 +79,13 @@ function AppleToggle({ checked, label, onChange }: AppleToggleProps) {
   );
 }
 
-export default function CustomizationModal({ open, settings, onChange, onClose }: Props) {
+export default function CustomizationModal({
+  open,
+  settings,
+  onChange,
+  onClose,
+  onRestartOnboarding,
+}: Props) {
   const { message } = App.useApp();
   const [draftBlockedSlots, setDraftBlockedSlots] = useState(settings.blockedSlots);
   const blockedSlotSet = useMemo(() => new Set(draftBlockedSlots), [draftBlockedSlots]);
@@ -148,11 +155,10 @@ export default function CustomizationModal({ open, settings, onChange, onClose }
       width={820}
     >
       <div className="customization">
-        <section className="customization__section">
+        <section className="customization__section customization__section--preferences" data-tour="customization-preferences">
           <div className="customization__section-head">
             <div>
               <h3>排课倾向</h3>
-              <p>先保证冲突课程尽可能少，再按所选倾向排列方案。</p>
             </div>
           </div>
           <div className="customization__preference-list">
@@ -175,7 +181,7 @@ export default function CustomizationModal({ open, settings, onChange, onClose }
           </div>
         </section>
 
-        <section className="customization__section">
+        <section className="customization__section" data-tour="customization-blocked-slots">
           <div className="customization__section-head customization__section-head--inline">
             <div>
               <h3>占位</h3>
@@ -256,7 +262,7 @@ export default function CustomizationModal({ open, settings, onChange, onClose }
             <h3>设置</h3>
             <p>更多说明与设置入口将在这里提供。</p>
           </div>
-          <Button disabled>查看网站功能介绍</Button>
+          <Button onClick={onRestartOnboarding}>重新查看新手引导</Button>
         </section>
       </div>
     </BottomModal>

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -19,8 +19,8 @@ export default function FilterBar({ filter, setFilter, resultCount }: Props) {
   const update = (patch: Partial<FilterState>) => setFilter({ ...filter, ...patch });
 
   return (
-    <div className="panel-inner filter-bar no-print">
-      <div className="filter-bar__search">
+    <div className="panel-inner filter-bar no-print" data-tour="filters">
+      <div className="filter-bar__search" data-tour="course-search">
         <Input
           placeholder="搜索课程名 / 课堂号 / 教师"
           value={filter.keyword}

--- a/src/components/PlanSwitcher.tsx
+++ b/src/components/PlanSwitcher.tsx
@@ -122,7 +122,7 @@ export default function PlanSwitcher({
 
   return (
     <div className="plan-switcher">
-      <div className="plan-switcher__main-row">
+      <div className="plan-switcher__main-row" data-tour="scheme-list">
         <span className="plan-switcher__label">我的方案</span>
         <SelectWithChevron
           className="plan-switcher__select"
@@ -131,7 +131,7 @@ export default function PlanSwitcher({
           onChange={switchTo}
           options={planOptions}
           optionLabelProp="title"
-          popupClassName="plan-select-dropdown"
+          classNames={{ popup: { root: 'plan-select-dropdown' } }}
           disabled={state.plans.length === 0}
         />
         <div className="plan-switcher__actions">
@@ -158,12 +158,13 @@ export default function PlanSwitcher({
               aria-label="更多方案操作"
               title="更多方案操作"
               disabled={!activePlan}
+              data-tour="more-actions"
               icon={<MoreIcon />}
             />
           </Dropdown>
         </div>
       </div>
-      <div className="plan-switcher__curriculum-row">
+      <div className="plan-switcher__curriculum-row" data-tour="program-selector">
         <SelectWithChevron
           className="plan-switcher__curriculum-select"
           showSearch
@@ -173,11 +174,15 @@ export default function PlanSwitcher({
           options={curriculumOptions}
           filterOption={filterCurriculumOption}
           optionFilterProp="label"
-          popupClassName="curriculum-select-dropdown"
+          classNames={{ popup: { root: 'curriculum-select-dropdown' } }}
           popupMatchSelectWidth={520}
           onChange={(value) => onCurriculumChange(typeof value === 'string' ? value : null)}
         />
-        <Button className="plan-switcher__manage-button" onClick={onManageCurriculum}>
+        <Button
+          className="plan-switcher__manage-button"
+          data-tour="curriculum-manage"
+          onClick={onManageCurriculum}
+        >
           管理
         </Button>
       </div>

--- a/src/components/SelectedCoursesModal.tsx
+++ b/src/components/SelectedCoursesModal.tsx
@@ -796,7 +796,10 @@ export default function SelectedCoursesModal({
               label: '培养方案内课程',
               children: (
                 <div className="selected-courses-section">
-                  <div className="selected-courses-toolbar selected-courses-toolbar--filters">
+                  <div
+                    className="selected-courses-toolbar selected-courses-toolbar--filters"
+                    data-tour="selected-courses-curriculum-tools"
+                  >
                     <SelectWithChevron
                       className="selected-courses-curriculum-select"
                       showSearch
@@ -806,7 +809,7 @@ export default function SelectedCoursesModal({
                       options={curriculumOptions}
                       filterOption={filterCurriculumOption}
                       optionFilterProp="label"
-                      popupClassName="curriculum-select-dropdown"
+                      classNames={{ popup: { root: 'curriculum-select-dropdown' } }}
                       popupMatchSelectWidth={520}
                       onChange={(value) => onCurriculumChange(typeof value === 'string' ? value : null)}
                     />

--- a/src/components/StatsBar.tsx
+++ b/src/components/StatsBar.tsx
@@ -8,10 +8,11 @@ interface Props {
 
 export default function StatsBar({ stats, onOpenSelectedCourses }: Props) {
   return (
-    <div className="stats-bar">
+    <div className="stats-bar" data-tour="plan-stats">
       <button
         className="stats-bar__item stats-bar__item--button"
         type="button"
+        data-tour="selected-courses-manage"
         onClick={onOpenSelectedCourses}
         disabled={!onOpenSelectedCourses}
       >

--- a/src/components/onboarding/OnboardingConfirm.tsx
+++ b/src/components/onboarding/OnboardingConfirm.tsx
@@ -1,0 +1,36 @@
+import { Button } from 'antd';
+
+interface Props {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmText: string;
+  cancelText?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function OnboardingConfirm({
+  open,
+  title,
+  description,
+  confirmText,
+  cancelText = '继续引导',
+  onConfirm,
+  onCancel,
+}: Props) {
+  if (!open) return null;
+
+  return (
+    <div className="onboarding-confirm" role="alertdialog" aria-modal="true" aria-labelledby="onboarding-confirm-title">
+      <section className="onboarding-confirm__panel">
+        <h2 id="onboarding-confirm-title" className="onboarding-confirm__title">{title}</h2>
+        <p className="onboarding-confirm__description">{description}</p>
+        <div className="onboarding-confirm__actions">
+          <Button onClick={onCancel}>{cancelText}</Button>
+          <Button danger type="primary" onClick={onConfirm}>{confirmText}</Button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/onboarding/OnboardingWizard.tsx
+++ b/src/components/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,167 @@
+import { Button } from 'antd';
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { OnboardingPreferences } from '@/onboarding/useOnboarding';
+import OnboardingConfirm from './OnboardingConfirm';
+import './onboarding.css';
+
+interface Props {
+  open: boolean;
+  preferences: OnboardingPreferences;
+  onComplete: (preferences: OnboardingPreferences, startTour: boolean) => void;
+  onSkip: () => void;
+}
+
+interface PreferenceOption {
+  key: keyof OnboardingPreferences;
+  title: string;
+}
+
+const PREFERENCE_OPTIONS: PreferenceOption[] = [
+  {
+    key: 'preferHalfDay',
+    title: '优先空出半天',
+  },
+  {
+    key: 'preferFewerEarlyMornings',
+    title: '优先减少早八天数',
+  },
+];
+
+function PreferenceSwitch({
+  checked,
+  title,
+  onChange,
+}: {
+  checked: boolean;
+  title: string;
+  onChange: (checked: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="onboarding-preference"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+    >
+      <span className="onboarding-preference__copy">
+        <span className="onboarding-preference__title">{title}</span>
+      </span>
+      <span className={`onboarding-preference__switch${checked ? ' onboarding-preference__switch--checked' : ''}`}>
+        <span className="onboarding-preference__thumb" />
+      </span>
+    </button>
+  );
+}
+
+export default function OnboardingWizard({ open, preferences, onComplete, onSkip }: Props) {
+  const [step, setStep] = useState(0);
+  const [draft, setDraft] = useState(preferences);
+  const [confirmSkipOpen, setConfirmSkipOpen] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setStep(0);
+    setDraft(preferences);
+    setConfirmSkipOpen(false);
+  }, [open, preferences]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      setConfirmSkipOpen(true);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onSkip, open]);
+
+  if (!open || typeof document === 'undefined') return null;
+
+  const updatePreference = (key: keyof OnboardingPreferences, checked: boolean) => {
+    setDraft((current) => ({ ...current, [key]: checked }));
+  };
+
+  const skip = () => {
+    setConfirmSkipOpen(true);
+  };
+
+  return createPortal(
+    <div className="onboarding-wizard" aria-hidden={!open}>
+      <section
+        className="onboarding-wizard__panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboarding-wizard-title"
+      >
+        <div className="onboarding-wizard__content">
+          {step === 0 ? (
+            <div className="onboarding-wizard__step">
+              <p className="onboarding-wizard__eyebrow">首次进入</p>
+              <h2 id="onboarding-wizard-title" className="onboarding-wizard__title">欢迎使用排课工具</h2>
+              <p className="onboarding-wizard__body">
+                你可以在这里搜索课程、生成多个课表方案、查询培养方案，并根据自己的偏好筛选出更合适的安排。
+              </p>
+            </div>
+          ) : null}
+
+          {step === 1 ? (
+            <div className="onboarding-wizard__step">
+              <p className="onboarding-wizard__eyebrow">基础偏好</p>
+              <h2 id="onboarding-wizard-title" className="onboarding-wizard__title">选择使用偏好</h2>
+              <div className="onboarding-wizard__preferences">
+                {PREFERENCE_OPTIONS.map((option) => (
+                  <PreferenceSwitch
+                    key={option.key}
+                    checked={draft[option.key]}
+                    title={option.title}
+                    onChange={(checked) => updatePreference(option.key, checked)}
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="onboarding-wizard__footer">
+          <div className="onboarding-wizard__actions">
+            {step > 0 ? <Button onClick={() => setStep((current) => current - 1)}>上一步</Button> : null}
+            {step === 0 ? (
+              <Button className="onboarding-wizard__skip-button" type="text" onClick={skip}>跳过</Button>
+            ) : null}
+            {step === 0 ? (
+              <Button
+                type="primary"
+                onClick={() => setStep((current) => current + 1)}
+              >
+                开始设置
+              </Button>
+            ) : (
+              <Button type="primary" onClick={() => onComplete(draft, true)}>下一步</Button>
+            )}
+          </div>
+        </div>
+      </section>
+      <OnboardingConfirm
+        open={confirmSkipOpen}
+        title="跳过新手引导？"
+        description="跳过后不会自动再次弹出，你仍然可以从“自定义”中重新查看。"
+        confirmText="确认跳过"
+        onCancel={() => setConfirmSkipOpen(false)}
+        onConfirm={onSkip}
+      />
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/onboarding/SpotlightTour.tsx
+++ b/src/components/onboarding/SpotlightTour.tsx
@@ -1,0 +1,517 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { tourSteps, type TourPlacement, type TourStep } from '@/onboarding/tourSteps';
+import OnboardingConfirm from './OnboardingConfirm';
+import TourCard from './TourCard';
+import './onboarding.css';
+
+type TourAction = NonNullable<TourStep['action']>;
+type TourEntryMode = 'wizard' | 'manual';
+
+interface Props {
+  open: boolean;
+  entryMode?: TourEntryMode;
+  onFinish: () => void;
+  onSkip: () => void;
+  onStepAction: (action: TourAction) => void;
+}
+
+interface SpotlightRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface CardPosition {
+  top: number;
+  left: number;
+  placement: TourPlacement | 'mobile';
+}
+
+interface ClickPoint {
+  key: string;
+  x: number;
+  y: number;
+}
+
+type SidePlacement = Exclude<TourPlacement, 'center'>;
+
+const SPOTLIGHT_MARGIN = 10;
+const VIEWPORT_PADDING = 12;
+const CARD_GAP = 16;
+const DESKTOP_CARD_WIDTH = 360;
+const DEFAULT_CARD_HEIGHT = 220;
+const SIDE_PLACEMENTS: SidePlacement[] = ['right', 'bottom', 'left', 'top'];
+const ARRANGEMENT_PREVIEW_CONFLICTS = [4, 4, 4, 4, 6, 6];
+const ARRANGEMENT_PREVIEW_HEIGHT = 260;
+const FIRST_FLOAT_STEP_ID = tourSteps[0]?.entryAnimation === 'float' ? tourSteps[0].id : '';
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function prefersReducedMotion(): boolean {
+  return window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false;
+}
+
+function orderedPlacements(preferred: TourPlacement): SidePlacement[] {
+  const ordered: SidePlacement[] = [];
+  if (preferred !== 'center') ordered.push(preferred);
+  for (const placement of SIDE_PLACEMENTS) {
+    if (!ordered.includes(placement)) ordered.push(placement);
+  }
+  return ordered;
+}
+
+function getTargetRect(target: HTMLElement): SpotlightRect {
+  const bounds = target.getBoundingClientRect();
+  const left = Math.max(VIEWPORT_PADDING, bounds.left - SPOTLIGHT_MARGIN);
+  const top = Math.max(VIEWPORT_PADDING, bounds.top - SPOTLIGHT_MARGIN);
+  const right = Math.min(window.innerWidth - VIEWPORT_PADDING, bounds.right + SPOTLIGHT_MARGIN);
+  const bottom = Math.min(window.innerHeight - VIEWPORT_PADDING, bounds.bottom + SPOTLIGHT_MARGIN);
+
+  return {
+    left,
+    top,
+    width: Math.max(0, right - left),
+    height: Math.max(0, bottom - top),
+  };
+}
+
+function stepSelectors(step: TourStep): string[] {
+  return [...(step.targets ?? []), ...(step.target ? [step.target] : [])];
+}
+
+function getTargetRects(step: TourStep): SpotlightRect[] {
+  const targetRects = stepSelectors(step)
+    .flatMap((selector) => [...document.querySelectorAll<HTMLElement>(selector)])
+    .map(getTargetRect)
+    .filter((item) => item.width > 0 && item.height > 0);
+  if (!step.mergeTargets) return targetRects;
+  const mergedRect = unionRects(targetRects);
+  return mergedRect ? [mergedRect] : [];
+}
+
+function unionRects(rects: SpotlightRect[]): SpotlightRect | null {
+  if (rects.length === 0) return null;
+  const left = Math.min(...rects.map((item) => item.left));
+  const top = Math.min(...rects.map((item) => item.top));
+  const right = Math.max(...rects.map((item) => item.left + item.width));
+  const bottom = Math.max(...rects.map((item) => item.top + item.height));
+  return {
+    left,
+    top,
+    width: right - left,
+    height: bottom - top,
+  };
+}
+
+function cardPositionFor(
+  rect: SpotlightRect | null,
+  preferred: TourPlacement,
+  cardWidth: number,
+  cardHeight: number,
+): CardPosition {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const maxLeft = Math.max(VIEWPORT_PADDING, viewportWidth - cardWidth - VIEWPORT_PADDING);
+  const maxTop = Math.max(VIEWPORT_PADDING, viewportHeight - cardHeight - VIEWPORT_PADDING);
+
+  if (viewportWidth <= 640) {
+    return {
+      left: VIEWPORT_PADDING,
+      top: Math.max(VIEWPORT_PADDING, viewportHeight - cardHeight - VIEWPORT_PADDING),
+      placement: 'mobile',
+    };
+  }
+
+  if (!rect || preferred === 'center') {
+    return {
+      left: clamp((viewportWidth - cardWidth) / 2, VIEWPORT_PADDING, maxLeft),
+      top: clamp((viewportHeight - cardHeight) / 2, VIEWPORT_PADDING, maxTop),
+      placement: 'center',
+    };
+  }
+
+  const candidates = orderedPlacements(preferred).map((placement) => {
+    if (placement === 'right') {
+      return {
+        placement,
+        left: rect.left + rect.width + CARD_GAP,
+        top: rect.top,
+        fits: rect.left + rect.width + CARD_GAP + cardWidth <= viewportWidth - VIEWPORT_PADDING,
+      };
+    }
+    if (placement === 'bottom') {
+      return {
+        placement,
+        left: rect.left,
+        top: rect.top + rect.height + CARD_GAP,
+        fits: rect.top + rect.height + CARD_GAP + cardHeight <= viewportHeight - VIEWPORT_PADDING,
+      };
+    }
+    if (placement === 'left') {
+      return {
+        placement,
+        left: rect.left - cardWidth - CARD_GAP,
+        top: rect.top,
+        fits: rect.left - cardWidth - CARD_GAP >= VIEWPORT_PADDING,
+      };
+    }
+    return {
+      placement,
+      left: rect.left,
+      top: rect.top - cardHeight - CARD_GAP,
+      fits: rect.top - cardHeight - CARD_GAP >= VIEWPORT_PADDING,
+    };
+  });
+
+  const selected = candidates.find((candidate) => candidate.fits) ?? candidates[0];
+  return {
+    left: clamp(selected.left, VIEWPORT_PADDING, maxLeft),
+    top: clamp(selected.top, VIEWPORT_PADDING, maxTop),
+    placement: selected.placement,
+  };
+}
+
+function getArrangementPreviewRect(): SpotlightRect {
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const fallbackWidth = viewportWidth - VIEWPORT_PADDING * 2;
+  if (viewportWidth <= 640) {
+    return {
+      left: VIEWPORT_PADDING,
+      top: VIEWPORT_PADDING + 58,
+      width: fallbackWidth,
+      height: Math.min(ARRANGEMENT_PREVIEW_HEIGHT, viewportHeight - VIEWPORT_PADDING * 2 - 58),
+    };
+  }
+
+  const poolPanel = document.querySelector<HTMLElement>('.pool-panel');
+  const planSummary = document.querySelector<HTMLElement>('.plan-summary');
+  if (!poolPanel) {
+    return {
+      left: VIEWPORT_PADDING,
+      top: VIEWPORT_PADDING + 92,
+      width: Math.min(520, fallbackWidth),
+      height: ARRANGEMENT_PREVIEW_HEIGHT,
+    };
+  }
+
+  const poolRect = poolPanel.getBoundingClientRect();
+  const summaryRect = planSummary?.getBoundingClientRect();
+  const top = (summaryRect?.bottom ?? poolRect.top) + 8;
+  const bottomLimit = Math.min(poolRect.bottom, viewportHeight - VIEWPORT_PADDING);
+  const availableHeight = Math.max(240, bottomLimit - top);
+
+  return {
+    left: poolRect.left,
+    top,
+    width: poolRect.width,
+    height: Math.min(ARRANGEMENT_PREVIEW_HEIGHT, availableHeight),
+  };
+}
+
+function ArrangementPanelPreview({ rect }: { rect: SpotlightRect }) {
+  return (
+    <div
+      className="panel-inner arrangement-panel spotlight-tour__arrangement-preview"
+      data-tour="arrangement-preview"
+      style={{
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+      }}
+      aria-hidden="true"
+    >
+      <div className="arrangement-panel__head">
+        <span className="arrangement-panel__title">排课方案</span>
+        <span className="arrangement-panel__sub">共 6 种方案</span>
+      </div>
+      <div className="arrangement-panel__list">
+        {ARRANGEMENT_PREVIEW_CONFLICTS.map((conflictCount, index) => (
+          <div
+            key={index}
+            className={`arrangement-card${index === 0 ? ' arrangement-card--applied' : ''}`}
+          >
+            <div className="arrangement-card__row">
+              <span className="arrangement-card__idx">#{index}</span>
+              <span className="arrangement-card__meta">6 门 · 16 学分</span>
+              <span className="spotlight-tour__arrangement-conflict">{conflictCount} 冲突</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function SpotlightTour({
+  open,
+  entryMode = 'manual',
+  onFinish,
+  onSkip,
+  onStepAction,
+}: Props) {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [rects, setRects] = useState<SpotlightRect[]>([]);
+  const [cardPosition, setCardPosition] = useState<CardPosition>({
+    top: VIEWPORT_PADDING,
+    left: VIEWPORT_PADDING,
+    placement: 'center',
+  });
+  const [confirmSkipOpen, setConfirmSkipOpen] = useState(false);
+  const [clickPoint, setClickPoint] = useState<ClickPoint | null>(null);
+  const [entryAnimationStepId, setEntryAnimationStepId] = useState(FIRST_FLOAT_STEP_ID);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const actedStepRef = useRef('');
+  const previousStepIndexRef = useRef(0);
+  const step = tourSteps[stepIndex];
+
+  const scrollTargetIntoView = useCallback((behavior?: ScrollBehavior) => {
+    if (!open || typeof document === 'undefined') return;
+    const [firstSelector] = stepSelectors(step);
+    if (!firstSelector) return;
+    const target = document.querySelector<HTMLElement>(firstSelector);
+    target?.scrollIntoView({
+      behavior: behavior ?? (prefersReducedMotion() ? 'auto' : 'smooth'),
+      block: window.innerWidth <= 640 ? 'center' : 'nearest',
+      inline: 'center',
+    });
+  }, [open, step]);
+
+  const updateGeometry = useCallback(() => {
+    if (!open || typeof document === 'undefined') return;
+
+    const cardWidth = cardRef.current?.offsetWidth
+      ?? Math.min(DESKTOP_CARD_WIDTH, window.innerWidth - VIEWPORT_PADDING * 2);
+    const cardHeight = cardRef.current?.offsetHeight ?? DEFAULT_CARD_HEIGHT;
+    const nextRects = getTargetRects(step);
+    const nextFocusRect = unionRects(nextRects);
+
+    setRects(nextRects);
+    setCardPosition(cardPositionFor(nextFocusRect, step.placement, cardWidth, cardHeight));
+  }, [open, step]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    setStepIndex(0);
+    setRects([]);
+    setCardPosition({
+      top: VIEWPORT_PADDING,
+      left: VIEWPORT_PADDING,
+      placement: 'center',
+    });
+    setConfirmSkipOpen(false);
+    setClickPoint(null);
+    setEntryAnimationStepId(FIRST_FLOAT_STEP_ID);
+    actedStepRef.current = '';
+    previousStepIndexRef.current = 0;
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || typeof document === 'undefined') return undefined;
+
+    const previousStepIndex = previousStepIndexRef.current;
+    const movingForward = stepIndex > previousStepIndex;
+    previousStepIndexRef.current = stepIndex;
+    const timers: number[] = [];
+
+    const scheduleGeometryUpdate = (delay: number) => {
+      timers.push(window.setTimeout(() => {
+        scrollTargetIntoView();
+        timers.push(window.setTimeout(updateGeometry, prefersReducedMotion() ? 0 : 260));
+      }, delay));
+    };
+
+    const runAction = () => {
+      if (!step.action) return;
+      onStepAction(step.action);
+    };
+
+    const actionKey = `${stepIndex}:${step.action ?? ''}`;
+    if (step.action && actedStepRef.current !== actionKey) {
+      actedStepRef.current = actionKey;
+      const clickTarget = step.clickTarget
+        ? document.querySelector<HTMLElement>(step.clickTarget)
+        : null;
+      if (movingForward && clickTarget && !prefersReducedMotion()) {
+        const bounds = clickTarget.getBoundingClientRect();
+        setClickPoint({
+          key: actionKey,
+          x: bounds.left + bounds.width / 2,
+          y: bounds.top + bounds.height / 2,
+        });
+        timers.push(window.setTimeout(() => {
+          runAction();
+          setClickPoint(null);
+          scheduleGeometryUpdate(280);
+        }, 1000));
+      } else {
+        runAction();
+        scheduleGeometryUpdate(step.action ? 280 : 0);
+      }
+    } else {
+      scheduleGeometryUpdate(0);
+    }
+
+    return () => {
+      timers.forEach((timer) => window.clearTimeout(timer));
+    };
+  }, [onStepAction, open, scrollTargetIntoView, step, stepIndex, updateGeometry]);
+
+  useLayoutEffect(() => {
+    if (open) updateGeometry();
+  }, [open, stepIndex, updateGeometry]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    let frame = 0;
+    let resizeTimer = 0;
+    const refresh = () => {
+      window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(updateGeometry);
+    };
+    const refreshAfterResize = () => {
+      scrollTargetIntoView('auto');
+      window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(refresh, 0);
+    };
+    window.addEventListener('resize', refreshAfterResize);
+    window.addEventListener('scroll', refresh, true);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.clearTimeout(resizeTimer);
+      window.removeEventListener('resize', refreshAfterResize);
+      window.removeEventListener('scroll', refresh, true);
+    };
+  }, [open, scrollTargetIntoView, updateGeometry]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      setConfirmSkipOpen(true);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onSkip, open]);
+
+  if (!open || typeof document === 'undefined') return null;
+
+  const moveToStep = (nextIndex: number) => {
+    const boundedIndex = clamp(nextIndex, 0, tourSteps.length - 1);
+    const nextStep = tourSteps[boundedIndex] ?? tourSteps[0];
+    if (nextStep.entryAnimation === 'float') {
+      setRects([]);
+      setEntryAnimationStepId(nextStep.id);
+    } else {
+      setEntryAnimationStepId('');
+    }
+    setStepIndex(boundedIndex);
+  };
+  const goNext = () => moveToStep(stepIndex + 1);
+  const goPrevious = () => moveToStep(stepIndex - 1);
+  const restart = () => moveToStep(0);
+  const skip = () => {
+    setConfirmSkipOpen(true);
+  };
+  const maskId = `spotlight-tour-mask-${step.id}`;
+  const hasTarget = stepSelectors(step).length > 0;
+  const hasMeasuredTarget = !hasTarget || rects.length > 0;
+  const shouldFloatCard = step.entryAnimation === 'float' && entryAnimationStepId === step.id;
+  const cardVisible = !shouldFloatCard || hasMeasuredTarget;
+  const arrangementPreviewRect = step.preview === 'arrangementPanel'
+    ? getArrangementPreviewRect()
+    : null;
+
+  return createPortal(
+    <div className={`spotlight-tour spotlight-tour--${entryMode}`}>
+      {arrangementPreviewRect ? <ArrangementPanelPreview rect={arrangementPreviewRect} /> : null}
+      <svg className="spotlight-tour__shade-svg" aria-hidden="true">
+        <defs>
+          <mask id={maskId}>
+            <rect x="0" y="0" width="100%" height="100%" fill="#fff" />
+            {rects.map((item, index) => (
+              <rect
+                key={index}
+                x={item.left}
+                y={item.top}
+                width={item.width}
+                height={item.height}
+                rx="14"
+                ry="14"
+                fill="#000"
+              />
+            ))}
+          </mask>
+        </defs>
+        <rect x="0" y="0" width="100%" height="100%" mask={`url(#${maskId})`} />
+      </svg>
+      {rects.map((item, index) => (
+        <div
+          key={index}
+          className="spotlight-tour__highlight"
+          style={{
+            top: item.top,
+            left: item.left,
+            width: item.width,
+            height: item.height,
+          }}
+        />
+      ))}
+      {clickPoint ? (
+        <div
+          className="spotlight-tour__cursor"
+          key={clickPoint.key}
+          style={{
+            top: clickPoint.y,
+            left: clickPoint.x,
+          }}
+          aria-hidden="true"
+        >
+          <span className="spotlight-tour__cursor-pointer" />
+          <span className="spotlight-tour__cursor-ring" />
+        </div>
+      ) : null}
+      <div
+        ref={cardRef}
+        className={[
+          'spotlight-tour__card-wrap',
+          `spotlight-tour__card-wrap--${cardPosition.placement}`,
+          cardVisible ? '' : 'spotlight-tour__card-wrap--pending',
+          shouldFloatCard && cardVisible ? 'spotlight-tour__card-wrap--float-in' : '',
+        ].filter(Boolean).join(' ')}
+        style={{
+          top: cardPosition.top,
+          left: cardPosition.left,
+        }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="新手引导"
+      >
+        <TourCard
+          step={step}
+          index={stepIndex}
+          total={tourSteps.length}
+          onPrevious={goPrevious}
+          onNext={goNext}
+          onSkip={skip}
+          onFinish={onFinish}
+          onRestart={restart}
+        />
+      </div>
+      <OnboardingConfirm
+        open={confirmSkipOpen}
+        title="跳过功能教学？"
+        description="跳过后不会自动再次弹出，你仍然可以从“自定义”中重新查看。"
+        confirmText="确认跳过"
+        onCancel={() => setConfirmSkipOpen(false)}
+        onConfirm={onSkip}
+      />
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/onboarding/TourCard.tsx
+++ b/src/components/onboarding/TourCard.tsx
@@ -1,0 +1,49 @@
+import { Button } from 'antd';
+import type { TourStep } from '@/onboarding/tourSteps';
+
+interface Props {
+  step: TourStep;
+  index: number;
+  total: number;
+  onPrevious: () => void;
+  onNext: () => void;
+  onSkip: () => void;
+  onFinish: () => void;
+  onRestart: () => void;
+}
+
+export default function TourCard({
+  step,
+  index,
+  total,
+  onPrevious,
+  onNext,
+  onSkip,
+  onFinish,
+  onRestart,
+}: Props) {
+  const isFirst = index === 0;
+  const isLast = index === total - 1;
+  const stepTotal = Math.max(total - 1, 1);
+
+  return (
+    <div className="tour-card">
+      {!isLast ? <div className="tour-card__step">步骤 {index + 1} / {stepTotal}</div> : null}
+      <h2 className="tour-card__title">{step.title}</h2>
+      <p className="tour-card__description">{step.description}</p>
+      {step.tip ? <p className="tour-card__tip">{step.tip}</p> : null}
+      <div className="tour-card__actions">
+        {!isFirst ? <Button onClick={onPrevious}>上一步</Button> : null}
+        {!isLast ? <Button onClick={onSkip}>跳过引导</Button> : null}
+        {isLast ? (
+          <>
+            <Button onClick={onRestart}>再看一遍</Button>
+            <Button type="primary" onClick={onFinish}>开始使用</Button>
+          </>
+        ) : (
+          <Button type="primary" onClick={onNext}>下一步</Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/onboarding.css
+++ b/src/components/onboarding/onboarding.css
@@ -1,0 +1,568 @@
+.onboarding-wizard {
+  position: fixed;
+  inset: 0;
+  z-index: 1400;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(15, 23, 42, 0.62);
+}
+
+.onboarding-wizard__panel {
+  width: min(100%, 560px);
+  max-height: min(720px, calc(100dvh - 48px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  border-radius: 16px;
+  background: var(--panel-bg);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.32);
+  animation: onboarding-panel-in 0.22s ease both;
+}
+
+.onboarding-wizard__content {
+  padding: 26px 28px 10px;
+  overflow: auto;
+}
+
+.onboarding-wizard__step {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.onboarding-wizard__eyebrow,
+.tour-card__step {
+  margin: 0;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.onboarding-wizard__title,
+.tour-card__title {
+  margin: 0;
+  color: var(--text);
+  font-size: 24px;
+  line-height: 1.25;
+}
+
+.onboarding-wizard__body,
+.tour-card__description,
+.tour-card__tip {
+  margin: 0;
+  color: var(--text-sub);
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.onboarding-wizard__preferences {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 0;
+}
+
+.onboarding-preference {
+  width: 100%;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--text) 2%, var(--panel-bg));
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.onboarding-preference:hover,
+.onboarding-preference:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
+  outline: 0;
+}
+
+.onboarding-preference:focus-visible {
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.onboarding-preference__copy {
+  min-width: 0;
+}
+
+.onboarding-preference__title {
+  color: var(--text);
+  font-size: 14px;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.onboarding-preference__switch {
+  position: relative;
+  width: 44px;
+  height: 26px;
+  flex: 0 0 44px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-sub) 24%, var(--panel-bg));
+  transition: background-color 0.18s ease;
+}
+
+.onboarding-preference__switch--checked {
+  background: var(--accent);
+}
+
+.onboarding-preference__thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.26);
+  transition: transform 0.18s ease;
+}
+
+.onboarding-preference__switch--checked .onboarding-preference__thumb {
+  transform: translateX(18px);
+}
+
+.onboarding-wizard__choice {
+  padding: 14px;
+  border: 1px solid color-mix(in srgb, var(--accent) 26%, var(--border));
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent) 8%, var(--panel-bg));
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.onboarding-wizard__footer,
+.tour-card__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.onboarding-wizard__footer {
+  padding: 4px 28px 24px;
+  border-top: 0;
+  justify-content: flex-end;
+}
+
+.onboarding-wizard__progress {
+  color: var(--text-sub);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+
+.onboarding-wizard__actions,
+.tour-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+#root .onboarding-wizard__skip-button.ant-btn,
+.onboarding-wizard__skip-button.ant-btn {
+  padding-inline: 4px;
+  background: transparent !important;
+  border-color: transparent !important;
+  color: var(--text-sub);
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+#root .onboarding-wizard__skip-button.ant-btn:hover,
+#root .onboarding-wizard__skip-button.ant-btn:focus-visible,
+.onboarding-wizard__skip-button.ant-btn:hover,
+.onboarding-wizard__skip-button.ant-btn:focus-visible {
+  background: transparent !important;
+  border-color: transparent !important;
+  color: var(--accent);
+  box-shadow: none !important;
+  outline: none !important;
+}
+
+.onboarding-confirm {
+  position: fixed;
+  inset: 0;
+  z-index: 1600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(15, 23, 42, 0.36);
+  pointer-events: auto;
+}
+
+.onboarding-confirm__panel {
+  width: min(100%, 360px);
+  padding: 20px;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--panel-bg);
+  box-shadow: 0 20px 58px rgba(0, 0, 0, 0.26);
+  animation: onboarding-confirm-in 0.18s ease both;
+}
+
+.onboarding-confirm__title {
+  margin: 0;
+  color: var(--text);
+  font-size: 18px;
+  line-height: 1.3;
+}
+
+.onboarding-confirm__description {
+  margin: 10px 0 0;
+  color: var(--text-sub);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.onboarding-confirm__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.spotlight-tour {
+  position: fixed;
+  inset: 0;
+  z-index: 1350;
+  pointer-events: none;
+}
+
+.spotlight-tour__shade {
+  position: fixed;
+  background: rgba(15, 23, 42, 0.6);
+  pointer-events: auto;
+  transition:
+    top 0.24s ease,
+    left 0.24s ease,
+    width 0.24s ease,
+    height 0.24s ease,
+    opacity 0.18s ease;
+}
+
+.spotlight-tour__shade-svg {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  fill: rgba(15, 23, 42, 0.6);
+  pointer-events: auto;
+}
+
+.spotlight-tour__highlight {
+  position: fixed;
+  border-radius: 14px;
+  box-shadow:
+    0 0 0 2px rgba(255, 255, 255, 0.22),
+    0 0 0 9999px transparent,
+    0 18px 44px rgba(0, 0, 0, 0.24);
+  pointer-events: none;
+}
+
+.spotlight-tour__arrangement-preview {
+  position: fixed;
+  z-index: 0;
+  box-sizing: border-box;
+  margin-top: 0;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.spotlight-tour__arrangement-preview .arrangement-panel__title {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.spotlight-tour__arrangement-preview .arrangement-panel__sub {
+  font-size: 15px;
+}
+
+.spotlight-tour__arrangement-preview .arrangement-panel__list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  max-height: none;
+  overflow: visible;
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
+.spotlight-tour__arrangement-preview .arrangement-card {
+  cursor: default;
+}
+
+.spotlight-tour__arrangement-conflict {
+  padding: 3px 10px;
+  border-radius: 8px;
+  background: var(--course-2-bg);
+  color: var(--course-2-stripe);
+  font-size: 13px;
+  line-height: 1.4;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.spotlight-tour__card-wrap {
+  position: fixed;
+  width: min(360px, calc(100vw - 24px));
+  pointer-events: auto;
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    top 0.28s ease,
+    left 0.28s ease,
+    opacity 0.18s ease,
+    transform 0.22s ease;
+}
+
+.spotlight-tour__card-wrap--pending {
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+.spotlight-tour__card-wrap--float-in {
+  animation: spotlight-card-float-in 0.24s ease both;
+  transition:
+    opacity 0.18s ease,
+    transform 0.22s ease;
+}
+
+.spotlight-tour__cursor {
+  position: fixed;
+  z-index: 1;
+  width: 46px;
+  height: 46px;
+  pointer-events: none;
+  transform: translate(-3px, -2px);
+}
+
+.spotlight-tour__cursor-pointer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 32px;
+  height: 38px;
+  background-image: url("data:image/svg+xml,%3Csvg width='32' height='38' viewBox='0 0 32 38' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M3 2v29.6l8.1-7.8 4.9 11.7 6.2-2.6-4.9-11.6h11.8L3 2Z' fill='%23fff' stroke='%230f172a' stroke-width='2.4' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  filter: drop-shadow(0 8px 16px rgba(0, 0, 0, 0.3));
+  transform-origin: 3px 2px;
+  animation: spotlight-cursor-press 1s ease both;
+}
+
+.spotlight-tour__cursor-pointer::after {
+  content: none;
+}
+
+.spotlight-tour__cursor-ring {
+  position: absolute;
+  top: -10px;
+  left: -10px;
+  width: 24px;
+  height: 24px;
+  border: 2px solid rgba(79, 107, 237, 0.76);
+  border-radius: 50%;
+  animation: spotlight-cursor-ring 1s ease-out both;
+}
+
+.tour-card {
+  padding: 20px 22px;
+  border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+  border-radius: 16px;
+  background: var(--panel-bg);
+  box-shadow: 0 18px 56px rgba(0, 0, 0, 0.28);
+}
+
+.tour-card__title {
+  margin-top: 8px;
+  font-size: 20px;
+}
+
+.tour-card__title:first-child {
+  margin-top: 0;
+}
+
+.tour-card__description {
+  margin-top: 10px;
+}
+
+.tour-card__tip {
+  margin-top: 8px;
+  padding: 0;
+  background: transparent;
+  color: var(--text-sub);
+  font-size: 14px;
+}
+
+.tour-card__actions {
+  margin-top: 18px;
+}
+
+@keyframes onboarding-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes onboarding-confirm-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes spotlight-card-float-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes spotlight-cursor-press {
+  0% {
+    opacity: 0;
+    transform: scale(1.55);
+  }
+  10% {
+    opacity: 1;
+    transform: scale(1.55);
+  }
+  42% {
+    opacity: 1;
+    transform: scale(1.55);
+  }
+  68% {
+    opacity: 1;
+    transform: scale(0.82);
+  }
+  86% {
+    opacity: 1;
+    transform: scale(1.14);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.14);
+  }
+}
+
+@keyframes spotlight-cursor-ring {
+  0% {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  58% {
+    opacity: 0;
+    transform: scale(0.55);
+  }
+  82% {
+    opacity: 0.9;
+    transform: scale(0.95);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.45);
+  }
+}
+
+@media (max-width: 640px) {
+  .onboarding-wizard {
+    align-items: flex-end;
+    padding: 12px;
+  }
+
+  .onboarding-wizard__panel {
+    max-height: calc(100dvh - 24px);
+    border-radius: 16px;
+  }
+
+  .onboarding-wizard__content {
+    padding: 20px 18px 10px;
+  }
+
+  .onboarding-wizard__title {
+    font-size: 22px;
+  }
+
+  .onboarding-wizard__footer {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 4px 18px 18px;
+  }
+
+  .onboarding-wizard__actions,
+  .tour-card__actions {
+    width: 100%;
+  }
+
+  .onboarding-wizard__actions .ant-btn,
+  .tour-card__actions .ant-btn {
+    flex: 1 1 120px;
+  }
+
+  .onboarding-wizard__actions .onboarding-wizard__skip-button.ant-btn {
+    flex: 0 0 auto;
+  }
+
+  .spotlight-tour__card-wrap {
+    left: 12px !important;
+    right: 12px;
+    bottom: 12px;
+    top: auto !important;
+    width: calc(100vw - 24px);
+  }
+
+  .tour-card {
+    padding: 18px 16px;
+    border-radius: 16px;
+  }
+
+  .tour-card__title {
+    font-size: 19px;
+  }
+
+  .spotlight-tour__arrangement-preview .arrangement-panel__list {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .onboarding-wizard__panel,
+  .onboarding-confirm__panel,
+  .spotlight-tour__shade,
+  .spotlight-tour__shade-svg,
+  .spotlight-tour__highlight,
+  .spotlight-tour__card-wrap,
+  .spotlight-tour__cursor-pointer,
+  .spotlight-tour__cursor-ring,
+  .onboarding-preference__switch,
+  .onboarding-preference__thumb {
+    animation: none;
+    transition: none;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -193,6 +193,14 @@ html {
   overflow: hidden;
 }
 
+.course-search-tour-target {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .table-panel {
   flex: 1;
   display: flex;
@@ -507,6 +515,14 @@ html {
   border-color: var(--border-strong);
 }
 
+.pool-item--selected:hover {
+  border-color: var(--accent);
+}
+
+.pool-item--conflict:hover {
+  border-color: var(--conflict);
+}
+
 .pool-item:focus-within {
   outline: none;
   box-shadow: none;
@@ -514,12 +530,12 @@ html {
 
 .pool-item--selected {
   background: var(--accent-soft);
-  border-color: var(--accent);
+  border-color: var(--border);
 }
 
 .pool-item--conflict {
   background: var(--conflict-bg);
-  border-color: var(--conflict);
+  border-color: var(--border);
 }
 
 .pool-item__head {
@@ -2994,6 +3010,10 @@ html.theme-transitioning *::after {
   gap: 14px;
 }
 
+.customization-modal .bottom-modal__header {
+  padding-bottom: 6px;
+}
+
 .customization__section {
   padding: 14px;
   display: flex;
@@ -3003,6 +3023,12 @@ html.theme-transitioning *::after {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--text) 2%, var(--panel-bg));
+}
+
+.customization__section.customization__section--preferences {
+  padding-top: 10px;
+  padding-bottom: 0;
+  gap: 4px;
 }
 
 .customization__section--compact,
@@ -3035,7 +3061,7 @@ html.theme-transitioning *::after {
 }
 
 .customization__preference-row {
-  min-height: 52px;
+  min-height: 60px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -3109,7 +3135,7 @@ html.theme-transitioning *::after {
 .availability-grid {
   width: 100%;
   min-width: 560px;
-  border: 1px solid var(--border-strong);
+  border: 2px solid var(--border-strong);
   border-collapse: separate;
   border-spacing: 0;
   table-layout: fixed;
@@ -3225,7 +3251,7 @@ html.theme-transitioning *::after {
   }
 
   .customization__preference-row {
-    min-height: 56px;
+    min-height: 60px;
   }
 
   .customization-modal {
@@ -3241,7 +3267,7 @@ html.theme-transitioning *::after {
 
   .customization-modal .bottom-modal__header {
     align-items: center;
-    padding: 14px 14px 8px;
+    padding: 14px 14px 6px;
   }
 
   .customization-modal .bottom-modal__title {
@@ -3272,7 +3298,7 @@ html.theme-transitioning *::after {
   }
 
   .customization__preference-row {
-    min-height: 52px;
+    min-height: 60px;
     gap: 12px;
   }
 

--- a/src/onboarding/tourSteps.ts
+++ b/src/onboarding/tourSteps.ts
@@ -1,0 +1,117 @@
+export type TourPlacement = 'right' | 'bottom' | 'left' | 'top' | 'center';
+
+export interface TourStep {
+  id: string;
+  target?: string;
+  targets?: string[];
+  title: string;
+  description: string;
+  tip?: string;
+  placement: TourPlacement;
+  action?: 'openSelectedCoursesCurriculum' | 'closeSelectedCourses' | 'openCustomization' | 'closeCustomization';
+  clickTarget?: string;
+  entryAnimation?: 'float';
+  mergeTargets?: boolean;
+  preview?: 'arrangementPanel';
+}
+
+export const tourSteps: TourStep[] = [
+  {
+    id: 'scheme-list',
+    targets: ['[data-tour="scheme-list"]', '[data-tour="plan-stats"]'],
+    title: '管理我的方案',
+    description: '这里是当前方案和方案操作区。你可以新建方案、删除当前方案，也可以在更多菜单里复制或重命名方案。下方可以看到当前方案的信息。',
+    placement: 'right',
+    entryAnimation: 'float',
+  },
+  {
+    id: 'arrangement-preview',
+    target: '[data-tour="arrangement-preview"]',
+    title: '了解排课方案',
+    description: '排课方案是基于当前“我的方案”自动生成的课表安排，会按冲突课程数从少到多排序，最多展示 8 种可选方案。“我的方案”是你保存的一组选课清单；“排课方案”是在这组选课里生成的不同时间组组合。',
+    placement: 'right',
+    preview: 'arrangementPanel',
+  },
+  {
+    id: 'program-selector',
+    target: '[data-tour="program-selector"]',
+    title: '添加培养方案',
+    description: '你可以在这里选择或搜索培养方案，方便后续查看培养方案内课程并按学期辅助选课。',
+    placement: 'right',
+  },
+  {
+    id: 'course-search-area',
+    target: '[data-tour="course-search-area"]',
+    title: '搜索与筛选课程',
+    description: '这里可以搜索课程名、课堂号或教师，也可以用下方筛选框缩小范围。匹配课程会在下方列表中展示。',
+    tip: '点击搜索结果中的课程卡片可以查看课程详情。',
+    placement: 'bottom',
+  },
+  {
+    id: 'course-result-groups',
+    target: '[data-tour="search-results"]',
+    title: '理解同名课程分组',
+    description: '如果看到课程名称和课程号完全一致的结果被分成多张卡片，这不是重复数据或 bug。系统会把同课程号且时间完全一致的班次合并；时间、周次、地点等不同的班次会作为不同时间组展示，方便你分别加入和排课。',
+    placement: 'right',
+  },
+  {
+    id: 'timetable-area',
+    target: '[data-tour="timetable-area"]',
+    title: '查看课表与操作',
+    description: '右侧会展示当前方案的周课表。上方可以切换周数、切换深浅模式、打开自定义设置，也可以导出课表图片。',
+    tip: '点击课表中的课程卡片可以查看课程详情。',
+    placement: 'left',
+  },
+  {
+    id: 'manage-entries',
+    targets: ['[data-tour="selected-courses-manage"]', '[data-tour="curriculum-manage"]'],
+    title: '管理入口',
+    description: '这两个“管理”入口都可以打开课程管理面板。已选课程入口用于查看当前方案，培养方案入口会直接进入培养方案内课程。',
+    action: 'closeSelectedCourses',
+    placement: 'right',
+  },
+  {
+    id: 'curriculum-management',
+    targets: ['.selected-courses-tabs > .ant-tabs-nav', '[data-tour="selected-courses-curriculum-tools"]'],
+    title: '按培养方案选课',
+    description: '可以在此处调整培养方案、选择学期、一键选择培养方案中本学期必修课、清空培养方案选课，也可以前往公共查询系统核查原始培养方案。',
+    action: 'openSelectedCoursesCurriculum',
+    clickTarget: '[data-tour="curriculum-manage"]',
+    placement: 'bottom',
+    entryAnimation: 'float',
+    mergeTargets: true,
+  },
+  {
+    id: 'customization-entry',
+    target: '[data-tour="customization"]',
+    title: '打开自定义',
+    description: '回到主页后，可以从这里进入自定义设置，调整排课倾向和占位时间。',
+    action: 'closeSelectedCourses',
+    placement: 'left',
+  },
+  {
+    id: 'customization-preferences',
+    target: '[data-tour="customization-preferences"]',
+    title: '调整排课倾向',
+    description: '在冲突课程尽可能少的前提下，按照所选倾向排列方案。',
+    action: 'openCustomization',
+    clickTarget: '[data-tour="customization"]',
+    placement: 'right',
+    entryAnimation: 'float',
+  },
+  {
+    id: 'customization-blocked-slots',
+    target: '[data-tour="customization-blocked-slots"]',
+    title: '设置占位时间',
+    description: '在占位表格中点选你不方便上课的时间，系统会把这些时间视为冲突并参与方案排序。',
+    action: 'openCustomization',
+    placement: 'top',
+  },
+  {
+    id: 'complete',
+    title: '准备就绪！',
+    description: '如果需要，可以随时从“自定义”里的“重新查看新手引导”再次打开本教程。',
+    action: 'closeCustomization',
+    placement: 'center',
+  },
+];

--- a/src/onboarding/useOnboarding.ts
+++ b/src/onboarding/useOnboarding.ts
@@ -1,0 +1,183 @@
+import { useCallback, useState } from 'react';
+
+const ONBOARDING_STORAGE_KEY = 'class-arrange:v1:onboarding';
+const LEGACY_COMPLETED_KEY = 'onboardingCompleted';
+
+export interface OnboardingPreferences {
+  preferHalfDay: boolean;
+  preferFewerEarlyMornings: boolean;
+}
+
+export interface OnboardingState {
+  wizardCompleted: boolean;
+  tourCompleted: boolean;
+  skipped: boolean;
+  preferences: OnboardingPreferences;
+}
+
+export type OnboardingStage = 'hidden' | 'wizard' | 'tour';
+export type OnboardingTourEntryMode = 'wizard' | 'manual';
+
+export const DEFAULT_ONBOARDING_PREFERENCES: OnboardingPreferences = {
+  preferHalfDay: false,
+  preferFewerEarlyMornings: true,
+};
+
+const DEFAULT_ONBOARDING_STATE: OnboardingState = {
+  wizardCompleted: false,
+  tourCompleted: false,
+  skipped: false,
+  preferences: DEFAULT_ONBOARDING_PREFERENCES,
+};
+
+function booleanFrom(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function normalizePreferences(value: unknown): OnboardingPreferences {
+  const source = value && typeof value === 'object'
+    ? value as Record<string, unknown>
+    : {};
+
+  return {
+    preferHalfDay: booleanFrom(
+      source.preferHalfDay ?? source.preferCompactSchedule,
+      DEFAULT_ONBOARDING_PREFERENCES.preferHalfDay,
+    ),
+    preferFewerEarlyMornings: booleanFrom(
+      source.preferFewerEarlyMornings ?? source.avoidEarlyMorning,
+      DEFAULT_ONBOARDING_PREFERENCES.preferFewerEarlyMornings,
+    ),
+  };
+}
+
+function normalizeState(value: unknown): OnboardingState {
+  const source = value && typeof value === 'object'
+    ? value as Partial<Record<keyof OnboardingState, unknown>>
+    : {};
+
+  return {
+    wizardCompleted: booleanFrom(source.wizardCompleted, DEFAULT_ONBOARDING_STATE.wizardCompleted),
+    tourCompleted: booleanFrom(source.tourCompleted, DEFAULT_ONBOARDING_STATE.tourCompleted),
+    skipped: booleanFrom(source.skipped, DEFAULT_ONBOARDING_STATE.skipped),
+    preferences: normalizePreferences(source.preferences),
+  };
+}
+
+export function readOnboardingState(): OnboardingState {
+  if (typeof window === 'undefined') return DEFAULT_ONBOARDING_STATE;
+
+  try {
+    const raw = window.localStorage.getItem(ONBOARDING_STORAGE_KEY);
+    const legacyCompleted = window.localStorage.getItem(LEGACY_COMPLETED_KEY) === 'true';
+    if (!raw) {
+      return legacyCompleted
+        ? { ...DEFAULT_ONBOARDING_STATE, wizardCompleted: true, tourCompleted: true }
+        : DEFAULT_ONBOARDING_STATE;
+    }
+
+    const parsed = readPersistedState(JSON.parse(raw));
+    return {
+      ...parsed,
+      wizardCompleted: parsed.wizardCompleted || legacyCompleted,
+    };
+  } catch {
+    return DEFAULT_ONBOARDING_STATE;
+  }
+}
+
+function saveOnboardingState(state: OnboardingState): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify({ onboarding: state }));
+    window.localStorage.setItem(LEGACY_COMPLETED_KEY, state.wizardCompleted ? 'true' : 'false');
+  } catch {
+    // 隐私模式或存储空间不足时保留本次会话状态。
+  }
+}
+
+function readPersistedState(raw: unknown): OnboardingState {
+  const maybeWrapped = raw && typeof raw === 'object'
+    ? raw as { onboarding?: unknown }
+    : {};
+  return normalizeState(maybeWrapped.onboarding ?? raw);
+}
+
+export function useOnboarding() {
+  const [initial] = useState(() => {
+    const state = readOnboardingState();
+    return {
+      state,
+      stage: state.wizardCompleted ? 'hidden' as const : 'wizard' as const,
+    };
+  });
+  const [state, setState] = useState(initial.state);
+  const [stage, setStage] = useState<OnboardingStage>(initial.stage);
+  const [tourEntryMode, setTourEntryMode] = useState<OnboardingTourEntryMode>('wizard');
+
+  const persist = useCallback((next: OnboardingState) => {
+    setState(next);
+    saveOnboardingState(next);
+  }, []);
+
+  const finishWizard = useCallback((preferences: OnboardingPreferences, startTour: boolean) => {
+    const next = {
+      ...state,
+      wizardCompleted: true,
+      skipped: !startTour,
+      preferences,
+    };
+    persist(next);
+    setTourEntryMode('wizard');
+    setStage(startTour ? 'tour' : 'hidden');
+  }, [persist, state]);
+
+  const skipWizard = useCallback(() => {
+    persist({
+      ...state,
+      wizardCompleted: true,
+      skipped: true,
+    });
+    setStage('hidden');
+  }, [persist, state]);
+
+  const finishTour = useCallback(() => {
+    persist({
+      ...state,
+      wizardCompleted: true,
+      tourCompleted: true,
+      skipped: false,
+    });
+    setStage('hidden');
+  }, [persist, state]);
+
+  const skipTour = useCallback(() => {
+    persist({
+      ...state,
+      wizardCompleted: true,
+      skipped: true,
+    });
+    setStage('hidden');
+  }, [persist, state]);
+
+  const startTour = useCallback(() => {
+    setTourEntryMode('manual');
+    setStage('tour');
+  }, []);
+
+  return {
+    state,
+    stage,
+    tourEntryMode,
+    finishWizard,
+    skipWizard,
+    finishTour,
+    skipTour,
+    startTour,
+  };
+}
+
+export function parseOnboardingStorage(raw: string): OnboardingState {
+  return readPersistedState(JSON.parse(raw));
+}


### PR DESCRIPTION
## Summary

- Add a first-run onboarding wizard with preference selection and skip confirmation.
- Add an 11-step feature tour with targeted highlights, modal walkthrough actions, arrangement preview guidance, and a final ready state.
- Wire tour restart from the customization modal and add tour targets across plan management, search, timetable, selected-course management, and customization areas.
- Refine related UI details, including selected course card hover borders, customization spacing, placeholder grid border weight, and onboarding animation behavior.