### PR TITLE
docs: refresh READMEs and add maintenance guide

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,204 @@
+# 日常维护指南
+
+本文档面向每学期/平时的数据与代码维护，列出**所有需要手动执行的步骤及其联动点**，避免漏掉「数据更新后前端某处也要跟着改」的情况。
+
+> 环境要求：Node 22+ / pnpm 11+ / uv / Python 3.12+。命令在 PowerShell 下运行。
+
+---
+
+## 速查：什么时候做什么
+
+| 场景 | 频率 | 涉及产物 | 是否需登录 |
+|---|---|---|---|
+| 更新学期开课与课堂详情 | 每学期开学 + 期中如有调整 | `public/data/semesters/<key>/{courses,updates}.json` + `index.json` | 是（首次） |
+| **切换到新学期**（如 2026-fall → 2027-spring） | 每学期一次 | 上面 + 前端 `termCalendar.ts` + 测试 | 是 |
+| 更新培养方案 | 每学期开学建议一次 | `src/data/curricula.ts` | 否（培养方案裸爬，但校外可能 401） |
+| 更新 icourse 评分 | 新学期开始一次即可 | `src/data/icourseRatings.ts` | 否 |
+| 改了代码 / 功能 | 随时 | 跑测试 + lint + build | 否 |
+
+---
+
+## 一、更新学期开课与课堂详情（最频繁）
+
+### 1.1 同步
+
+```powershell
+# 首次或依赖变更后
+uv sync --group spider --group dev
+
+# 主流程：同步并自动校验
+./scripts/sync_semester_courses.ps1 `
+  -Semester '2026年秋季学期','2026年夏季学期' `
+  -Activate '2026年秋季学期'
+```
+
+- `-Semester` 接教务系统 `nameZh`（中文学期名），可传多个；`-Activate` 指定默认学期（必须出现在 `-Semester` 中）。
+- 脚本等价于 `uv run --group spider python -m catalog_spider sync-lessons --semester ... --activate ...`，成功后**自动**跑 `validate-lessons --all`。
+- 首次运行会打开可见浏览器（优先 Edge，回退 Chromium），需手动登录一次 USTC 统一身份认证；登录态保存在 `catalog_spider/data/browser-profile/`（已 gitignore），后续复用。
+- 详情按 50 个课堂一批抓取并写断点到 `catalog_spider/data/raw/lessons/<key>/details.json`；中断后重跑只补缺失的课堂。
+- 三个 API：`GET /api/teach/semester/list`、`GET /api/teach/lesson/list-for-teach/{id}`、`POST /api/teach/lesson/infos`（429/5xx 按 1/2/4s 退避重试）。
+
+### 1.2 发布产物（均已入 git）
+
+同步成功后，`public/data/semesters/` 下**事务性**写入（中途失败自动回滚）：
+
+```
+public/data/semesters/index.json                    # manifest：defaultSemester + 每学期 key/name/file/revision/updatesFile
+public/data/semesters/<key>/courses.json            # 课程列表 + detailsBySection + revision
+public/data/semesters/<key>/updates.json            # 与上一版的 added/removed/modified 变更记录
+```
+
+- `revision` 是内容哈希（SHA-256，剥离 `generatedAt`/`enrolled` 等易变字段）。内容没变则 `updates.json` 不追加新条目（幂等），重跑不会产生重复更新记录。
+- 前端「最近更新」弹窗、方案对账（被删课堂自动移除并给替换候选、教师/时间/地点变化提示）都依赖 `updates.json`，所以**不要手动删它**。
+
+### 1.3 只改了转换规则 / 校历，不想重新登录抓取
+
+若 raw 已抓全，只调整了解析逻辑或 `CALENDAR_OVERRIDES`，用纯本地重建（不开浏览器、不联网）：
+
+```powershell
+uv run python -m catalog_spider build-lessons --semester-key 2026-fall --activate 2026-fall
+uv run python -m catalog_spider validate-lessons --all
+```
+
+### 1.4 验证
+
+```powershell
+uv run python -m catalog_spider validate-lessons --all
+```
+
+输出每学期的 `courses` / `raw_schedule_non_empty` / `scheduled_courses` / `clock_time_courses` / `grading_non_empty` / `grading_labels` / `textbooks` / `materials` / `reference_books_non_empty`。若 `scheduled_courses` 远低于 `raw_schedule_non_empty`，说明时间表大量解析失败，需检查 `lesson_transform.py` 的解析规则。
+
+---
+
+## 二、切换到新学期（最易漏联动点，务必完整执行）
+
+例如从 `2026-fall` 切到 `2027-spring`。**仅跑 `sync-lessons` 不够**，前端有两处硬编码需同步，否则测试失败、节假日/补课缺失。
+
+### 2.1 后端：加新学期的校历覆盖 + 同步
+
+1. 编辑 `catalog_spider/semester_calendar.py` 的 `CALENDAR_OVERRIDES`，新增学期 key 条目，填 `sourceUrl`（校历官方页）、`holidays`（休）、`makeupDays`（补课，含 `useWeekday`/`useWeek`）。
+   - **不加的话**：生成的 `catalog.semester.calendar` 没有节假日/补课，且 `sourceUrl` 回退为默认值。
+   - key 必须是 `YYYY-fall`/`YYYY-summer`/`YYYY-spring`，与 `semester_key()` 生成的格式一致。
+2. 同步新学期：
+   ```powershell
+   ./scripts/sync_semester_courses.ps1 -Semester '2027年春季学期' -Activate '2027年春季学期'
+   ```
+   - `index.json` 的 `defaultSemester` 会自动切到 `-Activate` 指定的学期。
+   - 排序规则：年份降序，同年 fall > summer > spring。
+
+### 2.2 前端：同步硬编码校历常量与测试
+
+> 课表日期实际由 `catalog.semester.calendar`（同步时生成）渲染，`App.tsx` 把它传给 `CourseTable`。但 `src/config/termCalendar.ts` 仍保留了一份镜像常量 `TERM_CALENDAR`，且 `src/config/termCalendar.test.ts` 对它有**硬编码断言**——换学期后 `pnpm test` 会在这里失败。
+
+3. 编辑 `src/config/termCalendar.ts`，把 `TERM_CALENDAR` 更新为新学期的 `termId` / `termName` / `termStartDate` / `termEndDate` / `weekStartDate` / `weekCount` / `sourceUrl` / `holidays` / `makeupDays`（与 2.1 的 `CALENDAR_OVERRIDES` 保持一致）。
+4. 编辑 `src/config/termCalendar.test.ts`，更新其中硬编码的 `termId` / 日期 / 周范围 / 节假日 / 补课断言，使其匹配新学期。
+
+### 2.3 切换学期检查清单
+
+- [ ] `catalog_spider/semester_calendar.py` `CALENDAR_OVERRIDES` 加了新学期条目
+- [ ] `sync-lessons` / `sync_semester_courses.ps1` 同步成功
+- [ ] `validate-lessons --all` 通过
+- [ ] `public/data/semesters/index.json` 的 `defaultSemester` 已是新学期
+- [ ] `src/config/termCalendar.ts` 的 `TERM_CALENDAR` 已更新
+- [ ] `src/config/termCalendar.test.ts` 断言已更新
+- [ ] `pnpm test` 通过（重点看 `termCalendar.test.ts`）
+- [ ] `pnpm build` 通过
+- [ ] git 提交（见第六节）
+
+---
+
+## 三、更新培养方案
+
+```powershell
+# 抓取 + 建索引（培养方案的 raw/index 不入 git，clone 后需先跑一次）
+uv run python -m catalog_spider all          # fetch-tree → fetch-details → build-index → build-by-term
+
+# 生成前端 TS（入 git）
+uv run python scripts/curricula_to_ts.py
+```
+
+- 爬取范围仅 `grade >= 2023`（`catalog_spider/details.py:MIN_GRADE`）。
+- 产物 `src/data/curricula.ts` 入 git；`catalog_spider/data/`（raw/index）不入 git。
+- 前端无额外联动：`curricula.ts` 被直接 import，生成后即可用。
+- 已抓过且只改转换规则时，可只跑 `build-index` + `build-by-term` + `curricula_to_ts.py`，不必重新抓取。
+- 校外裸爬可能 401（见 `catalog_spider/README.md` 鉴权说明），需校内网或已登录态。
+
+---
+
+## 四、更新 icourse 评分
+
+```powershell
+# 1. 爬取（8 进程，约数十分钟；输出 icourse_spider/course_rating.json，入 git）
+uv run python icourse_spider/spider.py
+
+# 2. 转前端 TS
+uv run python scripts/ratings_to_ts.py
+```
+
+- 匹配 key：`courseName + '#' + ','.join(sorted(teachers))`，按课堂号（section）维度。
+- **注意**：`ratings_to_ts.py` 读取 `src/data/courses.ts`，该文件由历史流程 `scripts/excel_to_ts.py` 从开课 Excel 生成，**当前不维护、不入 git**。除非手头有当学期 Excel，否则一般无需重跑评分转换；新的主数据流是 `catalog_spider sync-lessons` 产出的 `public/data/semesters/*/courses.json`。
+- 前端无额外联动：`src/data/icourseRatings.ts` 被直接查表使用。
+
+---
+
+## 五、改代码 / 新增功能后
+
+```powershell
+pnpm tsc -b          # 类型检查
+pnpm lint            # oxlint
+pnpm test            # Vitest（或 pnpm test:watch 监听）
+pnpm build           # 生产构建
+uv run pytest catalog_spider/tests -v   # 若改了爬虫/转换逻辑
+```
+
+- **新增用户可感知的功能时**，同步在 `src/updates/appUpdates.ts` 的 `APP_RELEASES` 追加一条版本记录（`version` 用 `YYYY.MM.DD.N`，保持最旧到最新顺序）。这是站内「最近更新」弹窗的版本日志来源。
+- 纯数据更新（仅跑 sync）**不需要**改 `APP_RELEASES`——课程增删改由 `updates.json` 自动驱动，与版本日志是两套机制。
+
+---
+
+## 六、提交
+
+当前项目用功能分支 + PR 合并到 `main`，不直接在 `main` 上提交。
+
+```powershell
+git checkout -b <分支名>      # 如 data/refresh-2026-fall、docs/maintenance
+git add -A
+git commit -m "<type>: <subject>"   # type 用 data / docs / feat / fix / chore 等
+git push -u origin <分支名>
+gh pr create --title "..." --body "..."
+```
+
+- 数据更新建议用 `data:` 前缀，如 `data: refresh 2026-fall lessons`。
+- 切换学期这类含前端联动的，一次提交涵盖后端数据 + `termCalendar.ts` + 测试，便于回溯。
+
+---
+
+## 七、常见问题
+
+**Q: `pnpm test` 在 `termCalendar.test.ts` 失败？**
+A: 换学期后没同步更新 `src/config/termCalendar.ts` 的 `TERM_CALENDAR` 常量与该测试的硬编码断言。见第二节。
+
+**Q: 课表不显示节假日/补课？**
+A: `catalog_spider/semester_calendar.py` 的 `CALENDAR_OVERRIDES` 没有该学期条目，或加了之后没重新 `sync-lessons` / `build-lessons`。
+
+**Q: `sync-lessons` 报 401？**
+A: USTC CAS/SSO 登录态过期。删除 `catalog_spider/data/browser-profile/` 后重跑，重新手动登录。校外需先连校内网或 VPN。
+
+**Q: 重跑 sync 后「最近更新」弹窗没有变化？**
+A: 内容哈希 `revision` 未变（幂等），`updates.json` 不追加新条目，属正常。若确实有变化却没记录，检查 `course_updates.py` 的 diff 逻辑。
+
+**Q: `validate-lessons` 显示 `scheduled_courses` 偏低？**
+A: 时间表解析失败率高。看 `lesson_transform.py` 的 `_schedule_slots` 是否覆盖了新的时间字符串格式，并用 `raw_schedule_non_empty` 对照排查。
+
+**Q: `ratings_to_ts.py` 报「找不到 src/data/courses.ts」？**
+A: 这是历史流程依赖，当前主数据流已改为 `public/data/semesters/*/courses.json`。除非有当学期 Excel 走 `excel_to_ts.py`，否则跳过评分转换。
+
+---
+
+## 参考
+
+- 项目总览与设计决策：[`README.md`](README.md)
+- 爬虫 CLI、schema、鉴权细节：[`catalog_spider/README.md`](catalog_spider/README.md)
+- 站内版本日志源：`src/updates/appUpdates.ts`（`APP_RELEASES`）
+- 校历覆盖源：`catalog_spider/semester_calendar.py`（`CALENDAR_OVERRIDES`）
+- 前端校历镜像与测试：`src/config/termCalendar.ts` + `src/config/termCalendar.test.ts`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - **周课表与校历**：按节次（1–13）×星期（周一至周日）渲染，显示学期、周次、日期、节假日和补课提示；全部周次视图按标准教学周展示
 - **已选课程管理**：集中查看当前排课、全部已选和培养方案内课程，可按时间组或整门课程移除、补选、批量移除
 - **培养方案辅助**：切换培养方案和学期，查看必修课程及可选时间组，支持一键加入当前学期必修课、清除一键新增的课堂，并跳转到教务系统核查原始方案
