### PR TITLE
data: refresh 2026-fall lessons

### DIFF
--- a/public/data/semesters/2026-fall/updates.json
+++ b/public/data/semesters/2026-fall/updates.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "semesterKey": "2026-fall",
-  "currentRevision": "59ccdd35b1702875acbc4b9eca8e3b9e4284b495f26ba6d87cbe440829706368",
+  "currentRevision": "5b037b34655138baac2ae0578248a6dfb0c08ee4decb1b8b707e4e46b5c9d29e",
   "entries": [
     {
       "id": "2026-fall:c0cbaf189652cc27",
@@ -14830,6 +14830,15555 @@
                 {
                   "room": "地点待定",
                   "campus": "其他"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2026-fall:5b037b34655138ba",
+      "revision": "5b037b34655138baac2ae0578248a6dfb0c08ee4decb1b8b707e4e46b5c9d29e",
+      "previousRevision": "59ccdd35b1702875acbc4b9eca8e3b9e4284b495f26ba6d87cbe440829706368",
+      "publishedAt": "2026-07-20T12:52:39Z",
+      "summary": {
+        "added": 4,
+        "removed": 6,
+        "modified": 131
+      },
+      "added": [
+        {
+          "id": "COMP7211P.02",
+          "courseCode": "COMP7211P",
+          "courseName": "人工智能前沿",
+          "teacher": "李安然",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                18
+              ],
+              "room": "GT-B103",
+              "day": 2,
+              "periods": [
+                8,
+                9
+              ],
+              "campus": "高新区"
+            }
+          ]
+        },
+        {
+          "id": "NSTE6414P.01",
+          "courseCode": "NSTE6414P",
+          "courseName": "大电流能量技术与应用",
+          "teacher": "",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                9
+              ],
+              "room": "3A410",
+              "day": 4,
+              "periods": [
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "NSTE7208P.01",
+          "courseCode": "NSTE7208P",
+          "courseName": "高功率电力电子技术应用",
+          "teacher": "",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                9
+              ],
+              "room": "3A207",
+              "day": 1,
+              "periods": [
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "NSTE7210P.01",
+          "courseCode": "NSTE7210P",
+          "courseName": "电器设备研制及实践",
+          "teacher": "",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                9
+              ],
+              "room": "2405",
+              "day": 5,
+              "periods": [
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "campus": "本部"
+            }
+          ]
+        }
+      ],
+      "removed": [
+        {
+          "course": {
+            "id": "BPEN6004P.01",
+            "courseCode": "BPEN6004P",
+            "courseName": "工业生物技术",
+            "teacher": "",
+            "schedule": []
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "FINA6414P.01",
+            "courseCode": "FINA6414P",
+            "courseName": "行为金融",
+            "teacher": "",
+            "schedule": []
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "PHIL7101U.19",
+            "courseCode": "PHIL7101U",
+            "courseName": "中国马克思主义与当代",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  18
+                ],
+                "room": "3A306",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PHIL7101U.01",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "刘立,江增辉",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "1102",
+                  "day": 1,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.02",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "刘立,江增辉",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "1102",
+                  "day": 2,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.03",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "叶政",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5302",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.04",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "李金龙,应验,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "3A206",
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.05",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "陈小林",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5502",
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.06",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "张德广",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5202",
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.07",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "陈小林,应验,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5202",
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.08",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "姜玲玲,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-B201",
+                  "day": 5,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.09",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "陈小林",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-A501",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.10",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "叶政",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-A401",
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.11",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "张德广",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-A101",
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.12",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "苏振源,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "G2-B403",
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.13",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "张贵红",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "G2-B303",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.14",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "姜玲玲,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "GT-B212",
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.15",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "应验,张德广,苏振源",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    9
+                  ],
+                  "room": "苏高院公共教学楼101教室",
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.16",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "王勇",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "room": "教育大厦6040",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "room": "教育大厦6040",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9
+                  ],
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.17",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "room": "郭可信楼109",
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "room": "郭可信楼109",
+                  "day": 6,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.18",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "苏振源,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "G2-B303",
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHIL7101U.20",
+            "courseCode": "PHIL7101U",
+            "courseName": "中国马克思主义与当代",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  18
+                ],
+                "room": "TH-A501",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PHIL7101U.01",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "刘立,江增辉",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "1102",
+                  "day": 1,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.02",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "刘立,江增辉",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "1102",
+                  "day": 2,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.03",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "叶政",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5302",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.04",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "李金龙,应验,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "3A206",
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.05",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "陈小林",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5502",
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.06",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "张德广",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5202",
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.07",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "陈小林,应验,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5202",
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.08",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "姜玲玲,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-B201",
+                  "day": 5,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.09",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "陈小林",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-A501",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.10",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "叶政",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-A401",
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.11",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "张德广",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-A101",
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.12",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "苏振源,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "G2-B403",
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.13",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "张贵红",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "G2-B303",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.14",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "姜玲玲,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "GT-B212",
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.15",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "应验,张德广,苏振源",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    9
+                  ],
+                  "room": "苏高院公共教学楼101教室",
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.16",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "王勇",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "room": "教育大厦6040",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "room": "教育大厦6040",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9
+                  ],
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.17",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "room": "郭可信楼109",
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "room": "郭可信楼109",
+                  "day": 6,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.18",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "苏振源,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "G2-B303",
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHIL7101U.21",
+            "courseCode": "PHIL7101U",
+            "courseName": "中国马克思主义与当代",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  18
+                ],
+                "room": "TH-A501",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PHIL7101U.01",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "刘立,江增辉",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "1102",
+                  "day": 1,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.02",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "刘立,江增辉",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "1102",
+                  "day": 2,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.03",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "叶政",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5302",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.04",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "李金龙,应验,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "3A206",
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.05",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "陈小林",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5502",
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.06",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "张德广",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5202",
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.07",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "陈小林,应验,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5202",
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.08",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "姜玲玲,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-B201",
+                  "day": 5,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.09",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "陈小林",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-A501",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.10",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "叶政",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-A401",
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.11",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "张德广",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-A101",
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.12",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "苏振源,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "G2-B403",
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.13",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "张贵红",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "G2-B303",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.14",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "姜玲玲,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "GT-B212",
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.15",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "应验,张德广,苏振源",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    9
+                  ],
+                  "room": "苏高院公共教学楼101教室",
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.16",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "王勇",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "room": "教育大厦6040",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "room": "教育大厦6040",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9
+                  ],
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.17",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "room": "郭可信楼109",
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "room": "郭可信楼109",
+                  "day": 6,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.18",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "苏振源,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "G2-B303",
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHIL7101U.22",
+            "courseCode": "PHIL7101U",
+            "courseName": "中国马克思主义与当代",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  18
+                ],
+                "room": "TH-A501",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PHIL7101U.01",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "刘立,江增辉",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "1102",
+                  "day": 1,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.02",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "刘立,江增辉",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "1102",
+                  "day": 2,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.03",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "叶政",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5302",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.04",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "李金龙,应验,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "3A206",
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.05",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "陈小林",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5502",
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.06",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "张德广",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5202",
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.07",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "陈小林,应验,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "5202",
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.08",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "姜玲玲,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-B201",
+                  "day": 5,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.09",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "陈小林",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-A501",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.10",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "叶政",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-A401",
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.11",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "张德广",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "TH-A101",
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.12",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "苏振源,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "G2-B403",
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.13",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "张贵红",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "G2-B303",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.14",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "姜玲玲,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "GT-B212",
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.15",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "应验,张德广,苏振源",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    9
+                  ],
+                  "room": "苏高院公共教学楼101教室",
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.16",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "王勇",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "room": "教育大厦6040",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "room": "教育大厦6040",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9
+                  ],
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.17",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "room": "郭可信楼109",
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "room": "郭可信楼109",
+                  "day": 6,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "PHIL7101U.18",
+              "courseCode": "PHIL7101U",
+              "courseName": "中国马克思主义与当代",
+              "teacher": "苏振源,刘立",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "room": "G2-B303",
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "modified": [
+        {
+          "course": {
+            "id": "007001.01",
+            "courseCode": "007001",
+            "courseName": "流体力学",
+            "teacher": "郑建秋,袁仁民"
+          },
+          "previous": {
+            "id": "007001.01",
+            "courseCode": "007001",
+            "courseName": "流体力学",
+            "teacher": "郑建秋,袁仁民",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "007001.01",
+            "courseCode": "007001",
+            "courseName": "流体力学",
+            "teacher": "郑建秋,袁仁民",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    9
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    10,
+                    16
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    9
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    10,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    10,
+                    16
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    9
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    10,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    9
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "008183.01",
+            "courseCode": "008183",
+            "courseName": "普通生物学实验",
+            "teacher": "马世嵩,谭树堂,罗建川"
+          },
+          "previous": {
+            "id": "008183.01",
+            "courseCode": "008183",
+            "courseName": "普通生物学实验",
+            "teacher": "马世嵩,谭树堂,罗建川",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "生物楼附楼K409",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "生物楼附楼K409",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "生物楼附楼K409",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "生物楼附楼K409",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "生物楼附楼K409",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "生物楼附楼K409",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "008183.01",
+            "courseCode": "008183",
+            "courseName": "普通生物学实验",
+            "teacher": "马世嵩,谭树堂,罗建川",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "生物楼附楼K409",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "生物楼附楼K409",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "生物楼附楼K409",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "生物楼附楼K409",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "生物楼附楼K409",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "生物楼附楼K409",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "008183.02",
+            "courseCode": "008183",
+            "courseName": "普通生物学实验",
+            "teacher": "马世嵩,谭树堂,罗建川"
+          },
+          "previous": {
+            "id": "008183.02",
+            "courseCode": "008183",
+            "courseName": "普通生物学实验",
+            "teacher": "马世嵩,谭树堂,罗建川",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "生物楼附楼K409",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "生物楼附楼K409",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "生物楼附楼K409",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "生物楼附楼K409",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "生物楼附楼K409",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "生物楼附楼K409",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "008183.02",
+            "courseCode": "008183",
+            "courseName": "普通生物学实验",
+            "teacher": "马世嵩,谭树堂,罗建川",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "生物楼附楼K409",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "生物楼附楼K409",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "生物楼附楼K409",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "生物楼附楼K409",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "生物楼附楼K409",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "生物楼附楼K409",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "008183.03",
+            "courseCode": "008183",
+            "courseName": "普通生物学实验",
+            "teacher": "马世嵩,谭树堂,罗建川"
+          },
+          "previous": {
+            "id": "008183.03",
+            "courseCode": "008183",
+            "courseName": "普通生物学实验",
+            "teacher": "马世嵩,谭树堂,罗建川",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "生物楼附楼K409",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "生物楼附楼K409",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "生物楼附楼K409",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "生物楼附楼K409",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "生物楼附楼K409",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "生物楼附楼K409",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "008183.03",
+            "courseCode": "008183",
+            "courseName": "普通生物学实验",
+            "teacher": "马世嵩,谭树堂,罗建川",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "生物楼附楼K409",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "生物楼附楼K409",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "生物楼附楼K409",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "生物楼附楼K409",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "生物楼附楼K409",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "生物楼附楼K409",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "008183.04",
+            "courseCode": "008183",
+            "courseName": "普通生物学实验",
+            "teacher": "马世嵩,谭树堂,罗建川"
+          },
+          "previous": {
+            "id": "008183.04",
+            "courseCode": "008183",
+            "courseName": "普通生物学实验",
+            "teacher": "马世嵩,谭树堂,罗建川",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "生物楼附楼K409",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "生物楼附楼K409",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "生物楼附楼K409",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "生物楼附楼K409",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "生物楼附楼K409",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "生物楼附楼K409",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "008183.04",
+            "courseCode": "008183",
+            "courseName": "普通生物学实验",
+            "teacher": "马世嵩,谭树堂,罗建川",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "生物楼附楼K409",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "生物楼附楼K409",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "生物楼附楼K409",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "生物楼附楼K409",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "生物楼附楼K409",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "生物楼附楼K409",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "019151.02",
+            "courseCode": "019151",
+            "courseName": "有机化学基础实验(上)",
+            "teacher": "查正根,徐航勋,蒋俊,兰泉,李玲玲,郑媛"
+          },
+          "previous": {
+            "id": "019151.02",
+            "courseCode": "019151",
+            "courseName": "有机化学基础实验(上)",
+            "teacher": "徐航勋,郑媛,蒋俊,兰泉,李玲玲,查正根",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区环资楼701-703",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10,
+                  11
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "019151.02",
+            "courseCode": "019151",
+            "courseName": "有机化学基础实验(上)",
+            "teacher": "查正根,徐航勋,蒋俊,兰泉,李玲玲,郑媛",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区环资楼701-703",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10,
+                  11
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 18,
+              "after": 36
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTA6013P.01",
+            "courseCode": "ASTA6013P",
+            "courseName": "统计计算与优化",
+            "teacher": "陈刘军,王月"
+          },
+          "previous": {
+            "id": "ASTA6013P.01",
+            "courseCode": "ASTA6013P",
+            "courseName": "统计计算与优化",
+            "teacher": "陈刘军,王月",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  9
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 2,
+                "periods": [
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "15:30",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTA6013P.01",
+            "courseCode": "ASTA6013P",
+            "courseName": "统计计算与优化",
+            "teacher": "陈刘军,王月",
+            "schedule": [
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "startTime": "14:00",
+                "endTime": "15:20",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  16
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  9
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 2,
+                "periods": [
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "15:30",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    9
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    10,
+                    16
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    17,
+                    17
+                  ],
+                  "day": 2,
+                  "periods": [
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "15:30",
+                  "endTime": "17:00"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    17,
+                    17
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "15:20"
+                },
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    16
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    9
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    17,
+                    17
+                  ],
+                  "day": 2,
+                  "periods": [
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "15:30",
+                  "endTime": "17:00"
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "囯金院5号楼101室",
+                  "campus": "其他"
+                },
+                {
+                  "room": "囯金院5号楼101室",
+                  "campus": "其他"
+                },
+                {
+                  "room": "囯金院5号楼101室",
+                  "campus": "其他"
+                },
+                {
+                  "room": "囯金院5号楼101室",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "囯金院5号楼101室",
+                  "campus": "其他"
+                },
+                {
+                  "room": "囯金院5号楼101室",
+                  "campus": "其他"
+                },
+                {
+                  "room": "囯金院5号楼101室",
+                  "campus": "其他"
+                },
+                {
+                  "room": "囯金院5号楼101室",
+                  "campus": "其他"
+                },
+                {
+                  "room": "囯金院5号楼101室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTR5001P.01",
+            "courseCode": "ASTR5001P",
+            "courseName": "广义相对论",
+            "teacher": "赵文"
+          },
+          "previous": {
+            "id": "ASTR5001P.01",
+            "courseCode": "ASTR5001P",
+            "courseName": "广义相对论",
+            "teacher": "赵文",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5107",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTR5001P.01",
+            "courseCode": "ASTR5001P",
+            "courseName": "广义相对论",
+            "teacher": "赵文",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5107",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "5107",
+                "day": 1,
+                "periods": [
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5107",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5107",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5107",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTR5002P.01",
+            "courseCode": "ASTR5002P",
+            "courseName": "星系天文学",
+            "teacher": "孔旭,张红欣"
+          },
+          "previous": {
+            "id": "ASTR5002P.01",
+            "courseCode": "ASTR5002P",
+            "courseName": "星系天文学",
+            "teacher": "孔旭,张红欣",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5406",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5406",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTR5002P.01",
+            "courseCode": "ASTR5002P",
+            "courseName": "星系天文学",
+            "teacher": "孔旭,张红欣",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5406",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "5406",
+                "day": 1,
+                "periods": [
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5406",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5406",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5406",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5406",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5406",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5406",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTR6001P.01",
+            "courseCode": "ASTR6001P",
+            "courseName": "天体物理中的辐射过程",
+            "teacher": "何志成,蔡振翼"
+          },
+          "previous": {
+            "id": "ASTR6001P.01",
+            "courseCode": "ASTR6001P",
+            "courseName": "天体物理中的辐射过程",
+            "teacher": "何志成,蔡振翼",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1302",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1302",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTR6001P.01",
+            "courseCode": "ASTR6001P",
+            "courseName": "天体物理中的辐射过程",
+            "teacher": "何志成,蔡振翼",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1302",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1302",
+                "day": 4,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "1302",
+                "day": 4,
+                "periods": [
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    11,
+                    12
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 4,
+                  "periods": [
+                    13
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "1302",
+                  "campus": "本部"
+                },
+                {
+                  "room": "1302",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "1302",
+                  "campus": "本部"
+                },
+                {
+                  "room": "1302",
+                  "campus": "本部"
+                },
+                {
+                  "room": "1302",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTR6012P.01",
+            "courseCode": "ASTR6012P",
+            "courseName": "天文应用软件与编程技术",
+            "teacher": "王宇,王春成"
+          },
+          "previous": {
+            "id": "ASTR6012P.01",
+            "courseCode": "ASTR6012P",
+            "courseName": "天文应用软件与编程技术",
+            "teacher": "王宇,王春成",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTR6012P.01",
+            "courseCode": "ASTR6012P",
+            "courseName": "天文应用软件与编程技术",
+            "teacher": "王宇,王春成",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "2406",
+                "day": 5,
+                "periods": [
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 5,
+                  "periods": [
+                    10
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2406",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2406",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2406",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTR6403P.01",
+            "courseCode": "ASTR6403P",
+            "courseName": "物理宇宙学",
+            "teacher": "方文娟"
+          },
+          "previous": {
+            "id": "ASTR6403P.01",
+            "courseCode": "ASTR6403P",
+            "courseName": "物理宇宙学",
+            "teacher": "方文娟",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2506",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTR6403P.01",
+            "courseCode": "ASTR6403P",
+            "courseName": "物理宇宙学",
+            "teacher": "方文娟",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2506",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  18,
+                  18
+                ],
+                "room": "2506",
+                "day": 6,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    18,
+                    18
+                  ],
+                  "day": 6,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2506",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2506",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2506",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTR6406P.01",
+            "courseCode": "ASTR6406P",
+            "courseName": "星际介质",
+            "teacher": "刘腾,王恩赐"
+          },
+          "previous": {
+            "id": "ASTR6406P.01",
+            "courseCode": "ASTR6406P",
+            "courseName": "星际介质",
+            "teacher": "刘腾,王恩赐",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2204",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTR6406P.01",
+            "courseCode": "ASTR6406P",
+            "courseName": "星际介质",
+            "teacher": "刘腾,王恩赐",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2204",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  18,
+                  18
+                ],
+                "room": "2204",
+                "day": 6,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    18,
+                    18
+                  ],
+                  "day": 6,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2204",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2204",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2204",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTR6413P.01",
+            "courseCode": "ASTR6413P",
+            "courseName": "致密星物理",
+            "teacher": "戴子高"
+          },
+          "previous": {
+            "id": "ASTR6413P.01",
+            "courseCode": "ASTR6413P",
+            "courseName": "致密星物理",
+            "teacher": "戴子高",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2408",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTR6413P.01",
+            "courseCode": "ASTR6413P",
+            "courseName": "致密星物理",
+            "teacher": "戴子高",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2408",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  18,
+                  18
+                ],
+                "room": "2408",
+                "day": 5,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    18,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2408",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2408",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2408",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTR7002P.01",
+            "courseCode": "ASTR7002P",
+            "courseName": "宇宙大尺度结构",
+            "teacher": "王慧元,容昱"
+          },
+          "previous": {
+            "id": "ASTR7002P.01",
+            "courseCode": "ASTR7002P",
+            "courseName": "宇宙大尺度结构",
+            "teacher": "王慧元,容昱",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2404",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2404",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTR7002P.01",
+            "courseCode": "ASTR7002P",
+            "courseName": "宇宙大尺度结构",
+            "teacher": "王慧元,容昱",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2404",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "2404",
+                "day": 3,
+                "periods": [
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2404",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 3,
+                  "periods": [
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2404",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2404",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2404",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2404",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2404",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIO1514G.01",
+            "courseCode": "BIO1514G",
+            "courseName": "生物进化论的历史由来、基本概念及未来发展",
+            "teacher": "占成,薛天"
+          },
+          "previous": {
+            "id": "BIO1514G.01",
+            "courseCode": "BIO1514G",
+            "courseName": "生物进化论的历史由来、基本概念及未来发展",
+            "teacher": "占成,薛天",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  9
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIO1514G.01",
+            "courseCode": "BIO1514G",
+            "courseName": "生物进化论的历史由来、基本概念及未来发展",
+            "teacher": "占成,薛天",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  9
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    3,
+                    9
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    10,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    9
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    10,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5203",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5203",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5203",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5203",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5203",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL5241P.02",
+            "courseCode": "BIOL5241P",
+            "courseName": "细胞生物学综合实验",
+            "teacher": "郭振"
+          },
+          "previous": {
+            "id": "BIOL5241P.02",
+            "courseCode": "BIOL5241P",
+            "courseName": "细胞生物学综合实验",
+            "teacher": "郭振",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "生物楼附楼",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL5241P.02",
+            "courseCode": "BIOL5241P",
+            "courseName": "细胞生物学综合实验",
+            "teacher": "郭振",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "生物楼附楼",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL6171P.01",
+            "courseCode": "BIOL6171P",
+            "courseName": "生物大分子结构与功能",
+            "teacher": "陈宇星,臧建业,陶余勇,李琼"
+          },
+          "previous": {
+            "id": "BIOL6171P.01",
+            "courseCode": "BIOL6171P",
+            "courseName": "生物大分子结构与功能",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A102",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A102",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL6171P.01",
+            "courseCode": "BIOL6171P",
+            "courseName": "生物大分子结构与功能",
+            "teacher": "陈宇星,臧建业,陶余勇,李琼",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A102",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A102",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "陈宇星,臧建业,陶余勇,李琼"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL6171P.02",
+            "courseCode": "BIOL6171P",
+            "courseName": "生物大分子结构与功能",
+            "teacher": "侯文韬,刘欣,钱洪武"
+          },
+          "previous": {
+            "id": "BIOL6171P.02",
+            "courseCode": "BIOL6171P",
+            "courseName": "生物大分子结构与功能",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A102",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A107",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL6171P.02",
+            "courseCode": "BIOL6171P",
+            "courseName": "生物大分子结构与功能",
+            "teacher": "侯文韬,刘欣,钱洪武",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A102",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A107",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "侯文韬,刘欣,钱洪武"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL6172P.01",
+            "courseCode": "BIOL6172P",
+            "courseName": "结构生物学I(晶体学)",
+            "teacher": "陶余勇"
+          },
+          "previous": {
+            "id": "BIOL6172P.01",
+            "courseCode": "BIOL6172P",
+            "courseName": "结构生物学I(晶体学)",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A303",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL6172P.01",
+            "courseCode": "BIOL6172P",
+            "courseName": "结构生物学I(晶体学)",
+            "teacher": "陶余勇",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A303",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "陶余勇"
+            },
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "基础",
+              "after": "专业"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL6173P.01",
+            "courseCode": "BIOL6173P",
+            "courseName": "结构生物学II(波谱学)",
+            "teacher": "项晟祺,龚庆国"
+          },
+          "previous": {
+            "id": "BIOL6173P.01",
+            "courseCode": "BIOL6173P",
+            "courseName": "结构生物学II(波谱学)",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A314",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL6173P.01",
+            "courseCode": "BIOL6173P",
+            "courseName": "结构生物学II(波谱学)",
+            "teacher": "项晟祺,龚庆国",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A314",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "项晟祺,龚庆国"
+            },
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "基础",
+              "after": "专业"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL6426P.01",
+            "courseCode": "BIOL6426P",
+            "courseName": "神经免疫学科导论",
+            "teacher": "李小龙,崔国梁,张济舟,胡弘历,晋艳,占成,朱书,段亚君,曹鹏"
+          },
+          "previous": {
+            "id": "BIOL6426P.01",
+            "courseCode": "BIOL6426P",
+            "courseName": "神经免疫学科导论",
+            "teacher": "朱书,崔国梁,李小龙,张济舟,胡弘历,段亚君,占成,晋艳",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A307",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL6426P.01",
+            "courseCode": "BIOL6426P",
+            "courseName": "神经免疫学科导论",
+            "teacher": "李小龙,崔国梁,张济舟,胡弘历,晋艳,占成,朱书,段亚君,曹鹏",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A307",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "朱书,崔国梁,李小龙,张济舟,胡弘历,段亚君,占成,晋艳",
+              "after": "李小龙,崔国梁,张济舟,胡弘历,晋艳,占成,朱书,段亚君,曹鹏"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BUSI6001P.01",
+            "courseCode": "BUSI6001P",
+            "courseName": "商业数据分析",
+            "teacher": "高梦海"
+          },
+          "previous": {
+            "id": "BUSI6001P.01",
+            "courseCode": "BUSI6001P",
+            "courseName": "商业数据分析",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "管理楼三楼机房",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:35",
+                "endTime": "17:30",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "管理楼三楼机房",
+                "day": 1,
+                "periods": [
+                  10,
+                  11,
+                  12
+                ],
+                "startTime": "18:00",
+                "endTime": "20:25",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "BUSI6001P.01",
+            "courseCode": "BUSI6001P",
+            "courseName": "商业数据分析",
+            "teacher": "高梦海",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "管理楼三楼机房",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:35",
+                "endTime": "17:30",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "管理楼三楼机房",
+                "day": 1,
+                "periods": [
+                  10,
+                  11,
+                  12
+                ],
+                "startTime": "18:00",
+                "endTime": "20:25",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "高梦海"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BUSI6003P.01",
+            "courseCode": "BUSI6003P",
+            "courseName": "企业研究方法",
+            "teacher": "吴剑琳"
+          },
+          "previous": {
+            "id": "BUSI6003P.01",
+            "courseCode": "BUSI6003P",
+            "courseName": "企业研究方法",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5405",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BUSI6003P.01",
+            "courseCode": "BUSI6003P",
+            "courseName": "企业研究方法",
+            "teacher": "吴剑琳",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5405",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "吴剑琳"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BUSI6104P.01",
+            "courseCode": "BUSI6104P",
+            "courseName": "管理研究哲学",
+            "teacher": "刘志迎"
+          },
+          "previous": {
+            "id": "BUSI6104P.01",
+            "courseCode": "BUSI6104P",
+            "courseName": "管理研究哲学",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5104",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BUSI6104P.01",
+            "courseCode": "BUSI6104P",
+            "courseName": "管理研究哲学",
+            "teacher": "刘志迎",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5104",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "刘志迎"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BUSI6401P.01",
+            "courseCode": "BUSI6401P",
+            "courseName": "企业战略管理",
+            "teacher": "王熹徽"
+          },
+          "previous": {
+            "id": "BUSI6401P.01",
+            "courseCode": "BUSI6401P",
+            "courseName": "企业战略管理",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "5107",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BUSI6401P.01",
+            "courseCode": "BUSI6401P",
+            "courseName": "企业战略管理",
+            "teacher": "王熹徽",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "5107",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "王熹徽"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BUSI6406P.01",
+            "courseCode": "BUSI6406P",
+            "courseName": "服务营销与管理",
+            "teacher": "殷哲"
+          },
+          "previous": {
+            "id": "BUSI6406P.01",
+            "courseCode": "BUSI6406P",
+            "courseName": "服务营销与管理",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5505",
+                "day": 4,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:10",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BUSI6406P.01",
+            "courseCode": "BUSI6406P",
+            "courseName": "服务营销与管理",
+            "teacher": "殷哲",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5505",
+                "day": 4,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:10",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "殷哲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BUSI6407P.01",
+            "courseCode": "BUSI6407P",
+            "courseName": "组织行为学：基础理论与研究前沿",
+            "teacher": "翁清雄"
+          },
+          "previous": {
+            "id": "BUSI6407P.01",
+            "courseCode": "BUSI6407P",
+            "courseName": "组织行为学：基础理论与研究前沿",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "5405",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BUSI6407P.01",
+            "courseCode": "BUSI6407P",
+            "courseName": "组织行为学：基础理论与研究前沿",
+            "teacher": "翁清雄",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "5405",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "翁清雄"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BUSI6408P.01",
+            "courseCode": "BUSI6408P",
+            "courseName": "科研规范与评价",
+            "teacher": "吴强"
+          },
+          "previous": {
+            "id": "BUSI6408P.01",
+            "courseCode": "BUSI6408P",
+            "courseName": "科研规范与评价",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "5205",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BUSI6408P.01",
+            "courseCode": "BUSI6408P",
+            "courseName": "科研规范与评价",
+            "teacher": "吴强",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "5205",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "吴强"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BUSI7104P.01",
+            "courseCode": "BUSI7104P",
+            "courseName": "实验研究方法",
+            "teacher": "黄锨"
+          },
+          "previous": {
+            "id": "BUSI7104P.01",
+            "courseCode": "BUSI7104P",
+            "courseName": "实验研究方法",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5505",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BUSI7104P.01",
+            "courseCode": "BUSI7104P",
+            "courseName": "实验研究方法",
+            "teacher": "黄锨",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5505",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "黄锨"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEM5012P.03",
+            "courseCode": "CHEM5012P",
+            "courseName": "电化学研究方法",
+            "teacher": "曹龙生"
+          },
+          "previous": {
+            "id": "CHEM5012P.03",
+            "courseCode": "CHEM5012P",
+            "courseName": "电化学研究方法",
+            "teacher": "曹龙生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "地点待定",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "地点待定",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEM5012P.03",
+            "courseCode": "CHEM5012P",
+            "courseName": "电化学研究方法",
+            "teacher": "曹龙生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "苏高院公共教学楼206教室",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "苏高院公共教学楼206教室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼206教室",
+                  "campus": "其他"
+                },
+                {
+                  "room": "苏高院公共教学楼206教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEM6022P.03",
+            "courseCode": "CHEM6022P",
+            "courseName": "化学生物学基础",
+            "teacher": "朱毅敏"
+          },
+          "previous": {
+            "id": "CHEM6022P.03",
+            "courseCode": "CHEM6022P",
+            "courseName": "化学生物学基础",
+            "teacher": "朱毅敏",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "地点待定",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEM6022P.03",
+            "courseCode": "CHEM6022P",
+            "courseName": "化学生物学基础",
+            "teacher": "朱毅敏",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "苏高院公共教学楼205教室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼205教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEM6040P.04",
+            "courseCode": "CHEM6040P",
+            "courseName": "材料与器件的微纳制造",
+            "teacher": "刘东"
+          },
+          "previous": {
+            "id": "CHEM6040P.04",
+            "courseCode": "CHEM6040P",
+            "courseName": "材料与器件的微纳制造",
+            "teacher": "刘东",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEM6040P.04",
+            "courseCode": "CHEM6040P",
+            "courseName": "材料与器件的微纳制造",
+            "teacher": "刘东",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "苏高院公共教学楼205教室",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼205教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEN7003P.01",
+            "courseCode": "CHEN7003P",
+            "courseName": "水污染控制原理",
+            "teacher": "葛晓琳,蒋晨啸"
+          },
+          "previous": {
+            "id": "CHEN7003P.01",
+            "courseCode": "CHEN7003P",
+            "courseName": "水污染控制原理",
+            "teacher": "江鸿,葛晓琳",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "TH-A102",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "TH-A102",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEN7003P.01",
+            "courseCode": "CHEN7003P",
+            "courseName": "水污染控制原理",
+            "teacher": "葛晓琳,蒋晨啸",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "TH-A102",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "TH-A102",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "江鸿,葛晓琳",
+              "after": "葛晓琳,蒋晨啸"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6003P.01",
+            "courseCode": "COMP6003P",
+            "courseName": "计算机应用数学",
+            "teacher": "宋骐"
+          },
+          "previous": {
+            "id": "COMP6003P.01",
+            "courseCode": "COMP6003P",
+            "courseName": "计算机应用数学",
+            "teacher": "宋骐",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-108",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6003P.01",
+            "courseCode": "COMP6003P",
+            "courseName": "计算机应用数学",
+            "teacher": "宋骐",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-108",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6109P.01",
+            "courseCode": "COMP6109P",
+            "courseName": "高级人工智能",
+            "teacher": "李金龙"
+          },
+          "previous": {
+            "id": "COMP6109P.01",
+            "courseCode": "COMP6109P",
+            "courseName": "高级人工智能",
+            "teacher": "李金龙",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B112",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B112",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6109P.01",
+            "courseCode": "COMP6109P",
+            "courseName": "高级人工智能",
+            "teacher": "李金龙",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B112",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B112",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6207P.01",
+            "courseCode": "COMP6207P",
+            "courseName": "图像处理",
+            "teacher": "董兰芳"
+          },
+          "previous": {
+            "id": "COMP6207P.01",
+            "courseCode": "COMP6207P",
+            "courseName": "图像处理",
+            "teacher": "董兰芳",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GT-B212",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6207P.01",
+            "courseCode": "COMP6207P",
+            "courseName": "图像处理",
+            "teacher": "董兰芳",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GT-B212",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "其他",
+              "after": ""
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6224P.01",
+            "courseCode": "COMP6224P",
+            "courseName": "优化理论",
+            "teacher": "尼克"
+          },
+          "previous": {
+            "id": "COMP6224P.01",
+            "courseCode": "COMP6224P",
+            "courseName": "优化理论",
+            "teacher": "尼克",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B102",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6224P.01",
+            "courseCode": "COMP6224P",
+            "courseName": "优化理论",
+            "teacher": "尼克",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B102",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "其他",
+              "after": ""
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CS1003.13",
+            "courseCode": "CS1003",
+            "courseName": "计算机程序设计",
+            "teacher": "王嵩"
+          },
+          "previous": {
+            "id": "CS1003.13",
+            "courseCode": "CS1003",
+            "courseName": "计算机程序设计",
+            "teacher": "王嵩",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3C104",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  14
+                ],
+                "room": "西活二楼机房",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "CS1003.13",
+            "courseCode": "CS1003",
+            "courseName": "计算机程序设计",
+            "teacher": "王嵩",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3C104",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  14
+                ],
+                "room": "西活二楼机房",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26王小谟网络空间科技英才班T",
+                "26信息安全",
+                "26中微集成电路科技英才班T",
+                "26网络空间安全",
+                "26微电子学院（大类）"
+              ],
+              "after": [
+                "26王小谟网络空间科技英才班T",
+                "26信息安全",
+                "26中微集成电路科技英才班T",
+                "26网络空间安全",
+                "26集电（大类）"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "DSCI6002P.01",
+            "courseCode": "DSCI6002P",
+            "courseName": "深度学习",
+            "teacher": "王超,康奇宇"
+          },
+          "previous": {
+            "id": "DSCI6002P.01",
+            "courseCode": "DSCI6002P",
+            "courseName": "深度学习",
+            "teacher": "王超,康奇宇",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-110",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "DSCI6002P.01",
+            "courseCode": "DSCI6002P",
+            "courseName": "深度学习",
+            "teacher": "王超,康奇宇",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-110",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EIEN7401P.05",
+            "courseCode": "EIEN7401P",
+            "courseName": "电子信息类开放实践课",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EIEN7401P.05",
+            "courseCode": "EIEN7401P",
+            "courseName": "电子信息类开放实践课",
+            "teacher": "",
+            "schedule": []
+          },
+          "current": {
+            "id": "EIEN7401P.05",
+            "courseCode": "EIEN7401P",
+            "courseName": "电子信息类开放实践课",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  18
+                ],
+                "room": "G2-B302",
+                "day": 1,
+                "periods": [
+                  10,
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    4,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    10,
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "G2-B302",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ELEC5302P.01",
+            "courseCode": "ELEC5302P",
+            "courseName": "快电子学",
+            "teacher": "王永纲"
+          },
+          "previous": {
+            "id": "ELEC5302P.01",
+            "courseCode": "ELEC5302P",
+            "courseName": "快电子学",
+            "teacher": "王永纲",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5403",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ELEC5302P.01",
+            "courseCode": "ELEC5302P",
+            "courseName": "快电子学",
+            "teacher": "王永纲",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2506",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 135,
+              "after": 65
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5403",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2506",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FINA6101P.01",
+            "courseCode": "FINA6101P",
+            "courseName": "金融经济学",
+            "teacher": "郭新帅"
+          },
+          "previous": {
+            "id": "FINA6101P.01",
+            "courseCode": "FINA6101P",
+            "courseName": "金融经济学",
+            "teacher": "郭新帅",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "国金院2号楼101室",
+                "day": 2,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  17
+                ],
+                "room": "国金院2号楼101室",
+                "day": 2,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "FINA6101P.01",
+            "courseCode": "FINA6101P",
+            "courseName": "金融经济学",
+            "teacher": "郭新帅",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "国金院2号楼101室",
+                "day": 2,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  17
+                ],
+                "room": "国金院2号楼101室",
+                "day": 2,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FINA6101P.02",
+            "courseCode": "FINA6101P",
+            "courseName": "金融经济学",
+            "teacher": "郭新帅"
+          },
+          "previous": {
+            "id": "FINA6101P.02",
+            "courseCode": "FINA6101P",
+            "courseName": "金融经济学",
+            "teacher": "郭新帅",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "国金院2号楼102室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  17
+                ],
+                "room": "国金院2号楼102室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "FINA6101P.02",
+            "courseCode": "FINA6101P",
+            "courseName": "金融经济学",
+            "teacher": "郭新帅",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "国金院2号楼102室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  17
+                ],
+                "room": "国金院2号楼102室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FINA6103P.01",
+            "courseCode": "FINA6103P",
+            "courseName": "应用统计方法",
+            "teacher": "冯群强"
+          },
+          "previous": {
+            "id": "FINA6103P.01",
+            "courseCode": "FINA6103P",
+            "courseName": "应用统计方法",
+            "teacher": "冯群强",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  4
+                ],
+                "room": "国金院2号楼101室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  17
+                ],
+                "room": "国金院2号楼101室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "FINA6103P.01",
+            "courseCode": "FINA6103P",
+            "courseName": "应用统计方法",
+            "teacher": "冯群强",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  4
+                ],
+                "room": "国金院2号楼101室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  17
+                ],
+                "room": "国金院2号楼101室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FINA6103P.02",
+            "courseCode": "FINA6103P",
+            "courseName": "应用统计方法",
+            "teacher": "冯群强"
+          },
+          "previous": {
+            "id": "FINA6103P.02",
+            "courseCode": "FINA6103P",
+            "courseName": "应用统计方法",
+            "teacher": "冯群强",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  4
+                ],
+                "room": "国金院2号楼102室",
+                "day": 4,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  17
+                ],
+                "room": "国金院2号楼102室",
+                "day": 4,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "FINA6103P.02",
+            "courseCode": "FINA6103P",
+            "courseName": "应用统计方法",
+            "teacher": "冯群强",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  4
+                ],
+                "room": "国金院2号楼102室",
+                "day": 4,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  17
+                ],
+                "room": "国金院2号楼102室",
+                "day": 4,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FINA6403P.01",
+            "courseCode": "FINA6403P",
+            "courseName": "财务会计",
+            "teacher": "张瑞稳"
+          },
+          "previous": {
+            "id": "FINA6403P.01",
+            "courseCode": "FINA6403P",
+            "courseName": "财务会计",
+            "teacher": "张瑞稳",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "国金院2号楼101室",
+                "day": 5,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  17
+                ],
+                "room": "国金院2号楼101室",
+                "day": 5,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  19,
+                  19
+                ],
+                "room": "国金院2号楼101室",
+                "day": 5,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "FINA6403P.01",
+            "courseCode": "FINA6403P",
+            "courseName": "财务会计",
+            "teacher": "张瑞稳",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "国金院2号楼101室",
+                "day": 5,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  17
+                ],
+                "room": "国金院2号楼101室",
+                "day": 5,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  19,
+                  19
+                ],
+                "room": "国金院2号楼101室",
+                "day": 5,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FINA6403P.02",
+            "courseCode": "FINA6403P",
+            "courseName": "财务会计",
+            "teacher": "张瑞稳"
+          },
+          "previous": {
+            "id": "FINA6403P.02",
+            "courseCode": "FINA6403P",
+            "courseName": "财务会计",
+            "teacher": "张瑞稳",
+            "schedule": []
+          },
+          "current": {
+            "id": "FINA6403P.02",
+            "courseCode": "FINA6403P",
+            "courseName": "财务会计",
+            "teacher": "张瑞稳",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FINA6424P.01",
+            "courseCode": "FINA6424P",
+            "courseName": "金融人工智能（I）",
+            "teacher": "林静"
+          },
+          "previous": {
+            "id": "FINA6424P.01",
+            "courseCode": "FINA6424P",
+            "courseName": "金融人工智能（I）",
+            "teacher": "林静",
+            "schedule": [
+              {
+                "weeks": [
+                  7,
+                  10
+                ],
+                "room": "囯金院5号楼202教室",
+                "day": 6,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "09:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  9
+                ],
+                "room": "囯金院5号楼202教室",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "09:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "FINA6424P.01",
+            "courseCode": "FINA6424P",
+            "courseName": "金融人工智能（I）",
+            "teacher": "林静",
+            "schedule": [
+              {
+                "weeks": [
+                  7,
+                  10
+                ],
+                "room": "囯金院5号楼202教室",
+                "day": 6,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "09:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  9
+                ],
+                "room": "囯金院5号楼202教室",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "09:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL7101U.03",
+            "courseCode": "FORL7101U",
+            "courseName": "科技论文写作",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "FORL7101U.03",
+            "courseCode": "FORL7101U",
+            "courseName": "科技论文写作",
+            "teacher": "",
+            "schedule": []
+          },
+          "current": {
+            "id": "FORL7101U.03",
+            "courseCode": "FORL7101U",
+            "courseName": "科技论文写作",
+            "teacher": "",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.09",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "李皓昭"
+          },
+          "previous": {
+            "id": "FS1001.09",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "李皓昭",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.09",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "李皓昭",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "核心通识",
+              "after": "科学与社会"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.10",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "陈景润"
+          },
+          "previous": {
+            "id": "FS1001.10",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "陈景润",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.10",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "陈景润",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "核心通识",
+              "after": "科学与社会"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.11",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "杨迪"
+          },
+          "previous": {
+            "id": "FS1001.11",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "杨迪",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.11",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "杨迪",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "核心通识",
+              "after": "科学与社会"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.12",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "孙凯文"
+          },
+          "previous": {
+            "id": "FS1001.12",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "孙凯文",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.12",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "孙凯文",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "核心通识",
+              "after": "科学与社会"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.45",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "刘西之"
+          },
+          "previous": {
+            "id": "FS1001.45",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "刘西之",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.45",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "刘西之",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "核心通识",
+              "after": "科学与社会"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.46",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "张土生"
+          },
+          "previous": {
+            "id": "FS1001.46",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "张土生",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.46",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "张土生",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "核心通识",
+              "after": "科学与社会"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.54",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "刘世平"
+          },
+          "previous": {
+            "id": "FS1001.54",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "刘世平",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.54",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "刘世平",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "核心通识",
+              "after": "科学与社会"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.55",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "陈小伍"
+          },
+          "previous": {
+            "id": "FS1001.55",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "陈小伍",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.55",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "陈小伍",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "核心通识",
+              "after": "科学与社会"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.56",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "马杰"
+          },
+          "previous": {
+            "id": "FS1001.56",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "马杰",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.56",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "马杰",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "核心通识",
+              "after": "科学与社会"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.57",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "熊涛"
+          },
+          "previous": {
+            "id": "FS1001.57",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "熊涛",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.57",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "熊涛",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "核心通识",
+              "after": "科学与社会"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1580M.09",
+            "courseCode": "HS1580M",
+            "courseName": "大学生国家安全教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1580M.09",
+            "courseCode": "HS1580M",
+            "courseName": "大学生国家安全教育",
+            "teacher": "",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1580M.09",
+            "courseCode": "HS1580M",
+            "courseName": "大学生国家安全教育",
+            "teacher": "",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26中微集成电路科技英才班T",
+                "26微电子学院（大类）"
+              ],
+              "after": [
+                "26中微集成电路科技英才班T",
+                "26集电（大类）"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "IC2701.02",
+            "courseCode": "IC2701",
+            "courseName": "集成电路科技导论",
+            "teacher": "谭青海"
+          },
+          "previous": {
+            "id": "IC2701.02",
+            "courseCode": "IC2701",
+            "courseName": "集成电路科技导论",
+            "teacher": "谭青海",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "3A202",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "IC2701.02",
+            "courseCode": "IC2701",
+            "courseName": "集成电路科技导论",
+            "teacher": "谭青海",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "3A202",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26微电子学院（大类）",
+                "26电子科学与技术(强基)"
+              ],
+              "after": [
+                "26集电（大类）",
+                "26电子科学与技术(强基)"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1011.12",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "苏振源"
+          },
+          "previous": {
+            "id": "MARX1011.12",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "苏振源",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "1301",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1011.12",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "苏振源",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "1301",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "25数学学院（大类）*",
+                "25中法英才班U",
+                "25数学学院（大类）(强基)"
+              ],
+              "after": [
+                "25数学学院（大类）*",
+                "25中法英才班U"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.14",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞"
+          },
+          "previous": {
+            "id": "MARX1014.14",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C203",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.14",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C203",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26生命科学学院（大类）",
+                "26中微集成电路科技英才班T",
+                "26微电子学院（大类）"
+              ],
+              "after": [
+                "26生命科学学院（大类）",
+                "26中微集成电路科技英才班T",
+                "26集电（大类）"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH1006.18",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "吴天"
+          },
+          "previous": {
+            "id": "MATH1006.18",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "吴天",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C301",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C301",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C301",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH1006.18",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "吴天",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C301",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C301",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C301",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26中微集成电路科技英才班T",
+                "26人工智能",
+                "26微电子学院（大类）",
+                "26电子科学与技术(强基)"
+              ],
+              "after": [
+                "26中微集成电路科技英才班T",
+                "26人工智能",
+                "26集电（大类）",
+                "26电子科学与技术(强基)"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH1009.05",
+            "courseCode": "MATH1009",
+            "courseName": "线性代数(B1)",
+            "teacher": "许小卫"
+          },
+          "previous": {
+            "id": "MATH1009.05",
+            "courseCode": "MATH1009",
+            "courseName": "线性代数(B1)",
+            "teacher": "许小卫",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C101",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C101",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH1009.05",
+            "courseCode": "MATH1009",
+            "courseName": "线性代数(B1)",
+            "teacher": "许小卫",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C101",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C101",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26中微集成电路科技英才班T",
+                "26微电子学院（大类）",
+                "26级210院03班",
+                "26级210院04班"
+              ],
+              "after": [
+                "26中微集成电路科技英才班T",
+                "26集电（大类）",
+                "26级210院03班",
+                "26级210院04班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH7429P.01",
+            "courseCode": "MATH7429P",
+            "courseName": "几何拓扑及高阶Teichmüller理论选讲",
+            "teacher": "孙哲"
+          },
+          "previous": {
+            "id": "MATH7429P.01",
+            "courseCode": "MATH7429P",
+            "courseName": "几何拓扑及高阶Teichmüller理论选讲",
+            "teacher": "孙哲",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2506",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2506",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH7429P.01",
+            "courseCode": "MATH7429P",
+            "courseName": "几何拓扑及高阶Teichmüller理论选讲",
+            "teacher": "孙哲",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "2506",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "2506",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    3,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MBAD6004P.01",
+            "courseCode": "MBAD6004P",
+            "courseName": "数据、模型与决策",
+            "teacher": "安南"
+          },
+          "previous": {
+            "id": "MBAD6004P.01",
+            "courseCode": "MBAD6004P",
+            "courseName": "数据、模型与决策",
+            "teacher": "安南",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  9
+                ],
+                "room": "2606",
+                "day": 2,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:40",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  12
+                ],
+                "room": "2606",
+                "day": 2,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:40",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  9
+                ],
+                "room": "2607",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:15",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  12
+                ],
+                "room": "2607",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:15",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MBAD6004P.01",
+            "courseCode": "MBAD6004P",
+            "courseName": "数据、模型与决策",
+            "teacher": "安南",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  9
+                ],
+                "room": "2606",
+                "day": 2,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:40",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  12
+                ],
+                "room": "2606",
+                "day": 2,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:40",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  9
+                ],
+                "room": "2607",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:15",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  12
+                ],
+                "room": "2607",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:15",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  5
+                ],
+                "room": "2609",
+                "day": 3,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:40",
+                "endTime": "12:00",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    8,
+                    9
+                  ],
+                  "day": 2,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:40",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    11,
+                    12
+                  ],
+                  "day": 2,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:40",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    8,
+                    9
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:15"
+                },
+                {
+                  "weeks": [
+                    11,
+                    12
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:15"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    8,
+                    9
+                  ],
+                  "day": 2,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:40",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    11,
+                    12
+                  ],
+                  "day": 2,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:40",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    8,
+                    9
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:15"
+                },
+                {
+                  "weeks": [
+                    11,
+                    12
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:15"
+                },
+                {
+                  "weeks": [
+                    4,
+                    5
+                  ],
+                  "day": 3,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:40",
+                  "endTime": "12:00"
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2606",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2606",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2607",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2607",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2606",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2606",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2607",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2607",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2609",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6202P.01",
+            "courseCode": "MCEN6202P",
+            "courseName": "工程数学",
+            "teacher": "张明波,杨赛赛,陈景润,蒋嘉敏"
+          },
+          "previous": {
+            "id": "MCEN6202P.01",
+            "courseCode": "MCEN6202P",
+            "courseName": "工程数学",
+            "teacher": "张明波,杨赛赛,陈景润,蒋嘉敏",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6202P.01",
+            "courseCode": "MCEN6202P",
+            "courseName": "工程数学",
+            "teacher": "张明波,杨赛赛,陈景润,蒋嘉敏",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "苏高院公共教学楼301教室",
+                "day": 2,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼301教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6202P.02",
+            "courseCode": "MCEN6202P",
+            "courseName": "工程数学",
+            "teacher": "张明波,杨赛赛,蒋嘉敏"
+          },
+          "previous": {
+            "id": "MCEN6202P.02",
+            "courseCode": "MCEN6202P",
+            "courseName": "工程数学",
+            "teacher": "张明波,杨赛赛,蒋嘉敏",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6202P.02",
+            "courseCode": "MCEN6202P",
+            "courseName": "工程数学",
+            "teacher": "张明波,杨赛赛,蒋嘉敏",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "苏高院公共教学楼301教室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼301教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6203P.01",
+            "courseCode": "MCEN6203P",
+            "courseName": "材料物理化学",
+            "teacher": "苏育德"
+          },
+          "previous": {
+            "id": "MCEN6203P.01",
+            "courseCode": "MCEN6203P",
+            "courseName": "材料物理化学",
+            "teacher": "苏育德",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "地点待定",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "地点待定",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6203P.01",
+            "courseCode": "MCEN6203P",
+            "courseName": "材料物理化学",
+            "teacher": "苏育德",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "苏高院公共教学楼205教室",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "苏高院公共教学楼205教室",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼205教室",
+                  "campus": "本部"
+                },
+                {
+                  "room": "苏高院公共教学楼205教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6204P.01",
+            "courseCode": "MCEN6204P",
+            "courseName": "材料化学",
+            "teacher": "霍颖超"
+          },
+          "previous": {
+            "id": "MCEN6204P.01",
+            "courseCode": "MCEN6204P",
+            "courseName": "材料化学",
+            "teacher": "霍颖超",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "地点待定",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6204P.01",
+            "courseCode": "MCEN6204P",
+            "courseName": "材料化学",
+            "teacher": "霍颖超",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "苏高院公共教学楼205教室",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼205教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6213P.01",
+            "courseCode": "MCEN6213P",
+            "courseName": "材料合成化学B",
+            "teacher": "邸江涛"
+          },
+          "previous": {
+            "id": "MCEN6213P.01",
+            "courseCode": "MCEN6213P",
+            "courseName": "材料合成化学B",
+            "teacher": "邸江涛",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "地点待定",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6213P.01",
+            "courseCode": "MCEN6213P",
+            "courseName": "材料合成化学B",
+            "teacher": "邸江涛",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "苏高院公共教学楼102教室",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼102教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6213P.02",
+            "courseCode": "MCEN6213P",
+            "courseName": "材料合成化学B",
+            "teacher": "霍颖超"
+          },
+          "previous": {
+            "id": "MCEN6213P.02",
+            "courseCode": "MCEN6213P",
+            "courseName": "材料合成化学B",
+            "teacher": "霍颖超",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "地点待定",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6213P.02",
+            "courseCode": "MCEN6213P",
+            "courseName": "材料合成化学B",
+            "teacher": "霍颖超",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "苏高院公共教学楼101教室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼101教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6213P.03",
+            "courseCode": "MCEN6213P",
+            "courseName": "材料合成化学B",
+            "teacher": "王颖"
+          },
+          "previous": {
+            "id": "MCEN6213P.03",
+            "courseCode": "MCEN6213P",
+            "courseName": "材料合成化学B",
+            "teacher": "王颖",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "地点待定",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6213P.03",
+            "courseCode": "MCEN6213P",
+            "courseName": "材料合成化学B",
+            "teacher": "王颖",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "苏高院公共教学楼102教室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼102教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6215P.01",
+            "courseCode": "MCEN6215P",
+            "courseName": "固体物理B",
+            "teacher": "樊士钊"
+          },
+          "previous": {
+            "id": "MCEN6215P.01",
+            "courseCode": "MCEN6215P",
+            "courseName": "固体物理B",
+            "teacher": "樊士钊",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "地点待定",
+                "day": 1,
+                "periods": [
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6215P.01",
+            "courseCode": "MCEN6215P",
+            "courseName": "固体物理B",
+            "teacher": "樊士钊",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "苏高院公共教学楼205教室",
+                "day": 1,
+                "periods": [
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼205教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6402X.01",
+            "courseCode": "MCEN6402X",
+            "courseName": "管理心理学",
+            "teacher": "李宏利"
+          },
+          "previous": {
+            "id": "MCEN6402X.01",
+            "courseCode": "MCEN6402X",
+            "courseName": "管理心理学",
+            "teacher": "李宏利",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "地点待定",
+                "day": 3,
+                "periods": [
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6402X.01",
+            "courseCode": "MCEN6402X",
+            "courseName": "管理心理学",
+            "teacher": "李宏利",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "苏高院公共教学楼205教室",
+                "day": 3,
+                "periods": [
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼205教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6404P.01",
+            "courseCode": "MCEN6404P",
+            "courseName": "热安全与纳米复合材料导论",
+            "teacher": "邢伟义,侯雁北"
+          },
+          "previous": {
+            "id": "MCEN6404P.01",
+            "courseCode": "MCEN6404P",
+            "courseName": "热安全与纳米复合材料导论",
+            "teacher": "邢伟义,侯雁北",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6404P.01",
+            "courseCode": "MCEN6404P",
+            "courseName": "热安全与纳米复合材料导论",
+            "teacher": "邢伟义,侯雁北",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "苏高院公共教学楼205教室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼205教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6405P.01",
+            "courseCode": "MCEN6405P",
+            "courseName": "科技写作",
+            "teacher": "霍颖超"
+          },
+          "previous": {
+            "id": "MCEN6405P.01",
+            "courseCode": "MCEN6405P",
+            "courseName": "科技写作",
+            "teacher": "霍颖超",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  10
+                ],
+                "room": "地点待定",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6405P.01",
+            "courseCode": "MCEN6405P",
+            "courseName": "科技写作",
+            "teacher": "霍颖超",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  10
+                ],
+                "room": "苏高院公共教学楼205教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼205教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6415P.01",
+            "courseCode": "MCEN6415P",
+            "courseName": "环境功能材料",
+            "teacher": "李文卫"
+          },
+          "previous": {
+            "id": "MCEN6415P.01",
+            "courseCode": "MCEN6415P",
+            "courseName": "环境功能材料",
+            "teacher": "李文卫",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "地点待定",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6415P.01",
+            "courseCode": "MCEN6415P",
+            "courseName": "环境功能材料",
+            "teacher": "李文卫",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "苏高院公共教学楼206教室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼206教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ME4502.01",
+            "courseCode": "ME4502",
+            "courseName": "工程流体力学",
+            "teacher": "吕兴霖"
+          },
+          "previous": {
+            "id": "ME4502.01",
+            "courseCode": "ME4502",
+            "courseName": "工程流体力学",
+            "teacher": "吕兴霖",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2505",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ME4502.01",
+            "courseCode": "ME4502",
+            "courseName": "工程流体力学",
+            "teacher": "吕兴霖",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2505",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MECH6101P.02",
+            "courseCode": "MECH6101P",
+            "courseName": "高等应用数学",
+            "teacher": "朱银波"
+          },
+          "previous": {
+            "id": "MECH6101P.02",
+            "courseCode": "MECH6101P",
+            "courseName": "高等应用数学",
+            "teacher": "朱银波",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C104",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C104",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MECH6101P.02",
+            "courseCode": "MECH6101P",
+            "courseName": "高等应用数学",
+            "teacher": "朱银波",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C104",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C104",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6007P.01",
+            "courseCode": "MPAD6007P",
+            "courseName": "学术规范和论文写作",
+            "teacher": "吉骏恺"
+          },
+          "previous": {
+            "id": "MPAD6007P.01",
+            "courseCode": "MPAD6007P",
+            "courseName": "学术规范和论文写作",
+            "teacher": "吉骏恺",
+            "schedule": []
+          },
+          "current": {
+            "id": "MPAD6007P.01",
+            "courseCode": "MPAD6007P",
+            "courseName": "学术规范和论文写作",
+            "teacher": "吉骏恺",
+            "schedule": [
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  15
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    14,
+                    15
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6007P.02",
+            "courseCode": "MPAD6007P",
+            "courseName": "学术规范和论文写作",
+            "teacher": "李宗印"
+          },
+          "previous": {
+            "id": "MPAD6007P.02",
+            "courseCode": "MPAD6007P",
+            "courseName": "学术规范和论文写作",
+            "teacher": "李宗印",
+            "schedule": []
+          },
+          "current": {
+            "id": "MPAD6007P.02",
+            "courseCode": "MPAD6007P",
+            "courseName": "学术规范和论文写作",
+            "teacher": "李宗印",
+            "schedule": [
+              {
+                "weeks": [
+                  14,
+                  14
+                ],
+                "room": "2106",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "2106",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  15
+                ],
+                "room": "2106",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    14,
+                    14
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    14,
+                    15
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "2106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2106",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6009P.01",
+            "courseCode": "MPAD6009P",
+            "courseName": "公共政策分析",
+            "teacher": "王善勇,雷于萱"
+          },
+          "previous": {
+            "id": "MPAD6009P.01",
+            "courseCode": "MPAD6009P",
+            "courseName": "公共政策分析",
+            "teacher": "王善勇,雷于萱",
+            "schedule": []
+          },
+          "current": {
+            "id": "MPAD6009P.01",
+            "courseCode": "MPAD6009P",
+            "courseName": "公共政策分析",
+            "teacher": "王善勇,雷于萱",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "2121",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  13
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  13
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    8,
+                    8
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    13,
+                    13
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    8,
+                    13
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2121",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6461P.01",
+            "courseCode": "MPAD6461P",
+            "courseName": "博弈论",
+            "teacher": "戴现朝"
+          },
+          "previous": {
+            "id": "MPAD6461P.01",
+            "courseCode": "MPAD6461P",
+            "courseName": "博弈论",
+            "teacher": "戴现朝",
+            "schedule": []
+          },
+          "current": {
+            "id": "MPAD6461P.01",
+            "courseCode": "MPAD6461P",
+            "courseName": "博弈论",
+            "teacher": "戴现朝",
+            "schedule": [
+              {
+                "weeks": [
+                  9,
+                  10
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  12
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  14
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "1102",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  13
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    9,
+                    10
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    12,
+                    12
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    14,
+                    14
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    12,
+                    13
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "1102",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6463P.01",
+            "courseCode": "MPAD6463P",
+            "courseName": "网络空间治理概论",
+            "teacher": "杨林"
+          },
+          "previous": {
+            "id": "MPAD6463P.01",
+            "courseCode": "MPAD6463P",
+            "courseName": "网络空间治理概论",
+            "teacher": "杨林",
+            "schedule": []
+          },
+          "current": {
+            "id": "MPAD6463P.01",
+            "courseCode": "MPAD6463P",
+            "courseName": "网络空间治理概论",
+            "teacher": "杨林",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  13
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    8,
+                    13
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6463P.02",
+            "courseCode": "MPAD6463P",
+            "courseName": "网络空间治理概论",
+            "teacher": "杨林"
+          },
+          "previous": {
+            "id": "MPAD6463P.02",
+            "courseCode": "MPAD6463P",
+            "courseName": "网络空间治理概论",
+            "teacher": "杨林",
+            "schedule": []
+          },
+          "current": {
+            "id": "MPAD6463P.02",
+            "courseCode": "MPAD6463P",
+            "courseName": "网络空间治理概论",
+            "teacher": "杨林",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2106",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  8
+                ],
+                "room": "2106",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  10
+                ],
+                "room": "2106",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  12
+                ],
+                "room": "2106",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  13
+                ],
+                "room": "2106",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "1101",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    2
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    8
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    10,
+                    10
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    12,
+                    12
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    13,
+                    13
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "1101",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2106",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6472P.01",
+            "courseCode": "MPAD6472P",
+            "courseName": "公共科技政策",
+            "teacher": "杜磊"
+          },
+          "previous": {
+            "id": "MPAD6472P.01",
+            "courseCode": "MPAD6472P",
+            "courseName": "公共科技政策",
+            "teacher": "张煜",
+            "schedule": []
+          },
+          "current": {
+            "id": "MPAD6472P.01",
+            "courseCode": "MPAD6472P",
+            "courseName": "公共科技政策",
+            "teacher": "杜磊",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  13
+                ],
+                "room": "2106",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "2106",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张煜",
+              "after": "杜磊"
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    8,
+                    13
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "2106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2106",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6484P.01",
+            "courseCode": "MPAD6484P",
+            "courseName": "环境政策与环境管理",
+            "teacher": "汪沫然"
+          },
+          "previous": {
+            "id": "MPAD6484P.01",
+            "courseCode": "MPAD6484P",
+            "courseName": "环境政策与环境管理",
+            "teacher": "汪沫然",
+            "schedule": []
+          },
+          "current": {
+            "id": "MPAD6484P.01",
+            "courseCode": "MPAD6484P",
+            "courseName": "环境政策与环境管理",
+            "teacher": "汪沫然",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  11
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  14
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    2
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    8,
+                    11
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    14,
+                    14
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE5003P.01",
+            "courseCode": "MSAE5003P",
+            "courseName": "博弈论",
+            "teacher": "杜少甫"
+          },
+          "previous": {
+            "id": "MSAE5003P.01",
+            "courseCode": "MSAE5003P",
+            "courseName": "博弈论",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "3A412",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE5003P.01",
+            "courseCode": "MSAE5003P",
+            "courseName": "博弈论",
+            "teacher": "杜少甫",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5102",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "杜少甫"
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A412",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5102",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE6001P.01",
+            "courseCode": "MSAE6001P",
+            "courseName": "社会科学研究方法",
+            "teacher": "刘和福,陈猛,李涛,郭晓龙"
+          },
+          "previous": {
+            "id": "MSAE6001P.01",
+            "courseCode": "MSAE6001P",
+            "courseName": "社会科学研究方法",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A412",
+                "day": 2,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE6001P.01",
+            "courseCode": "MSAE6001P",
+            "courseName": "社会科学研究方法",
+            "teacher": "刘和福,陈猛,李涛,郭晓龙",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "管理楼1层第二教室",
+                "day": 2,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "刘和福,陈猛,李涛,郭晓龙"
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A412",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "管理楼1层第二教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE6103P.01",
+            "courseCode": "MSAE6103P",
+            "courseName": "智能决策",
+            "teacher": "毕功兵"
+          },
+          "previous": {
+            "id": "MSAE6103P.01",
+            "courseCode": "MSAE6103P",
+            "courseName": "智能决策",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "5401",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE6103P.01",
+            "courseCode": "MSAE6103P",
+            "courseName": "智能决策",
+            "teacher": "毕功兵",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "5401",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "毕功兵"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE6105P.01",
+            "courseCode": "MSAE6105P",
+            "courseName": "最优化理论与方法",
+            "teacher": "张勋,李宜福"
+          },
+          "previous": {
+            "id": "MSAE6105P.01",
+            "courseCode": "MSAE6105P",
+            "courseName": "最优化理论与方法",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "1102",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE6105P.01",
+            "courseCode": "MSAE6105P",
+            "courseName": "最优化理论与方法",
+            "teacher": "张勋,李宜福",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "1102",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "张勋,李宜福"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE6110P.01",
+            "courseCode": "MSAE6110P",
+            "courseName": "人工智能理论与应用",
+            "teacher": "秦进"
+          },
+          "previous": {
+            "id": "MSAE6110P.01",
+            "courseCode": "MSAE6110P",
+            "courseName": "人工智能理论与应用",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  20,
+                  20
+                ],
+                "room": "2503",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  20
+                ],
+                "room": "2503",
+                "day": 5,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:10",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE6110P.01",
+            "courseCode": "MSAE6110P",
+            "courseName": "人工智能理论与应用",
+            "teacher": "秦进",
+            "schedule": [
+              {
+                "weeks": [
+                  20,
+                  20
+                ],
+                "room": "2503",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  20
+                ],
+                "room": "2503",
+                "day": 5,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:10",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "秦进"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE6404P.01",
+            "courseCode": "MSAE6404P",
+            "courseName": "信息技术与组织战略",
+            "teacher": "秦娟"
+          },
+          "previous": {
+            "id": "MSAE6404P.01",
+            "courseCode": "MSAE6404P",
+            "courseName": "信息技术与组织战略",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  6
+                ],
+                "room": "5303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  6
+                ],
+                "room": "5303",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE6404P.01",
+            "courseCode": "MSAE6404P",
+            "courseName": "信息技术与组织战略",
+            "teacher": "秦娟",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  6
+                ],
+                "room": "5303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  6
+                ],
+                "room": "5303",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "秦娟"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE6406P.01",
+            "courseCode": "MSAE6406P",
+            "courseName": "随机系统建模与仿真",
+            "teacher": "曹平"
+          },
+          "previous": {
+            "id": "MSAE6406P.01",
+            "courseCode": "MSAE6406P",
+            "courseName": "随机系统建模与仿真",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "5106",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE6406P.01",
+            "courseCode": "MSAE6406P",
+            "courseName": "随机系统建模与仿真",
+            "teacher": "曹平",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "5106",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "曹平"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE6414P.01",
+            "courseCode": "MSAE6414P",
+            "courseName": "应急管理决策与运作",
+            "teacher": "樊彧,王熹徽"
+          },
+          "previous": {
+            "id": "MSAE6414P.01",
+            "courseCode": "MSAE6414P",
+            "courseName": "应急管理决策与运作",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "2508",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE6414P.01",
+            "courseCode": "MSAE6414P",
+            "courseName": "应急管理决策与运作",
+            "teacher": "樊彧,王熹徽",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "2508",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "樊彧,王熹徽"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE7106P.01",
+            "courseCode": "MSAE7106P",
+            "courseName": "管理科学学术论文写作",
+            "teacher": "郭晓龙"
+          },
+          "previous": {
+            "id": "MSAE7106P.01",
+            "courseCode": "MSAE7106P",
+            "courseName": "管理科学学术论文写作",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5405",
+                "day": 5,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:10",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE7106P.01",
+            "courseCode": "MSAE7106P",
+            "courseName": "管理科学学术论文写作",
+            "teacher": "郭晓龙",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5405",
+                "day": 5,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:10",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "郭晓龙"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE7109P.01",
+            "courseCode": "MSAE7109P",
+            "courseName": "管理信息系统前沿理论与经典文献阅读",
+            "teacher": "孙培樑,叶强"
+          },
+          "previous": {
+            "id": "MSAE7109P.01",
+            "courseCode": "MSAE7109P",
+            "courseName": "管理信息系统前沿理论与经典文献阅读",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5505",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "18:40",
+                "endTime": "21:50",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE7109P.01",
+            "courseCode": "MSAE7109P",
+            "courseName": "管理信息系统前沿理论与经典文献阅读",
+            "teacher": "孙培樑,叶强",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5505",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "18:40",
+                "endTime": "21:50",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "孙培樑,叶强"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE7116P.01",
+            "courseCode": "MSAE7116P",
+            "courseName": "高等决策分析",
+            "teacher": "杨锋"
+          },
+          "previous": {
+            "id": "MSAE7116P.01",
+            "courseCode": "MSAE7116P",
+            "courseName": "高等决策分析",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5102",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE7116P.01",
+            "courseCode": "MSAE7116P",
+            "courseName": "高等决策分析",
+            "teacher": "杨锋",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5102",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "杨锋"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE7121P.01",
+            "courseCode": "MSAE7121P",
+            "courseName": "行为研究实验设计与分析",
+            "teacher": "于莉莉"
+          },
+          "previous": {
+            "id": "MSAE7121P.01",
+            "courseCode": "MSAE7121P",
+            "courseName": "行为研究实验设计与分析",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5307",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE7121P.01",
+            "courseCode": "MSAE7121P",
+            "courseName": "行为研究实验设计与分析",
+            "teacher": "于莉莉",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5307",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "于莉莉"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE7123P.01",
+            "courseCode": "MSAE7123P",
+            "courseName": "数智驱动论文复现和研究方法案例",
+            "teacher": "余玉刚"
+          },
+          "previous": {
+            "id": "MSAE7123P.01",
+            "courseCode": "MSAE7123P",
+            "courseName": "数智驱动论文复现和研究方法案例",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  7,
+                  9,
+                  11,
+                  13,
+                  15
+                ],
+                "room": "5206",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "19:00",
+                "endTime": "22:10",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE7123P.01",
+            "courseCode": "MSAE7123P",
+            "courseName": "数智驱动论文复现和研究方法案例",
+            "teacher": "余玉刚",
+            "schedule": [
+              {
+                "weeks": [
+                  7,
+                  9,
+                  11,
+                  13,
+                  15
+                ],
+                "room": "5206",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "19:00",
+                "endTime": "22:10",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "余玉刚"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE7127P.01",
+            "courseCode": "MSAE7127P",
+            "courseName": "随机与鲁棒优化",
+            "teacher": "朱宁"
+          },
+          "previous": {
+            "id": "MSAE7127P.01",
+            "courseCode": "MSAE7127P",
+            "courseName": "随机与鲁棒优化",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "18:30",
+                "endTime": "21:40",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE7127P.01",
+            "courseCode": "MSAE7127P",
+            "courseName": "随机与鲁棒优化",
+            "teacher": "朱宁",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "18:30",
+                "endTime": "21:40",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "朱宁"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE7128P.01",
+            "courseCode": "MSAE7128P",
+            "courseName": "管理科学前沿文献分析",
+            "teacher": "詹东远"
+          },
+          "previous": {
+            "id": "MSAE7128P.01",
+            "courseCode": "MSAE7128P",
+            "courseName": "管理科学前沿文献分析",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5106",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:20",
+                "endTime": "17:30",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE7128P.01",
+            "courseCode": "MSAE7128P",
+            "courseName": "管理科学前沿文献分析",
+            "teacher": "詹东远",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5106",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:20",
+                "endTime": "17:30",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "詹东远"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSEN6005P.05",
+            "courseCode": "MSEN6005P",
+            "courseName": "材料合成化学",
+            "teacher": "周天柱"
+          },
+          "previous": {
+            "id": "MSEN6005P.05",
+            "courseCode": "MSEN6005P",
+            "courseName": "材料合成化学",
+            "teacher": "周天柱",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "地点待定",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "地点待定",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSEN6005P.05",
+            "courseCode": "MSEN6005P",
+            "courseName": "材料合成化学",
+            "teacher": "周天柱",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "苏高院公共教学楼205教室",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "苏高院公共教学楼205教室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼205教室",
+                  "campus": "本部"
+                },
+                {
+                  "room": "苏高院公共教学楼205教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSEN6402P.01",
+            "courseCode": "MSEN6402P",
+            "courseName": "半导体器件原理",
+            "teacher": "凤建岗"
+          },
+          "previous": {
+            "id": "MSEN6402P.01",
+            "courseCode": "MSEN6402P",
+            "courseName": "半导体器件原理",
+            "teacher": "凤建岗",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "地点待定",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "地点待定",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSEN6402P.01",
+            "courseCode": "MSEN6402P",
+            "courseName": "半导体器件原理",
+            "teacher": "凤建岗",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "苏高院公共教学楼206教室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "苏高院公共教学楼206教室",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼206教室",
+                  "campus": "其他"
+                },
+                {
+                  "room": "苏高院公共教学楼206教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSEN7001P.01",
+            "courseCode": "MSEN7001P",
+            "courseName": "新能源材料与技术",
+            "teacher": "张宁"
+          },
+          "previous": {
+            "id": "MSEN7001P.01",
+            "courseCode": "MSEN7001P",
+            "courseName": "新能源材料与技术",
+            "teacher": "张宁",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSEN7001P.01",
+            "courseCode": "MSEN7001P",
+            "courseName": "新能源材料与技术",
+            "teacher": "张宁",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "苏高院公共教学楼305教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼305教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NSEN6001P.01",
+            "courseCode": "NSEN6001P",
+            "courseName": "纳米科学与工程",
+            "teacher": "范雅珣,李储鑫,赵创奇"
+          },
+          "previous": {
+            "id": "NSEN6001P.01",
+            "courseCode": "NSEN6001P",
+            "courseName": "纳米科学与工程",
+            "teacher": "范雅珣,李储鑫,赵创奇",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "地点待定",
+                "day": 1,
+                "periods": [
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "地点待定",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "NSEN6001P.01",
+            "courseCode": "NSEN6001P",
+            "courseName": "纳米科学与工程",
+            "teacher": "范雅珣,李储鑫,赵创奇",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "苏高院公共教学楼204教室",
+                "day": 1,
+                "periods": [
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "苏高院公共教学楼204教室",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼204教室",
+                  "campus": "其他"
+                },
+                {
+                  "room": "苏高院公共教学楼204教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NSEN6002P.01",
+            "courseCode": "NSEN6002P",
+            "courseName": "纳米材料与化学基础",
+            "teacher": "张振"
+          },
+          "previous": {
+            "id": "NSEN6002P.01",
+            "courseCode": "NSEN6002P",
+            "courseName": "纳米材料与化学基础",
+            "teacher": "张振",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "地点待定",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "NSEN6002P.01",
+            "courseCode": "NSEN6002P",
+            "courseName": "纳米材料与化学基础",
+            "teacher": "张振",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "苏高院公共教学楼204教室",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "苏高院公共教学楼204教室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼204教室",
+                  "campus": "其他"
+                },
+                {
+                  "room": "苏高院公共教学楼204教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NSEN6003P.01",
+            "courseCode": "NSEN6003P",
+            "courseName": "纳米科学与工程前沿实验",
+            "teacher": "王毅琳,范雅珣,张振,朱忠鹏,赵创奇,高寒飞,杨俊川"
+          },
+          "previous": {
+            "id": "NSEN6003P.01",
+            "courseCode": "NSEN6003P",
+            "courseName": "纳米科学与工程前沿实验",
+            "teacher": "王毅琳,范雅珣,张振,朱忠鹏,赵创奇,高寒飞,杨俊川",
+            "schedule": [
+              {
+                "weeks": [
+                  6,
+                  12
+                ],
+                "room": "地点待定",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "NSEN6003P.01",
+            "courseCode": "NSEN6003P",
+            "courseName": "纳米科学与工程前沿实验",
+            "teacher": "王毅琳,范雅珣,张振,朱忠鹏,赵创奇,高寒飞,杨俊川",
+            "schedule": [
+              {
+                "weeks": [
+                  6,
+                  12
+                ],
+                "room": "纳米学院纳米科学与工程实验室",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 70
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "纳米学院纳米科学与工程实验室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NSEN6004P.01",
+            "courseCode": "NSEN6004P",
+            "courseName": "微纳米材料与器件制造",
+            "teacher": "刘东"
+          },
+          "previous": {
+            "id": "NSEN6004P.01",
+            "courseCode": "NSEN6004P",
+            "courseName": "微纳米材料与器件制造",
+            "teacher": "刘东",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "NSEN6004P.01",
+            "courseCode": "NSEN6004P",
+            "courseName": "微纳米材料与器件制造",
+            "teacher": "刘东",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "苏高院公共教学楼206教室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼206教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NSEN7001P.01",
+            "courseCode": "NSEN7001P",
+            "courseName": "仿生纳米复合材料与工程",
+            "teacher": "程群峰"
+          },
+          "previous": {
+            "id": "NSEN7001P.01",
+            "courseCode": "NSEN7001P",
+            "courseName": "仿生纳米复合材料与工程",
+            "teacher": "程群峰",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "NSEN7001P.01",
+            "courseCode": "NSEN7001P",
+            "courseName": "仿生纳米复合材料与工程",
+            "teacher": "程群峰",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "苏高院公共教学楼205教室",
+                "day": 2,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼205教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NSEN7002P.01",
+            "courseCode": "NSEN7002P",
+            "courseName": "纳米科学与工程名师讲堂",
+            "teacher": "江雷,朱忠鹏"
+          },
+          "previous": {
+            "id": "NSEN7002P.01",
+            "courseCode": "NSEN7002P",
+            "courseName": "纳米科学与工程名师讲堂",
+            "teacher": "江雷,朱忠鹏",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "地点待定",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "NSEN7002P.01",
+            "courseCode": "NSEN7002P",
+            "courseName": "纳米科学与工程名师讲堂",
+            "teacher": "江雷,朱忠鹏",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "苏高院公共教学楼104教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼104教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PEET7310P.01",
+            "courseCode": "PEET7310P",
+            "courseName": "新能源技术和政策",
+            "teacher": "蔡国田,汪鹏,黄莹,成贝贝,黄玉萍"
+          },
+          "previous": {
+            "id": "PEET7310P.01",
+            "courseCode": "PEET7310P",
+            "courseName": "新能源技术和政策",
+            "teacher": "蔡国田,汪鹏,黄莹,成贝贝,黄玉萍",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "GT-B104",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  4,
+                  4
+                ],
+                "room": "GT-B104",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  6,
+                  6
+                ],
+                "room": "GT-B104",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  8
+                ],
+                "room": "GT-B104",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  10
+                ],
+                "room": "GT-B104",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  11,
+                  12
+                ],
+                "room": "GT-B104",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "GT-B104",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  4,
+                  4
+                ],
+                "room": "GT-B104",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  6,
+                  6
+                ],
+                "room": "GT-B104",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  8
+                ],
+                "room": "GT-B104",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  10
+                ],
+                "room": "GT-B104",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  11,
+                  12
+                ],
+                "room": "GT-B104",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "PEET7310P.01",
+            "courseCode": "PEET7310P",
+            "courseName": "新能源技术和政策",
+            "teacher": "蔡国田,汪鹏,黄莹,成贝贝,黄玉萍",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "3A410",
+                "day": 3,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  5
+                ],
+                "room": "3A410",
+                "day": 3,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  7
+                ],
+                "room": "3A410",
+                "day": 3,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  9
+                ],
+                "room": "3A410",
+                "day": 3,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  11
+                ],
+                "room": "3A410",
+                "day": 3,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "3A410",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  5
+                ],
+                "room": "3A410",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  7
+                ],
+                "room": "3A410",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  9
+                ],
+                "room": "3A410",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  11
+                ],
+                "room": "3A410",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    4
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    6,
+                    6
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    8
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    10
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    11,
+                    12
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    4
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    6,
+                    6
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    8
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    10
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    11,
+                    12
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 3,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    5
+                  ],
+                  "day": 3,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    6,
+                    7
+                  ],
+                  "day": 3,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    8,
+                    9
+                  ],
+                  "day": 3,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    10,
+                    11
+                  ],
+                  "day": 3,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    5
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    6,
+                    7
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    8,
+                    9
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    10,
+                    11
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "GT-B104",
+                  "campus": "高新区"
+                },
+                {
+                  "room": "GT-B104",
+                  "campus": "高新区"
+                },
+                {
+                  "room": "GT-B104",
+                  "campus": "高新区"
+                },
+                {
+                  "room": "GT-B104",
+                  "campus": "高新区"
+                },
+                {
+                  "room": "GT-B104",
+                  "campus": "高新区"
+                },
+                {
+                  "room": "GT-B104",
+                  "campus": "高新区"
+                },
+                {
+                  "room": "GT-B104",
+                  "campus": "高新区"
+                },
+                {
+                  "room": "GT-B104",
+                  "campus": "高新区"
+                },
+                {
+                  "room": "GT-B104",
+                  "campus": "高新区"
+                },
+                {
+                  "room": "GT-B104",
+                  "campus": "高新区"
+                },
+                {
+                  "room": "GT-B104",
+                  "campus": "高新区"
+                },
+                {
+                  "room": "GT-B104",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "3A410",
+                  "campus": "本部"
+                },
+                {
+                  "room": "3A410",
+                  "campus": "本部"
+                },
+                {
+                  "room": "3A410",
+                  "campus": "本部"
+                },
+                {
+                  "room": "3A410",
+                  "campus": "本部"
+                },
+                {
+                  "room": "3A410",
+                  "campus": "本部"
+                },
+                {
+                  "room": "3A410",
+                  "campus": "本部"
+                },
+                {
+                  "room": "3A410",
+                  "campus": "本部"
+                },
+                {
+                  "room": "3A410",
+                  "campus": "本部"
+                },
+                {
+                  "room": "3A410",
+                  "campus": "本部"
+                },
+                {
+                  "room": "3A410",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PEET7310P.02",
+            "courseCode": "PEET7310P",
+            "courseName": "新能源技术和政策",
+            "teacher": "漆小玲,王文秀,谢鹏程,黄玉萍"
+          },
+          "previous": {
+            "id": "PEET7310P.02",
+            "courseCode": "PEET7310P",
+            "courseName": "新能源技术和政策",
+            "teacher": "漆小玲,王文秀,谢鹏程,黄玉萍",
+            "schedule": []
+          },
+          "current": {
+            "id": "PEET7310P.02",
+            "courseCode": "PEET7310P",
+            "courseName": "新能源技术和政策",
+            "teacher": "漆小玲,王文秀,谢鹏程,黄玉萍",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "地点待定",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  4,
+                  5
+                ],
+                "room": "地点待定",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "地点待定",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  8,
+                  10
+                ],
+                "room": "地点待定",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  11,
+                  12
+                ],
+                "room": "地点待定",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  4,
+                  5
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  8,
+                  10
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  11,
+                  12
+                ],
+                "room": "地点待定",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    8,
+                    10
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    11,
+                    12
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    5
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    8,
+                    10
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    11,
+                    12
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                },
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PEET7322P.01",
+            "courseCode": "PEET7322P",
+            "courseName": "新能源与可再生能源前沿讲座",
+            "teacher": "盛松伟,张亚群,王坤林,王振鹏,张宇,卢静生,马泽涛,庄新姝,宋文吉,关进安"
+          },
+          "previous": {
+            "id": "PEET7322P.01",
+            "courseCode": "PEET7322P",
+            "courseName": "新能源与可再生能源前沿讲座",
+            "teacher": "张亚群,张宇,庄新姝,宋文吉",
+            "schedule": []
+          },
+          "current": {
+            "id": "PEET7322P.01",
+            "courseCode": "PEET7322P",
+            "courseName": "新能源与可再生能源前沿讲座",
+            "teacher": "盛松伟,张亚群,王坤林,王振鹏,张宇,卢静生,马泽涛,庄新姝,宋文吉,关进安",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张亚群,张宇,庄新姝,宋文吉",
+              "after": "盛松伟,张亚群,王坤林,王振鹏,张宇,卢静生,马泽涛,庄新姝,宋文吉,关进安"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHIL7101U.15",
+            "courseCode": "PHIL7101U",
+            "courseName": "中国马克思主义与当代",
+            "teacher": "应验,张德广,苏振源"
+          },
+          "previous": {
+            "id": "PHIL7101U.15",
+            "courseCode": "PHIL7101U",
+            "courseName": "中国马克思主义与当代",
+            "teacher": "应验,张德广,苏振源",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "地点待定",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHIL7101U.15",
+            "courseCode": "PHIL7101U",
+            "courseName": "中国马克思主义与当代",
+            "teacher": "应验,张德广,苏振源",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "苏高院公共教学楼101教室",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "苏高院公共教学楼101教室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1001A.10",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "秦胜勇"
+          },
+          "previous": {
+            "id": "PHYS1001A.10",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "卫子安",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5306",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5306",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1001A.10",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "秦胜勇",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5306",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5306",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "卫子安",
+              "after": "秦胜勇"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1001A.11",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "卫子安"
+          },
+          "previous": {
+            "id": "PHYS1001A.11",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "秦胜勇",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5407",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5407",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1001A.11",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "卫子安",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5407",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5407",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "秦胜勇",
+              "after": "卫子安"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS5082P.01",
+            "courseCode": "PHYS5082P",
+            "courseName": "放射治疗物理原理",
+            "teacher": "杨益东,唐泽波"
+          },
+          "previous": {
+            "id": "PHYS5082P.01",
+            "courseCode": "PHYS5082P",
+            "courseName": "放射治疗物理原理",
+            "teacher": "杨益东,唐泽波",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2303",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1115",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS5082P.01",
+            "courseCode": "PHYS5082P",
+            "courseName": "放射治疗物理原理",
+            "teacher": "杨益东,唐泽波",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2303",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1115",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PLNT6401P.01",
+            "courseCode": "PLNT6401P",
+            "courseName": "行星粘土矿物科学",
+            "teacher": "李亚梅"
+          },
+          "previous": {
+            "id": "PLNT6401P.01",
+            "courseCode": "PLNT6401P",
+            "courseName": "行星粘土矿物科学",
+            "teacher": "李亚梅",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "2602",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PLNT6401P.01",
+            "courseCode": "PLNT6401P",
+            "courseName": "行星粘土矿物科学",
+            "teacher": "李亚梅",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "2602",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT2002.03",
+            "courseCode": "STAT2002",
+            "courseName": "概率论与数理统计",
+            "teacher": "毛甜甜"
+          },
+          "previous": {
+            "id": "STAT2002.03",
+            "courseCode": "STAT2002",
+            "courseName": "概率论与数理统计",
+            "teacher": "毛甜甜",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5102",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT2002.03",
+            "courseCode": "STAT2002",
+            "courseName": "概率论与数理统计",
+            "teacher": "毛甜甜",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5403",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5102",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5403",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT5104P.01",
+            "courseCode": "STAT5104P",
+            "courseName": "高等概率论",
+            "teacher": "胡太忠,庄玮玮"
+          },
+          "previous": {
+            "id": "STAT5104P.01",
+            "courseCode": "STAT5104P",
+            "courseName": "高等概率论",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "5104",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ],
+                "room": "5104",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT5104P.01",
+            "courseCode": "STAT5104P",
+            "courseName": "高等概率论",
+            "teacher": "胡太忠,庄玮玮",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "5104",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ],
+                "room": "5104",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "胡太忠,庄玮玮"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT5127P.01",
+            "courseCode": "STAT5127P",
+            "courseName": "贝叶斯分析",
+            "teacher": "张伟平,陈昱"
+          },
+          "previous": {
+            "id": "STAT5127P.01",
+            "courseCode": "STAT5127P",
+            "courseName": "贝叶斯分析",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "2406",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT5127P.01",
+            "courseCode": "STAT5127P",
+            "courseName": "贝叶斯分析",
+            "teacher": "张伟平,陈昱",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "2406",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "张伟平,陈昱"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT6123P.01",
+            "courseCode": "STAT6123P",
+            "courseName": "统计计算与优化A",
+            "teacher": "张洪"
+          },
+          "previous": {
+            "id": "STAT6123P.01",
+            "courseCode": "STAT6123P",
+            "courseName": "统计计算与优化A",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5502",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT6123P.01",
+            "courseCode": "STAT6123P",
+            "courseName": "统计计算与优化A",
+            "teacher": "张洪",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5502",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "张洪"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT6127P.01",
+            "courseCode": "STAT6127P",
+            "courseName": "非参数统计",
+            "teacher": "贺百花,陈刘军"
+          },
+          "previous": {
+            "id": "STAT6127P.01",
+            "courseCode": "STAT6127P",
+            "courseName": "非参数统计",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5407",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT6127P.01",
+            "courseCode": "STAT6127P",
+            "courseName": "非参数统计",
+            "teacher": "贺百花,陈刘军",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5407",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "贺百花,陈刘军"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT6201P.01",
+            "courseCode": "STAT6201P",
+            "courseName": "高等计量经济学",
+            "teacher": "吴彬,叶五一"
+          },
+          "previous": {
+            "id": "STAT6201P.01",
+            "courseCode": "STAT6201P",
+            "courseName": "高等计量经济学",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  19
+                ],
+                "room": "5505",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT6201P.01",
+            "courseCode": "STAT6201P",
+            "courseName": "高等计量经济学",
+            "teacher": "吴彬,叶五一",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  19
+                ],
+                "room": "5505",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "吴彬,叶五一"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT6202P.01",
+            "courseCode": "STAT6202P",
+            "courseName": "高等微观经济学",
+            "teacher": "单有"
+          },
+          "previous": {
+            "id": "STAT6202P.01",
+            "courseCode": "STAT6202P",
+            "courseName": "高等微观经济学",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5203",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT6202P.01",
+            "courseCode": "STAT6202P",
+            "courseName": "高等微观经济学",
+            "teacher": "单有",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5203",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "单有"
+            },
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT6205P.01",
+            "courseCode": "STAT6205P",
+            "courseName": "金融工程中的数学基础",
+            "teacher": "金百锁"
+          },
+          "previous": {
+            "id": "STAT6205P.01",
+            "courseCode": "STAT6205P",
+            "courseName": "金融工程中的数学基础",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "2408",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT6205P.01",
+            "courseCode": "STAT6205P",
+            "courseName": "金融工程中的数学基础",
+            "teacher": "金百锁",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "2408",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "金百锁"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT6705P.01",
+            "courseCode": "STAT6705P",
+            "courseName": "固定收益证券",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "STAT6705P.01",
+            "courseCode": "STAT6705P",
+            "courseName": "固定收益证券",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  20
+                ],
+                "room": "5406",
+                "day": 1,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  20
+                ],
+                "room": "5405",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "2507",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  20
+                ],
+                "room": "5404",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT6705P.01",
+            "courseCode": "STAT6705P",
+            "courseName": "固定收益证券",
+            "teacher": "",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  20
+                ],
+                "room": "5406",
+                "day": 1,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  20
+                ],
+                "room": "5405",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  20
+                ],
+                "room": "5404",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    20
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    20
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    15
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    20
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    20
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    20
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    20
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2507",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5404",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5405",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5406",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5404",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5405",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5406",
+                  "campus": "本部"
                 }
               ]
             }

