### PR TITLE
data: refresh 2026-fall lessons

### DIFF
--- a/public/data/semesters/2026-fall/updates.json
+++ b/public/data/semesters/2026-fall/updates.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "semesterKey": "2026-fall",
-  "currentRevision": "262de6d9b86206ab535ca49d00574b8d257c104693f8d7a638c3e67c39c9e8a9",
+  "currentRevision": "5e6c9cdd284a5ba55121e81d4e2b2f9e59467cdaf70e5d34b06528b6654c5042",
   "entries": [
     {
       "id": "2026-fall:c0cbaf189652cc27",
@@ -94346,6 +94346,81 @@
               "label": "本研同堂",
               "before": false,
               "after": true
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2026-fall:5e6c9cdd284a5ba5",
+      "revision": "5e6c9cdd284a5ba55121e81d4e2b2f9e59467cdaf70e5d34b06528b6654c5042",
+      "previousRevision": "262de6d9b86206ab535ca49d00574b8d257c104693f8d7a638c3e67c39c9e8a9",
+      "publishedAt": "2026-07-23T03:27:50Z",
+      "summary": {
+        "added": 0,
+        "removed": 0,
+        "modified": 1
+      },
+      "added": [],
+      "removed": [],
+      "modified": [
+        {
+          "course": {
+            "id": "CONT5215P.01",
+            "courseCode": "CONT5215P",
+            "courseName": "智能机器人",
+            "teacher": "张彬,张飞,王敬"
+          },
+          "previous": {
+            "id": "CONT5215P.01",
+            "courseCode": "CONT5215P",
+            "courseName": "智能机器人",
+            "teacher": "张彬,张飞,王敬",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "G3-109",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "CONT5215P.01",
+            "courseCode": "CONT5215P",
+            "courseName": "智能机器人",
+            "teacher": "张彬,张飞,王敬",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "G3-109",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
             }
           ]
         }

--- a/public/data/semesters/index.json
+++ b/public/data/semesters/index.json
@@ -6,7 +6,7 @@
       "key": "2026-fall",
       "name": "2026年秋季学期",
       "file": "2026-fall/courses.json",
-      "revision": "262de6d9b86206ab535ca49d00574b8d257c104693f8d7a638c3e67c39c9e8a9",
+      "revision": "5e6c9cdd284a5ba55121e81d4e2b2f9e59467cdaf70e5d34b06528b6654c5042",
       "updatesFile": "2026-fall/updates.json"
     },
     {


### PR DESCRIPTION
## 概要

按 [`MAINTENANCE.md`](../blob/main/MAINTENANCE.md) 第一节再次刷新 2026-fall 课程数据（纯数据刷新，非切学期）。

## 执行

- `./scripts/sync_semester_courses.ps1 -Semester '2026年秋季学期' -Activate '2026年秋季学期'`
- **复用上次登录态**（`catalog_spider/data/browser-profile/`），未重新登录，脚本直接拿到 `登录状态: 200`。

## validate-lessons 结果

```
semester=2026-fall courses=2466 raw_schedule_non_empty=2351 scheduled_courses=2351 clock_time_courses=91 grading_non_empty=2466 grading_labels=二分制,五分制,百分制 textbooks=2264 materials=180 reference_books_non_empty=2424
semester=2026-summer courses=89 raw_schedule_non_empty=64 scheduled_courses=64 clock_time_courses=5 grading_non_empty=89 grading_labels=二分制,五分制,百分制 textbooks=50 materials=26 reference_books_non_empty=89
```

- `scheduled_courses == raw_schedule_non_empty`：两学期时间表解析均零失败。
- 2026-fall `revision`：`262de6d9…` -> `5e6c9cdd…`
- revision 四处一致性校验通过（`index.json` == `courses.json` == `updates.json.currentRevision` == 最新 entry.revision）。
- `updates.json` 新增 entry（2026-07-23）：**+0 added / -0 removed / 1 modified**，`previousRevision` 指向上一条 entry，链条连贯。

## 无前端联动

纯数据刷新，按 MAINTENANCE.md 第五节不涉及 `termCalendar.ts` / 测试 / `APP_RELEASES`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)