-- **排课枚举**：当一门课选了多个不同 group 时，自动枚举所有可能的排课组合，按冲突数从少到多列出最多 8 种方案，课表与状态栏默认显示冲突最少的一种，可在小卡片间切换
+- **排课枚举**：当一门课选了多个不同 group 时，自动枚举所有可能的排课组合，按冲突数从少到多列出方案（数量上限可在「自定义」中选 2 / 4 / 8 / 12 / 16），课表与状态栏默认显示冲突最少的一种，可在小卡片间切换；面板还能「显示全部不冲突方案」
 - **多方案**：本地保存多个选课方案，并按学期完全隔离
 - **自定义占位**：标记固定"有事"时段（按节次粒度），并将其纳入冲突统计和排课排序
 - **排课倾向**：在新手引导中可选择"优先空出半天"和"优先减少早八天数"，与冲突数共同影响方案排序
@@ -45,6 +45,11 @@
 - **明暗主题**：跟随系统 + 手动切换，使用浏览器 View Transition API 在切换时保留布局
 - **新手引导**：首次进入自动弹出偏好向导与分步 Spotlight Tour，介绍方案、排课、培养方案、占位时间等核心功能，可随时在"自定义"中重新查看
 - **icourse 评分**：卡片与详情弹窗内显示每门课的 icourse.club 评分（同时间不同老师各自展示，可选评分人数）