--- a/public/data/semesters/index.json
+++ b/public/data/semesters/index.json
@@ -6,7 +6,7 @@
       "key": "2026-fall",
       "name": "2026年秋季学期",
       "file": "2026-fall/courses.json",
-      "revision": "59ccdd35b1702875acbc4b9eca8e3b9e4284b495f26ba6d87cbe440829706368",
+      "revision": "5b037b34655138baac2ae0578248a6dfb0c08ee4decb1b8b707e4e46b5c9d29e",
       "updatesFile": "2026-fall/updates.json"
     },
     {


### PR DESCRIPTION
## 概要

按 [`MAINTENANCE.md`](../blob/main/MAINTENANCE.md) 第一节执行 2026 年秋季学期的课程数据刷新（纯数据刷新，非切学期）。

## 执行流程

- `uv sync --group spider --group dev`
- `./scripts/sync_semester_courses.ps1 -Semester '2026年秋季学期' -Activate '2026年秋季学期'`
  - 可见浏览器手动登录 USTC CAS/SSO，复用持久化 profile
  - 同步全量课堂 + 详情，自动跑 `validate-lessons --all`

## 变更

| 文件 | 说明 |
|---|---|
| `public/data/semesters/2026-fall/courses.json` | 课程列表 + detailsBySection + revision |
| `public/data/semesters/2026-fall/updates.json` | 追加一条变更记录（2026-07-20） |
| `public/data/semesters/index.json` | 2026-fall revision 更新 |

## validate-lessons 结果

```
semester=2026-fall courses=2469 raw_schedule_non_empty=2340 scheduled_courses=2340 clock_time_courses=70 grading_non_empty=2469 grading_labels=二分制,五分制,百分制 textbooks=2265 materials=182 reference_books_non_empty=2427
semester=2026-summer courses=90 raw_schedule_non_empty=65 scheduled_courses=65 clock_time_courses=5 grading_non_empty=90 grading_labels=二分制,五分制,百分制 textbooks=51 materials=26 reference_books_non_empty=90
```

- `scheduled_courses == raw_schedule_non_empty`：时间表解析无失败，无需检查 `lesson_transform.py`。
- 2026-fall `revision`：`59ccdd35…` → `5b037b34…`
- `updates.json` 新增 entry：**+4 added, -6 removed, 131 modified**（removed 课堂均带 `replacementCandidates`）。

## 无前端联动

本次为纯数据刷新，按 MAINTENANCE.md 不涉及：
- `src/config/termCalendar.ts` / `termCalendar.test.ts`（仅切学期时改）
- `src/updates/appUpdates.ts`（课程增删改由 `updates.json` 驱动，与版本日志是两套机制）

🤖 Generated with [Claude Code](https://claude.com/claude-code)