### PR TITLE
data: snapshot 2026-fall 课程数据 (2026-07-23)

### DIFF
--- a/public/data/snapshots/2026-fall/2026-07-23/README.md
+++ b/public/data/snapshots/2026-fall/2026-07-23/README.md
@@ -1,0 +1,36 @@
+# 2026-fall 课程数据快照 · 2026-07-23
+
+本目录是 2026 年秋季学期课程数据在 **2026-07-23** 的封存快照，代表一个特殊时间点的开课数量基准。
+
+**不会被 `catalog_spider sync-lessons` 覆盖**--该命令只写 `public/data/semesters/`，本目录隔离于同步流程之外，内容固定不变。
+
+## 元数据
+
+| 字段 | 值 |
+|---|---|
+| 学期 | `2026-fall`（2026年秋季学期） |
+| 封存日期 | 2026-07-23 |
+| `revision` | `5e6c9cdd284a5ba55121e81d4e2b2f9e59467cdaf70e5d34b06528b6654c5042` |
+| 来源文件 | `public/data/semesters/2026-fall/courses.json` |
+| 来源提交 | `00de591`（PR #29 合并后的 main） |
+
+## 数量指标（来自 `validate-lessons`）
+
+| 指标 | 值 |
+|---|---|
+| `courses` | 2466 |
+| `raw_schedule_non_empty` | 2351 |
+| `scheduled_courses` | 2351（= `raw_schedule_non_empty`，时间表解析零失败） |
+| `clock_time_courses` | 91 |
+| `grading_non_empty` | 2466 |
+| `grading_labels` | 二分制,五分制,百分制 |
+| `textbooks` | 2264 |
+| `materials` | 180 |
+| `reference_books_non_empty` | 2424 |
+
+## 说明
+
+- 此快照用于固化该时间点的课程数量，不随后续数据刷新而变化。
+- 主数据流仍为 `public/data/semesters/2026-fall/courses.json`，会随 `sync-lessons` 持续更新；本快照不参与该流程。
+- 如需对比当前数据与本快照的差异，可 diff 两份 `courses.json`，或比较当前 `index.json` 的 `revision` 与上表的 `revision`。
+- 同目录下的 `courses.json` 是来源文件的逐字节副本，未做任何改动。


### PR DESCRIPTION
## 概要

封存 2026-07-23 时间点的 2026-fall 课程数据快照，固化该时间点的开课数量基准。代表一个特殊时间点，用于记录当时的课程数量。

## 封存内容

存放于 `public/data/snapshots/2026-fall/2026-07-23/`：

| 文件 | 说明 |
|---|---|
| `courses.json` | `public/data/semesters/2026-fall/courses.json` 的逐字节副本（19.8 MB，SHA-256 已校验一致） |
| `README.md` | 元数据 + `validate-lessons` 数量指标 |

## 为什么放在这里

- `catalog_spider sync-lessons` 只写 `public/data/semesters/`，**不会覆盖** `public/data/snapshots/` 下的内容--快照隔离于同步流程，内容固定不变。
- `.gitignore` 不忽略该路径，会正常入 git。

## 元数据

| 字段 | 值 |
|---|---|
| 学期 | `2026-fall` |
| 封存日期 | 2026-07-23 |
| `revision` | `5e6c9cdd…` |
| 来源提交 | `00de591`（PR #29 合并后的 main） |
| `courses` | 2466 |
| `scheduled_courses` | 2351（= `raw_schedule_non_empty`，零失败） |

## 说明

- 主数据流仍为 `public/data/semesters/2026-fall/courses.json`，会随 `sync-lessons` 持续更新；本快照不参与该流程。
- `courses.json` 较大（约 19.8 MB / 23 万行），入 git 会增加仓库体积，但为完整封存该时间点数据所必需。

🤖 Generated with [Claude Code](https://claude.com/claude-code)