+- **收藏**：可收藏选课方案、排课方案、课程时间组、具体课堂四类对象，按学期独立持久化；收藏的排课方案在排序中优先靠前，并优先包含更多收藏课程
+- **更新感知**：访问时自动弹「最近更新」，含网站版本日志、本学期课程增删改、以及受影响的个人方案（被删课堂自动移除并给出替换候选、教师/时间/地点变化逐项提示）；可在「自定义」中查看完整更新记录、关闭非关键弹窗（被删课堂警告始终保留）
+- **校区规避**：排课倾向可设置常驻校区（本部 / 高新区），将跨校区切换作为方案排序的并列因素
+- **自动 / 手动排课**：自动模式下输入变化即时重算；手动模式保留当前课表直到手动点击「开始排课」
+- **显示全部不冲突方案**：排课面板可懒加载枚举所有零冲突组合，方案数量上限可在「自定义」中选 2 / 4 / 8 / 12 / 16
 
 ---
 
@@ -57,9 +62,10 @@
 | UI 库 | Ant Design 6 |
 | 虚拟滚动 | react-window 2.x（`List` + `useDynamicRowHeight`） |
 | 状态 | React Context + `useReducer` |
+| 排课引擎 | Web Worker（`src/workers/`），主线程不卡顿；不可用时退化为同步 |
 | 校历 / 周次 | `src/config/termCalendar.ts`（含节假日 / 补课映射） |
 | 主题切换 | 浏览器 View Transition API + 手动降级 |
-| Python 数据脚本 | uv + openpyxl / requests / tqdm / pytest |
+| Python 数据脚本 | uv + openpyxl / requests / tqdm / playwright / pytest |
 
 ---
 
@@ -67,61 +73,70 @@
 
 ```
 class-arrange/
-├── LICENSE.md                    # 项目许可证与第三方 AGPL v3 代码说明
+├── LICENSE                      # 项目许可证（非商用）与第三方 AGPL v3 代码说明
+├── COPYING                      # GNU AGPL v3 全文（供 icourse_spider 衍生代码）
 ├── index.html
-├── package.json                  # 前端依赖（pnpm）
-├── pnpm-workspace.yaml           # pnpm 工作区配置（esbuild allowBuilds）
+├── package.json                 # 前端依赖（pnpm）
+├── pnpm-workspace.yaml          # esbuild allowBuilds 配置
 ├── pnpm-lock.yaml
-├── pyproject.toml                # Python 依赖（uv）
+├── pyproject.toml               # Python 依赖（uv）
 ├── tsconfig*.json
 ├── vite.config.ts
+├── vitest.config.ts
 │
 ├── docs/
 │   └── screenshots/              # README 界面截图
 │
+├── public/
+│   └── data/semesters/           # 已入 git：index.json + 每学期 courses.json / updates.json
+│
 ├── src/
-│   ├── App.tsx                   # 应用根、主题、布局
-│   ├── main.tsx
+│   ├── App.tsx                   # 应用根、主题、布局、Provider 组装
+│   ├── main.tsx                  # 入口：SemesterCatalogProvider → UpdateAwarenessProvider → App
 │   ├── data/
-│   │   ├── semesterCatalog.ts    # 学期索引与单学期 JSON 加载/校验
+│   │   ├── SemesterCatalogContext.tsx  # 学期目录加载/切换/校验 + 加载态 fallback
+│   │   ├── semesterCatalog.ts    # manifest / catalog / updates 的 fetch + 校验（schemaVersion=1）
 │   │   ├── curricula.ts          # 由 scripts/curricula_to_ts.py 自动生成
-│   │   ├── icourseRatings.ts     # 由 scripts/ratings_to_ts.py 自动生成
-│   │   └── index.ts
-│   ├── types/                    # CourseSection / CourseGroup / ScheduleSlot / Plan / Arrangement
-│   ├── components/               # 课程池 / 课表 / 弹窗 / 筛选 / 方案等 UI
+│   │   └── icourseRatings.ts     # 由 scripts/ratings_to_ts.py 自动生成
+│   ├── types/                    # CourseSection / CourseGroup / ScheduleSlot / Plan / Arrangement / Favorites / Updates
+│   ├── components/               # 课程池 / 课表 / 弹窗 / 筛选 / 方案 / 收藏 / 更新提示等 UI
 │   │   └── onboarding/           # OnboardingWizard / SpotlightTour / TourCard
 │   ├── onboarding/               # useOnboarding hook + tourSteps
 │   ├── config/                   # termCalendar（学期、节假日、补课）+ 单测
-│   ├── hooks/                    # useFilteredCourses / useConflicts / useWeekGrid
-│   ├── store/                    # plansContext + plansReducer
-│   ├── utils/                    # courseGroup / conflict / arrangement / grid / weeks /
-│   │                             #   courseColor / icourseRating / curriculum / customization /
-│   │                             #   exportPrint / teachers / scheduleFormat / stats / planSeed
+│   ├── hooks/                    # useFilteredCourses / useConflicts / useWeekGrid / useArrangementCalculation
+│   ├── store/                    # plansContext + plansReducer（按学期命名空间）
+│   ├── favorites/                # favorites 收藏存储 + FavoritesContext（方案/排课/时间组/课堂）
+│   ├── updates/                  # 更新感知 + 方案对账 + APP_RELEASES 更新日志
+│   ├── workers/                  # arrangement.worker + arrangementProtocol（排课在 Web Worker 中跑）
+│   ├── utils/                    # arrangement* / conflict / courseGroup / campusTransfers / customization /
+│   │                             #   icourseRating / curriculum / exportPrint / planSeed / schedule* / stats 等
 │   ├── constants/                # grid / filterOptions
 │   └── styles/                   # tokens / print
 │
 ├── scripts/
-│   ├── sync_semester_courses.ps1 # 登录后同步一个或多个学期（主流程）
-│   ├── excel_to_ts.py            # 旧版 Excel 转换工具（仅兼容历史流程）
+│   ├── sync_semester_courses.ps1 # 登录后同步一个或多个学期，成功后自动 validate-lessons --all
+│   ├── excel_to_ts.py            # 旧版 Excel 转换工具（仅兼容历史流程，非主数据流）
 │   ├── curricula_to_ts.py        # 培养方案 index → src/data/curricula.ts
 │   └── ratings_to_ts.py          # icourse 评分 JSON → src/data/icourseRatings.ts
 │
 ├── icourse_spider/               # icourse.club 评分爬虫（学长遗产，AGPL v3）
-│   ├── spider.py                 # 多进程爬取课程名 + 教师 + 评分
+│   ├── spider.py                 # 8 进程爬取课程名 + 教师 + 评分
 │   ├── lesson_match.py           # 匹配 key 工具（name + '#' + sorted(teachers)）
 │   └── course_rating.json        # 爬取的最新评分数据（被 git 跟踪）
 │
-└── catalog_spider/               # USTC 培养方案爬虫（详见 catalog_spider/README.md）
-    ├── __main__.py               # CLI 入口（fetch-tree / fetch-details / build-index / build-by-term / all）
-    ├── client.py                 # HTTP 客户端（10 次重试 + 浏览器 UA）
-    ├── tree.py                   # 解析 program_tree.json + filter_by_min_grade
-    ├── details.py                # 8 进程并发抓取 details（断点续爬）
-    ├── process.py                # 从 raw 生成 index
-    ├── paths.py                  # 数据目录常量 + ensure_dirs()
-    ├── tests/                    # 19 个 pytest 单测（client / details / process / tree）
-    ├── README.md
-    └── data/                     # raw + index（已入 git）
+└── catalog_spider/               # USTC 培养方案 + 学期开课爬虫（详见 catalog_spider/README.md）
+    ├── __main__.py               # CLI 入口：8 个子命令（见下）
+    ├── client.py                 # 培养方案爬取 HTTP 客户端（10 次重试 + 浏览器 UA，无鉴权）
+    ├── tree.py / details.py / process.py / paths.py   # 培养方案侧
+    ├── lesson_sync.py            # 学期开课同步：Playwright 登录 + 3 个 API + 事务发布
+    ├── lesson_transform.py       # 课堂/详情归一化、时间表解析、目录构建与校验
+    ├── course_updates.py         # revision 内容哈希 + diff，生成 updates.json
+    ├── semester_calendar.py      # 周数计算 + CALENDAR_OVERRIDES 节假日/补课
+    ├── tests/                    # 7 个文件、97 个 pytest 用例
+    └── data/                     # raw + index（不入 git）
 ```
+
+`catalog_spider` 的 8 个子命令：培养方案侧 `fetch-tree` / `fetch-details` / `build-index` / `build-by-term` / `all`；学期开课侧 `sync-lessons` / `build-lessons` / `validate-lessons`。详见 [`catalog_spider/README.md`](catalog_spider/README.md)。
 
 ---
 
@@ -144,9 +159,10 @@ uv sync --group spider --group dev
 ```
 
 > 包含：
-> - `openpyxl`：把开课 Excel 转成 TS（`scripts/excel_to_ts.py`）
-> - `requests`、`tqdm`：icourse 评分爬虫（`icourse_spider/spider.py`）
-> - `pytest`：运行 `src/config`、`src/utils`、`catalog_spider/tests` 中的单元测试
+> - `openpyxl`：把开课 Excel 转成 TS（`scripts/excel_to_ts.py`，仅历史流程）
+> - `playwright`：`catalog_spider` 的 `sync-lessons` 登录同步（USTC CAS/SSO）
+> - `requests`、`tqdm`：`icourse_spider` 评分爬虫与 `catalog_spider` 培养方案爬取
+> - `pytest`：运行 `catalog_spider/tests` 中的单元测试
 
 仅装数据脚本依赖（不开爬虫）：
 
@@ -186,17 +202,19 @@ uv sync --group spider --group dev
   -Activate '2026年秋季学期'
 ```
 
-脚本会打开可见浏览器并完成一次登录。教务系统（`catalog.ustc.edu.cn`）走 USTC 统一身份认证，学期列表 / 课堂列表 / 课堂详情接口对零 cookie 请求返回 401（2026-07 校外实测），因此**首次运行必须手动登录一次**；登录会话保存在已忽略的专用 profile 中，后续运行可直接复用。抓取按 50 个课堂一批保存断点，失败后重跑只补缺失详情。
+脚本会打开可见浏览器并完成一次登录。教务系统（`catalog.ustc.edu.cn`）走 USTC 统一身份认证，学期列表 / 课堂列表 / 课堂详情接口对零 cookie 请求返回 401（2026-07 校外实测），因此**首次运行必须手动登录一次**；登录会话保存在已忽略的专用 profile 中，后续运行可直接复用。抓取按 50 个课堂一批保存断点，失败后重跑只补缺失详情。同步成功后脚本自动跑 `validate-lessons --all` 校验全部已发布学期。
 
-每个学期发布为单独文件：
+每个学期发布为单独文件（均已入 git）：
 
 ```text
-public/data/semesters/index.json
-public/data/semesters/2026-fall/courses.json
+public/data/semesters/index.json                       # manifest：defaultSemester + 每学期 key/name/file/revision/updatesFile
+public/data/semesters/2026-fall/courses.json           # 课程列表 + detailsBySection + revision
+public/data/semesters/2026-fall/updates.json           # 与上一版的 added/removed/modified 变更记录
 public/data/semesters/2026-summer/courses.json
+public/data/semesters/2026-summer/updates.json
 ```
 
-`courses.json` 同时包含课程列表和 `detailsBySection`。前端先读取轻量索引，用户选择哪个学期才加载哪个学期文件；方案也存入对应学期的独立命名空间。
+`courses.json` 同时包含课程列表和 `detailsBySection`。前端先读取轻量索引，用户选择哪个学期才加载哪个学期文件；方案也存入对应学期的独立命名空间。`updates.json` 由 `course_updates.py` 对比上一版生成（内容哈希 `revision` 不变则不追加），供前端「最近更新」提示与方案对账使用。
 
 旧版 `scripts/excel_to_ts.py` 仅保留作历史数据兼容工具，不再是网站的主数据流程。
 
@@ -212,7 +230,7 @@ uv run python -m catalog_spider all
 uv run python scripts/curricula_to_ts.py
 ```
 
-> 数据已入 git：clone 后无需重新抓取，直接跑 `build-index` / `build-by-term` / `curricula_to_ts.py` 即可；只有数据过期需要刷新时才跑 `fetch-tree` / `fetch-details`。
+> 培养方案的 raw / index **不入 git**：clone 后 `catalog_spider/data/` 为空，需先跑 `all`（即 `fetch-tree` + `fetch-details` + `build-index` + `build-by-term`）抓取一次；只有 `curricula.ts` 生成结果入 git。已抓过且仅改转换规则时，可只跑 `build-index` / `build-by-term` / `curricula_to_ts.py`。
 >
 > 爬取范围：**仅 `grade >= 2023` 的培养方案**（详见 `catalog_spider/details.py:MIN_GRADE`）。
 
@@ -238,6 +256,8 @@ key = courseName + '#' + ','.join(sorted(teachers))
 
 未在 icourse 上出现的课不会出现在 `icourseRatings.ts` 里，前端对应位置不显示任何评分。
 
+> **注意**：`ratings_to_ts.py` 读取 `src/data/courses.ts`（由历史流程 `excel_to_ts.py` 从开课 Excel 生成，当前已不维护、不入 git）。因此这条路径目前依赖历史 Excel；新的主数据流是 `catalog_spider sync-lessons` 产出的 `public/data/semesters/*/courses.json`。除非你手里有当学期 Excel，否则一般无需重跑评分转换。
+
 ---
 
 ## 关键设计决策
@@ -254,20 +274,24 @@ key = courseName + '#' + ','.join(sorted(teachers))
 
 ### 排课方案枚举
 
-学生同时选了同一门课的多个 group（比如 MATH1006 的两个时间不同的 group），视为"还没决定上哪个老师"，系统进入排课枚举态：
+学生同时选了同一门课的多个 group（比如 MATH1006 的两个时间不同的 group），视为"还没决定上哪个老师"，系统进入排课枚举态。排课在 **Web Worker** 中执行（`src/workers/arrangement.worker.ts` + `arrangementProtocol.ts`），主线程不卡顿；Worker 不可用时（如测试）退化为同步执行。
 
-1. 用 `Arrangement` 对每个 courseCode 的可选 group 做笛卡尔积（`src/utils/arrangement.ts:enumerateArrangements`）
-2. 每个组合跑 `detectConflicts` 算冲突 group 数
-3. 按冲突数升序排序（同分按 groupKeys 字典序稳定排序），取前 8 种
-4. 默认应用冲突数最小的；用户点击 `ArrangementPanel` 小卡片可切换
-5. 课表、状态栏只看当前应用的方案——恰好"一门课一格"，`已选课程` 不重复计数同课多 group
+1. 把每个 courseCode 的可选 group 划分为「锁定」（只有一组）和「待定」（多组各选其一），对「待定」做组合搜索（`src/utils/arrangementEngine.ts:enumerateArrangementsExact`）
+2. 用预计算的周-日-分钟区间 + 增量增删维护冲突计数，避免对每个组合重算
+3. 用容量受限的最大堆保留前 N 个候选（N 由「自定义」中的方案数量上限决定，可选 2 / 4 / 8 / 12 / 16）
+4. 排序键（`compareArrangementRanks`）：已收藏的方案 → 冲突更少 → 含更多收藏课程 →（可选）校区切换更少 →（可选）空半天分更高 →（可选）早八更少 → 字典序 → 学分更多
+5. 默认应用排名第一的方案；用户点击 `ArrangementPanel` 小卡片可切换；面板可懒加载「显示全部不冲突方案」（第二个 Worker 调用，枚举所有零冲突组合）
+6. 课表、状态栏只看当前应用的方案——恰好"一门课一格"，`已选课程` 不重复计数同课多 group
 
 ### 排课倾向与占位时间
 
 `src/utils/customization.ts` 中的 `CustomScheduleSettings` 把"用户偏好"显式持久化：
 
-- `preferHalfDay` / `preferFewerEarlyMornings` —— 由新手引导选择，影响方案排序
+- `preferHalfDay` / `preferFewerEarlyMornings` / `preferAvoidCampusTransfers` + `residentCampus` —— 由新手引导选择，影响方案排序
 - `blockedSlots` —— "有事"时段，按 `day-period` 字符串存储，纳入冲突统计
+- `calculationMode` —— 自动 / 手动是否即时重算
+- `arrangementDisplayCount` —— 推荐方案数量上限（2 / 4 / 8 / 12 / 16）
+- `mergeAllTimeGroups` —— 课程池中把同一门课的多个时间组合并成一张卡片（仅显示，不影响选课/冲突/排课）
 
 ### 周次与校历
 
@@ -324,16 +348,16 @@ key = courseName + '#' + ','.join(sorted(teachers))
 - `package.json`/`pnpm-lock.yaml` 用 pnpm 管理前端依赖
 - `pyproject.toml`/`uv.lock` 用 uv 管理 Python 依赖
 - 前端不用 ESLint，用 oxlint（更快）
-- TypeScript 严格模式，`verbatimModuleSyntax` + `noUnusedLocals`
-- 前端测试用 Vitest（`pnpm test`），Python 爬虫 / 工具用 pytest（`uv run pytest catalog_spider/tests -v`）
-- 功能更新时同步完善 `src/updates/appUpdates.ts` 中的更新记录
+- TypeScript 启用 `verbatimModuleSyntax`、`noUnusedLocals`、`noUnusedParameters`、`erasableSyntaxOnly`、`noFallthroughCasesInSwitch`（未开全局 `strict`）
+- 前端测试用 Vitest（`pnpm test` / `pnpm test:watch`），Python 爬虫 / 工具用 pytest（`uv run pytest catalog_spider/tests -v`）
+- 功能更新时同步完善 `src/updates/appUpdates.ts` 中的 `APP_RELEASES` 更新记录
 - 提交前跑 `pnpm tsc -b && pnpm lint` 确保通过
 
 ---
 
 ## License
 
-许可证与第三方来源说明见 [`LICENSE.md`](LICENSE.md)。
+许可证与第三方来源说明见 [`LICENSE`](LICENSE)（项目主体为非商用许可证，`icourse_spider` 衍生代码为 AGPL v3），AGPL v3 全文见 [`COPYING`](COPYING)。
 
 其中 `icourse_spider/spider.py` 与 `icourse_spider/lesson_match.py` 来自
 `https://github.com/feixukeji/paike`，原项目许可证为 AGPL v3；相关来源也写在文件顶部注释中。

--- a/catalog_spider/README.md
+++ b/catalog_spider/README.md
@@ -86,7 +86,7 @@ uv run python -m catalog_spider validate-lessons --all
 ```
 
 `build-lessons` 是纯本地命令，不会打开浏览器或发送网络请求。它会先读取并转换所有指定学期，调用与在线同步相同的 catalog 校验，再一次性事务写入
-`public/data/semesters/<semester-key>/courses.json` 和 `index.json`；任一输入、转换、校验或写入失败时，现有发布文件保持不变。`--activate` 接受本次 `--semester-key` 中的一个 key；省略时保留 manifest 当前默认学期。
+`public/data/semesters/<semester-key>/courses.json`、`updates.json` 和 `index.json`；任一输入、转换、校验或写入失败时，现有发布文件保持不变。`--activate` 接受本次 `--semester-key` 中的一个 key；省略时保留 manifest 当前默认学期。
 
 流程会打开可见的持久浏览器，并通过与页面共享认证状态的请求上下文读取：
 
@@ -94,11 +94,21 @@ uv run python -m catalog_spider validate-lessons --all
 - 指定学期全量课堂；
 - 每个课堂的评分制、英文名、中英文简介、先修要求、教学大纲、教材、讲义和参考书等详情。
 
-详情每 50 个课堂写一次原始断点到 `data/raw/lessons/<semester-key>/`。所有请求学期都抓取、转换并校验成功后，才事务性发布 `public/data/semesters/<semester-key>/courses.json` 与 `index.json`；发布中途失败会恢复原文件，原始断点仍保留。
+详情每 50 个课堂写一次原始断点到 `data/raw/lessons/<semester-key>/`。所有请求学期都抓取、转换并校验成功后，才事务性发布 `public/data/semesters/<semester-key>/courses.json`、`updates.json` 与 `index.json`；发布中途失败会恢复原文件，原始断点仍保留。
+
+### 变更追踪（`updates.json` + `revision`）
+
+每次发布都为学期目录算一个内容哈希 `revision`（SHA-256，剥离 `generatedAt`、`enrolled` 等易变字段、教师按排序归一），写进 `courses.json.revision` 与 manifest 条目的 `revision`。若与上一版不同，`course_updates.py` 会 diff 出 `added` / `removed` / `modified` 三类变化，追加一条记录到该学期的 `updates.json`：
+
+- `removed` 课堂附带 `replacementCandidates`（优先同课程号、回退同名），供前端提示「替换失效课程」；
+- `modified` 课堂列出字段级 `changes`（教师、时间、地点、详情等），不内嵌大段 HTML；
+- 内容完全相同则不追加（幂等），重跑 `sync-lessons` 不会产生重复条目。
+
+前端 `UpdateAwarenessContext` 据此在访问时弹「最近更新」，并把删除的课堂从用户方案中移除。
 
 `validate-lessons` 除评分制和教材覆盖率外，还输出 `raw_schedule_non_empty`、`scheduled_courses` 与 `clock_time_courses`，便于同步或本地重建后立即发现课堂时间大量解析为空的问题。
 
-**数据已入 git**（用户明确）：clone 后无需重新抓取，直接跑 `build-index` / `build-by-term` / `curricula_to_ts.py` 即可；只有数据过期需要刷新时才跑 `fetch-tree` / `fetch-details`。
+**培养方案的 raw / index 不入 git**：clone 后 `catalog_spider/data/` 为空，需先跑 `fetch-tree` + `fetch-details` 抓取（约 2 分钟），再 `build-index` / `build-by-term` / `curricula_to_ts.py`。而**学期开课的发布文件 `public/data/semesters/*` 已入 git**（`index.json` + 每学期 `courses.json` / `updates.json`），前端无需抓取即可直接使用。
 
 爬取范围：**仅 `grade >= 2023` 的培养方案**（详见 `catalog_spider/details.py:MIN_GRADE`）。
 
@@ -108,29 +118,51 @@ uv run python -m catalog_spider validate-lessons --all
 
 ```
 catalog_spider/
-├── __main__.py            # CLI 入口（5 个子命令）
-├── client.py              # HTTP 客户端（10 次重试 + 浏览器 UA）
+├── __main__.py            # CLI 入口（8 个子命令，见下）
+├── client.py              # 培养方案爬取的 HTTP 客户端（10 次重试 + 浏览器 UA，无鉴权）
 ├── tree.py                # 解析 program_tree.json + filter_by_min_grade
-├── details.py             # 8 进程并发抓取 details（断点续爬）
+├── details.py             # 8 进程并发抓取 details（断点续爬，MIN_GRADE=2023）
 ├── process.py             # 从 raw 生成 index（programs.json + by_program_term.json）
 ├── paths.py               # 数据目录常量 + ensure_dirs()
+├── lesson_sync.py         # 学期开课同步：Playwright 登录 + 3 个 API + 事务发布
+├── lesson_transform.py    # 课堂/详情归一化、时间表解析、学期目录构建与校验
+├── course_updates.py      # 内容哈希 revision + 与上一版 diff，生成 updates.json
+├── semester_calendar.py   # 由学期起止算周数；CALENDAR_OVERRIDES 硬编码节假日/补课
 ├── README.md
-├── tests/                 # 19 个 pytest 单测
-│   ├── test_client.py
-│   ├── test_details.py
-│   ├── test_process.py
-│   ├── test_tree.py
-│   └── fixtures/          # 含真实 3413.json（断网也能跑测试）
-└── data/
-    ├── raw/
-    │   ├── program_tree.json
-    │   └── programs/{id}.json
-    └── index/
-        ├── programs.json
-        └── by_program_term.json
+├── tests/                 # 7 个文件、97 个 pytest 用例
+│   ├── test_client.py / test_details.py / test_process.py / test_tree.py
+│   ├── test_lesson_sync.py        # 同步流程、重试退避、断点续爬、事务回滚、CLI 参数
+│   ├── test_lesson_transform.py   # 时间表解析、校区归类、校验规则、日历
+│   ├── test_course_updates.py     # revision 幂等、diff、替换候选
+│   └── fixtures/                  # program_3413 / program_tree_mini / lesson_list/lesson_details mini
+└── data/                  # 不入 git（见下）：raw / index / browser-profile / raw/lessons
+    ├── raw/{program_tree.json, programs/{id}.json, lessons/<key>/{semester,lessons,details}.json}
+    └── index/{programs.json, by_program_term.json}
 
 scripts/curricula_to_ts.py    # 从 index/* 生成 src/data/curricula.ts（前端 import）
 ```
+
+### 子命令
+
+培养方案侧（`all` 只跑这 4 个）：
+
+| 命令 | 作用 |
+|---|---|
+| `fetch-tree` | 抓 `program_tree`（秒级） |
+| `fetch-details` | 并发抓所有 program 详情（断点续爬） |
+| `build-index` | 从 raw 生成 `index/programs.json` |
+| `build-by-term` | 从 raw 生成 `index/by_program_term.json` |
+| `all` | 按顺序跑完上面 4 个 |
+
+学期开课侧：
+
+| 命令 | 参数 | 作用 |
+|---|---|---|
+| `sync-lessons` | `--semester <中文名>`（可重复）、`--activate`、`--profile-dir` | 可见浏览器登录后同步指定学期开课与详情 |
+| `build-lessons` | `--semester-key <key>`（可重复）、`--activate` | 从本地 raw JSON 重建，不联网不开浏览器 |
+| `validate-lessons` | `--all` 或 `--semester-key <key>`（二选一） | 校验已发布学期目录并打印覆盖率 |
+
+`--activate` 必须精确匹配某个 `--semester` / `--semester-key`；`sync-lessons` 的 `--semester` 接教务系统 `nameZh`（如 `2026年秋季学期`），`build-lessons` 的 `--semester-key` 接短 key（如 `2026-fall`，正则 `^\d{4}-(fall|summer|spring)$`）。
 
 ---
 


### PR DESCRIPTION
## 变更

基于对前端、`catalog_spider`、工具链的完整代码核对，完善两份 README 并新增日常维护文档。

### `README.md`（根）
- 项目结构补齐 `public/`、`src/favorites/`、`src/updates/`、`src/workers/`、`vitest.config.ts`、`COPYING`；删除不存在的 `src/data/index.ts`
- 功能列表新增收藏、更新感知、校区规避、自动/手动排课、显示全部不冲突方案；「最多 8 种」改为可配置 2/4/8/12/16
- 技术栈补 Web Worker 排课引擎 + `playwright`
- 排课枚举决策重写为 Worker + 增量搜索 + 容量堆 + 完整排序键
- 数据流程补 `updates.json` + manifest 的 `revision/updatesFile`；修正「数据已入 git」（培养方案 raw/index 不入，学期开课发布文件入）
- `ratings_to_ts.py` 补 legacy 依赖警告
- License `LICENSE.md` → `LICENSE` + `COPYING`；开发者约定的 TS 严格模式描述改为实际启用的 lint flag

### `catalog_spider/README.md`
- CLI 从 5 个子命令补全为 8 个，加参数表
- 项目结构补 `lesson_sync`/`lesson_transform`/`course_updates`/`semester_calendar` + 测试实情（7 文件 97 用例）
- 新增「变更追踪（updates.json + revision）」段落
- 修正「数据已入 git」

### `MAINTENANCE.md`（新）
面向每学期的日常维护指南，含：
- 速查表（场景 → 频率/产物/是否需登录）
- 更新学期开课、更新培养方案、更新 icourse 评分的完整步骤
- **切换新学期检查清单**（重点：`CALENDAR_OVERRIDES` + `termCalendar.ts` 常量 + `termCalendar.test.ts` 断言必须同步，否则 `pnpm test` 失败）
- 改代码后流程 + `APP_RELEASES` 何时该改
- 功能分支 + PR 提交流程 + 常见问题排查

## 验证
- 所有命令、路径、字段名经源码核对（`lesson_sync.py`/`__main__.py`/`termCalendar.ts`/`appUpdates.ts`/`package.json`/`pyproject.toml` 等）
- `git ls-files` 确认 `catalog_spider/data/` 0 文件入 git、`public/data/semesters/` 5 文件入 git

🤖 Generated with [Claude Code](https://claude.com/claude-code)