### PR TITLE
feat: 全局备忘录功能

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,7 @@ import UpdateHistoryModal from '@/components/UpdateHistoryModal';
 import { useOverlayStackSnapshot } from '@/components/overlayStack';
 import { loadPlansPayload, savePlansPayload } from '@/utils/planSeed';
 import { FavoritesProvider, useFavorites } from '@/favorites/FavoritesContext';
+import { MemosProvider } from '@/memos/MemosContext';
 import {
   activeArrangementFavoritePreferences,
   activeArrangementFavoriteIds,
@@ -1092,20 +1093,22 @@ export default function App() {
       }}
     >
       <AntApp>
-        <FavoritesProvider
-          key={`favorites:${catalog.semester.key}`}
-          semesterKey={catalog.semester.key}
-        >
-          <PlansProvider
-            key={catalog.semester.key}
+        <MemosProvider>
+          <FavoritesProvider
+            key={`favorites:${catalog.semester.key}`}
             semesterKey={catalog.semester.key}
-            defaultSemesterKey={manifest.defaultSemester}
-            courseMap={courseMap}
-            catalogRevision={catalog.revision}
           >
-            <MainArea themeMode={themeMode} onToggleTheme={toggleTheme} />
-          </PlansProvider>
-        </FavoritesProvider>
+            <PlansProvider
+              key={catalog.semester.key}
+              semesterKey={catalog.semester.key}
+              defaultSemesterKey={manifest.defaultSemester}
+              courseMap={courseMap}
+              catalogRevision={catalog.revision}
+            >
+              <MainArea themeMode={themeMode} onToggleTheme={toggleTheme} />
+            </PlansProvider>
+          </FavoritesProvider>
+        </MemosProvider>
       </AntApp>
     </ConfigProvider>
   );

--- a/src/components/FilterBar.test.ts
+++ b/src/components/FilterBar.test.ts
@@ -3,6 +3,7 @@ import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 import FilterBar from './FilterBar';
+import { MemosProvider } from '@/memos/MemosContext';
 
 const filterBarSource = readFileSync(new URL('./FilterBar.tsx', import.meta.url), 'utf8');
 const appSource = readFileSync(new URL('../App.tsx', import.meta.url), 'utf8');
@@ -34,11 +35,11 @@ const options = {
 
 describe('FilterBar search row', () => {
   it('places teacher search beside the input and removes result counts', () => {
-    const html = renderToStaticMarkup(createElement(FilterBar, {
+    const html = renderToStaticMarkup(createElement(MemosProvider, null, createElement(FilterBar, {
       filter,
       setFilter: vi.fn(),
       options,
-    } as Parameters<typeof FilterBar>[0]));
+    } as Parameters<typeof FilterBar>[0])));
 
     const teacherToggleIndex = html.indexOf('filter-bar__teacher-toggle');
     const controlsIndex = html.indexOf('filter-bar__controls');
@@ -70,11 +71,11 @@ describe('FilterBar search row', () => {
   });
 
   it('offers course category and education level filters', () => {
-    const html = renderToStaticMarkup(createElement(FilterBar, {
+    const html = renderToStaticMarkup(createElement(MemosProvider, null, createElement(FilterBar, {
       filter: { ...filter, category: '专业课', level: '本研贯通' },
       setFilter: vi.fn(),
       options,
-    } as Parameters<typeof FilterBar>[0]));
+    } as Parameters<typeof FilterBar>[0])));
 
     expect(filterBarSource).toContain('placeholder="课程范畴"');
     expect(filterBarSource).toContain('placeholder="学历层次"');

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,7 +1,9 @@
 import { Checkbox, Input } from 'antd';
+import { useState } from 'react';
 import type { FilterState } from '@/types';
 import type { CourseFilterOptions } from '@/constants/filterOptions';
 import SelectWithChevron from './SelectWithChevron';
+import MemoModal from './MemoModal';
 
 interface Props {
   filter: FilterState;
@@ -11,6 +13,7 @@ interface Props {
 
 export default function FilterBar({ filter, setFilter, options }: Props) {
   const update = (patch: Partial<FilterState>) => setFilter({ ...filter, ...patch });
+  const [memoOpen, setMemoOpen] = useState(false);
 
   return (
     <div className="panel-inner filter-bar no-print" data-tour="filters">
@@ -21,13 +24,23 @@ export default function FilterBar({ filter, setFilter, options }: Props) {
           onChange={(e) => update({ keyword: e.target.value })}
           allowClear
         />
-        <Checkbox
-          className="filter-bar__teacher-toggle"
-          checked={filter.includeTeacher}
-          onChange={(event) => update({ includeTeacher: event.target.checked })}
-        >
-          查询任课老师
-        </Checkbox>
+        <div className="filter-bar__search-aside">
+          <Checkbox
+            className="filter-bar__teacher-toggle"
+            checked={filter.includeTeacher}
+            onChange={(event) => update({ includeTeacher: event.target.checked })}
+          >
+            查询任课老师
+          </Checkbox>
+          <button
+            type="button"
+            className="filter-bar__memo-toggle"
+            onClick={() => setMemoOpen(true)}
+            aria-label="打开备忘录"
+          >
+            备忘录
+          </button>
+        </div>
       </div>
       <div className="filter-bar__controls">
         <SelectWithChevron
@@ -103,6 +116,7 @@ export default function FilterBar({ filter, setFilter, options }: Props) {
           options={options.languages.map((v) => ({ label: v, value: v }))}
         />
       </div>
+      <MemoModal open={memoOpen} onClose={() => setMemoOpen(false)} />
     </div>
   );
 }

--- a/src/components/MemoModal.test.ts
+++ b/src/components/MemoModal.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { act, createElement, type ReactNode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import MemoModal from './MemoModal';
+import { MemosProvider } from '@/memos/MemosContext';
+
+async function mount(node: ReactNode): Promise<void> {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const root = createRoot(host);
+  await act(async () => {
+    root.render(node);
+  });
+}
+
+function setTextareaValue(textarea: HTMLTextAreaElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    'value',
+  )?.set;
+  setter?.call(textarea, value);
+  textarea.dispatchEvent(new window.Event('input', { bubbles: true }));
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  localStorage.clear();
+});
+
+describe('MemoModal', () => {
+  it('renders title and empty state when open', async () => {
+    await mount(
+      createElement(MemosProvider, null, createElement(MemoModal, { open: true, onClose: () => {} })),
+    );
+    expect(document.querySelector('.bottom-modal')).toBeTruthy();
+    expect(document.body.textContent).toContain('备忘录');
+    expect(document.body.textContent).toContain('暂无备忘录');
+  });
+
+  it('renders nothing when closed', async () => {
+    await mount(
+      createElement(MemosProvider, null, createElement(MemoModal, { open: false, onClose: () => {} })),
+    );
+    expect(document.querySelector('.bottom-modal')).toBeNull();
+  });
+
+  it('adds a note via the compose area', async () => {
+    await mount(
+      createElement(MemosProvider, null, createElement(MemoModal, { open: true, onClose: () => {} })),
+    );
+    const textarea = document.querySelector<HTMLTextAreaElement>('.memo-modal__compose textarea');
+    expect(textarea).toBeTruthy();
+    await act(async () => {
+      setTextareaValue(textarea!, '选课提醒');
+    });
+
+    const addBtn = document.querySelector<HTMLButtonElement>('.memo-modal__compose button');
+    expect(addBtn).toBeTruthy();
+    expect(addBtn!.disabled).toBe(false);
+    await act(async () => {
+      addBtn!.click();
+    });
+
+    expect(document.body.textContent).toContain('选课提醒');
+    expect(document.body.textContent).not.toContain('暂无备忘录');
+  });
+});

--- a/src/components/MemoModal.tsx
+++ b/src/components/MemoModal.tsx
@@ -1,0 +1,97 @@
+import { Button } from 'antd';
+import { useState } from 'react';
+import BottomModal from './BottomModal';
+import { useMemos } from '@/memos/MemosContext';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function MemoModal({ open, onClose }: Props) {
+  const { notes, addNote, updateNote, removeNote } = useMemos();
+  const [draft, setDraft] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingText, setEditingText] = useState('');
+
+  const handleAdd = () => {
+    const text = draft.trim();
+    if (!text) return;
+    addNote(text);
+    setDraft('');
+  };
+
+  const startEdit = (id: string, text: string) => {
+    setEditingId(id);
+    setEditingText(text);
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditingText('');
+  };
+
+  const commitEdit = () => {
+    if (!editingId) return;
+    const text = editingText.trim();
+    if (text) {
+      updateNote(editingId, text);
+    } else {
+      removeNote(editingId);
+    }
+    cancelEdit();
+  };
+
+  return (
+    <BottomModal
+      open={open}
+      title="备忘录"
+      onClose={onClose}
+      width={560}
+      className="memo-modal"
+      footer={<Button type="primary" onClick={onClose}>关闭</Button>}
+    >
+      <div className="memo-modal__body">
+        <div className="memo-modal__compose">
+          <textarea
+            className="memo-modal__textarea"
+            placeholder="记录选课备注…"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={3}
+          />
+          <Button size="small" onClick={handleAdd} disabled={!draft.trim()}>添加</Button>
+        </div>
+        <ul className="memo-modal__list">
+          {notes.map((note) => (
+            <li key={note.id} className="memo-modal__item">
+              {editingId === note.id ? (
+                <div className="memo-modal__edit">
+                  <textarea
+                    className="memo-modal__textarea"
+                    value={editingText}
+                    onChange={(e) => setEditingText(e.target.value)}
+                    rows={2}
+                  />
+                  <div className="memo-modal__actions">
+                    <Button size="small" type="primary" onClick={commitEdit}>保存</Button>
+                    <Button size="small" onClick={cancelEdit}>取消</Button>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <p className="memo-modal__text">{note.text}</p>
+                  <div className="memo-modal__actions">
+                    <Button size="small" onClick={() => startEdit(note.id, note.text)}>编辑</Button>
+                    <Button size="small" danger onClick={() => removeNote(note.id)}>删除</Button>
+                  </div>
+                </>
+              )}
+            </li>
+          ))}
+          {notes.length === 0 ? <li className="memo-modal__empty">暂无备忘录</li> : null}
+        </ul>
+      </div>
+    </BottomModal>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -516,6 +516,95 @@ html {
   padding-inline-end: 0;
 }
 
+.filter-bar__search-aside {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 4px;
+}
+
+.filter-bar__memo-toggle {
+  color: var(--text-sub);
+  font-size: 12px;
+  line-height: 18px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.filter-bar__memo-toggle:hover {
+  color: var(--text);
+}
+
+/* ============================================================
+ * MemoModal
+ * ============================================================ */
+.memo-modal__body {
+  display: grid;
+  gap: 14px;
+}
+
+.memo-modal__compose {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: end;
+  gap: 8px;
+}
+
+.memo-modal__textarea {
+  width: 100%;
+  min-height: 56px;
+  resize: vertical;
+  padding: 8px;
+  border: 1px solid var(--accent-soft, #d9d9d9);
+  border-radius: var(--radius-md);
+  font: inherit;
+  background: var(--panel-bg, #fff);
+  color: var(--text, #000);
+}
+
+.memo-modal__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.memo-modal__item {
+  display: grid;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--accent-soft, #d9d9d9);
+  border-radius: var(--radius-md);
+}
+
+.memo-modal__text {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.memo-modal__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.memo-modal__edit {
+  display: grid;
+  gap: 8px;
+}
+
+.memo-modal__empty {
+  color: var(--text-sub);
+  font-size: 13px;
+  text-align: center;
+  padding: 12px 0;
+}
+
 /* ============================================================
  * CoursePool
  * ============================================================ */

--- a/src/memos/MemosContext.test.ts
+++ b/src/memos/MemosContext.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { act, createElement, type ReactNode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MemosProvider, useMemos, type MemosContextValue } from './MemosContext';
+
+let captured: MemosContextValue | null = null;
+function Consumer() {
+  captured = useMemos();
+  return null;
+}
+
+async function mount(node: ReactNode): Promise<void> {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const root = createRoot(host);
+  await act(async () => {
+    root.render(node);
+  });
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterEach(() => {
+  localStorage.clear();
+  captured = null;
+});
+
+describe('MemosContext', () => {
+  it('addNote / updateNote / removeNote mutate notes', async () => {
+    await mount(createElement(MemosProvider, null, createElement(Consumer)));
+    expect(captured!.notes).toEqual([]);
+
+    await act(async () => {
+      captured!.addNote('hello');
+    });
+    expect(captured!.notes).toHaveLength(1);
+    expect(captured!.notes[0].text).toBe('hello');
+    const id = captured!.notes[0].id;
+
+    await act(async () => {
+      captured!.updateNote(id, 'world');
+    });
+    expect(captured!.notes[0].text).toBe('world');
+
+    await act(async () => {
+      captured!.removeNote(id);
+    });
+    expect(captured!.notes).toHaveLength(0);
+  });
+
+  it('persists across remount via localStorage', async () => {
+    await mount(createElement(MemosProvider, null, createElement(Consumer)));
+    await act(async () => {
+      captured!.addNote('persisted');
+    });
+    captured = null;
+
+    await mount(createElement(MemosProvider, null, createElement(Consumer)));
+    expect(captured!.notes.some((n) => n.text === 'persisted')).toBe(true);
+  });
+});

--- a/src/memos/MemosContext.tsx
+++ b/src/memos/MemosContext.tsx
@@ -1,0 +1,83 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { MemoNote, MemosState } from '@/types';
+import { genId } from '@/utils/planSeed';
+import {
+  addNote,
+  loadMemos,
+  removeNote,
+  saveMemos,
+  updateNoteText,
+} from './memos';
+
+export interface MemosContextValue {
+  notes: MemoNote[];
+  addNote: (text: string) => void;
+  updateNote: (id: string, text: string) => void;
+  removeNote: (id: string) => void;
+}
+
+const MemosContext = createContext<MemosContextValue | null>(null);
+
+interface MemosProviderProps {
+  children: ReactNode;
+}
+
+export function MemosProvider({ children }: MemosProviderProps) {
+  const [state, setState] = useState<MemosState>(() => loadMemos());
+  const latestStateRef = useRef(state);
+  latestStateRef.current = state;
+
+  const addNoteCallback = useCallback((text: string) => {
+    const next = addNote(latestStateRef.current, {
+      id: genId(),
+      text,
+      updatedAt: Date.now(),
+    });
+    if (next === latestStateRef.current) return;
+    latestStateRef.current = next;
+    setState(next);
+    saveMemos(next);
+  }, []);
+
+  const updateNote = useCallback((id: string, text: string) => {
+    const next = updateNoteText(latestStateRef.current, id, text, Date.now());
+    if (next === latestStateRef.current) return;
+    latestStateRef.current = next;
+    setState(next);
+    saveMemos(next);
+  }, []);
+
+  const removeNoteCallback = useCallback((id: string) => {
+    const next = removeNote(latestStateRef.current, id);
+    if (next === latestStateRef.current) return;
+    latestStateRef.current = next;
+    setState(next);
+    saveMemos(next);
+  }, []);
+
+  const value = useMemo<MemosContextValue>(
+    () => ({
+      notes: state.notes,
+      addNote: addNoteCallback,
+      updateNote,
+      removeNote: removeNoteCallback,
+    }),
+    [addNoteCallback, removeNoteCallback, state.notes, updateNote],
+  );
+
+  return <MemosContext.Provider value={value}>{children}</MemosContext.Provider>;
+}
+
+export function useMemos(): MemosContextValue {
+  const context = useContext(MemosContext);
+  if (!context) throw new Error('useMemos must be used within MemosProvider');
+  return context;
+}

--- a/src/memos/memos.test.ts
+++ b/src/memos/memos.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EMPTY_MEMOS_STATE,
+  MEMOS_STORAGE_KEY,
+  addNote,
+  loadMemos,
+  removeNote,
+  saveMemos,
+  updateNoteText,
+  type StorageLike,
+} from './memos';
+import type { MemosState } from '@/types';
+
+class MemoryStorage implements StorageLike {
+  private readonly values = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+describe('memos persistence', () => {
+  it('uses a global versioned storage key and empty fallback', () => {
+    const storage = new MemoryStorage();
+    expect(MEMOS_STORAGE_KEY).toBe('class-arrange:v1:memos');
+    expect(loadMemos(storage)).toEqual(EMPTY_MEMOS_STATE);
+  });
+
+  it('round-trips notes via save/load', () => {
+    const storage = new MemoryStorage();
+    const state: MemosState = {
+      version: 1,
+      notes: [{ id: 'n1', text: '选课备注', updatedAt: 1000 }],
+    };
+    saveMemos(state, storage);
+    expect(loadMemos(storage)).toEqual(state);
+  });
+
+  it('drops malformed entries without throwing', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      MEMOS_STORAGE_KEY,
+      JSON.stringify({ version: 1, notes: [{ id: 'x' }, 'bad', { text: 'no id' }] }),
+    );
+    expect(loadMemos(storage)).toEqual({ version: 1, notes: [] });
+  });
+
+  it('returns empty state on wrong version / bad json', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(MEMOS_STORAGE_KEY, JSON.stringify({ version: 2, notes: [] }));
+    expect(loadMemos(storage)).toEqual(EMPTY_MEMOS_STATE);
+    storage.setItem(MEMOS_STORAGE_KEY, 'not json');
+    expect(loadMemos(storage)).toEqual(EMPTY_MEMOS_STATE);
+  });
+});
+
+describe('memos reducers', () => {
+  const base: MemosState = { version: 1, notes: [{ id: 'n1', text: 'a', updatedAt: 1 }] };
+
+  it('addNote prepends new notes and dedupes by id', () => {
+    const next = addNote(base, { id: 'n2', text: 'b', updatedAt: 2 });
+    expect(next.notes.map((n) => n.id)).toEqual(['n2', 'n1']);
+    expect(addNote(next, { id: 'n2', text: 'dup', updatedAt: 3 })).toBe(next);
+  });
+
+  it('addNote ignores empty id', () => {
+    expect(addNote(base, { id: '', text: 'x', updatedAt: 2 })).toBe(base);
+  });
+
+  it('updateNoteText updates text and updatedAt', () => {
+    const next = updateNoteText(base, 'n1', 'changed', 9);
+    expect(next.notes[0]).toEqual({ id: 'n1', text: 'changed', updatedAt: 9 });
+    expect(updateNoteText(base, 'missing', 'x', 9)).toBe(base);
+  });
+
+  it('removeNote removes by id', () => {
+    const next = removeNote(base, 'n1');
+    expect(next.notes).toEqual([]);
+    expect(removeNote(next, 'n1')).toBe(next);
+  });
+});

--- a/src/memos/memos.ts
+++ b/src/memos/memos.ts
@@ -1,0 +1,98 @@
+import type { MemoNote, MemosState } from '@/types';
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export const EMPTY_MEMOS_STATE: MemosState = { version: 1, notes: [] };
+
+export const MEMOS_STORAGE_KEY = 'class-arrange:v1:memos';
+
+function emptyMemosState(): MemosState {
+  return { version: 1, notes: [] };
+}
+
+function normalizeNotes(value: unknown): MemoNote[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const notes: MemoNote[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const record = item as Record<string, unknown>;
+    if (typeof record.id !== 'string' || typeof record.text !== 'string') continue;
+    const id = record.id.trim();
+    if (!id || seen.has(id)) continue;
+    const updatedAt =
+      typeof record.updatedAt === 'number' && Number.isFinite(record.updatedAt)
+        ? record.updatedAt
+        : 0;
+    seen.add(id);
+    notes.push({ id, text: record.text, updatedAt });
+  }
+  return notes;
+}
+
+function getStorage(storage?: StorageLike): StorageLike | null {
+  if (storage) return storage;
+  if (typeof localStorage === 'undefined') return null;
+  return localStorage;
+}
+
+export function loadMemos(storage?: StorageLike): MemosState {
+  try {
+    const serialized = getStorage(storage)?.getItem(MEMOS_STORAGE_KEY);
+    if (!serialized) return emptyMemosState();
+    const parsed: unknown = JSON.parse(serialized);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return emptyMemosState();
+    const stored = parsed as Record<string, unknown>;
+    if (stored.version !== 1) return emptyMemosState();
+    return { version: 1, notes: normalizeNotes(stored.notes) };
+  } catch {
+    return emptyMemosState();
+  }
+}
+
+export function saveMemos(state: MemosState, storage?: StorageLike): boolean {
+  try {
+    const target = getStorage(storage);
+    if (!target) return false;
+    target.setItem(
+      MEMOS_STORAGE_KEY,
+      JSON.stringify({ version: 1, notes: normalizeNotes(state.notes) } satisfies MemosState),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function addNote(state: MemosState, note: MemoNote): MemosState {
+  if (!note.id) return state;
+  if (state.notes.some((item) => item.id === note.id)) return state;
+  return { ...state, notes: [{ ...note }, ...state.notes] };
+}
+
+export function updateNoteText(
+  state: MemosState,
+  id: string,
+  text: string,
+  now: number,
+): MemosState {
+  const normalizedId = id.trim();
+  if (!normalizedId) return state;
+  let changed = false;
+  const notes = state.notes.map((item) => {
+    if (item.id !== normalizedId) return item;
+    changed = true;
+    return { ...item, text, updatedAt: now };
+  });
+  return changed ? { ...state, notes } : state;
+}
+
+export function removeNote(state: MemosState, id: string): MemosState {
+  const normalizedId = id.trim();
+  if (!normalizedId) return state;
+  if (!state.notes.some((item) => item.id === normalizedId)) return state;
+  return { ...state, notes: state.notes.filter((item) => item.id !== normalizedId) };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,6 +100,17 @@ export interface FavoritesState extends ArrangementFavoritePreferences {
   arrangementRecords: ArrangementFavoriteRecord[];
 }
 
+export interface MemoNote {
+  id: string;
+  text: string;
+  updatedAt: number;
+}
+
+export interface MemosState {
+  version: 1;
+  notes: MemoNote[];
+}
+
 /**
  * 选课单元：把「同课程号 + 时间完全一致」的多个班次合并成一个对象。
  * 学生排课时不纠结老师，同时间同课的不同班次视为同一选课对象。


### PR DESCRIPTION
## 功能

在搜索框右下角加「备忘录」入口按钮，点击弹出弹窗，支持全局自由文本备忘录的新增/编辑/删除（localStorage 持久化，不按学期划分）。复用 `BottomModal` 保持与现有弹窗样式一致。

## 实现（仿 favorites 模块分层）

| 文件 | 职责 |
|---|---|
| `src/memos/memos.ts` | 纯 reducer + localStorage 持久化（全局 key `class-arrange:v1:memos`，`StorageLike` 注入便于测试） |
| `src/memos/MemosContext.tsx` | `MemosProvider` + `useMemos` hook（复用 `genId`，变更即 `saveMemos`） |
| `src/components/MemoModal.tsx` | 弹窗（`BottomModal` + textarea 列表 + 新增/编辑/删除） |
| `src/components/FilterBar.tsx` | 入口按钮（搜索框右下角 `.filter-bar__search-aside` 内 Checkbox 下方） |
| `src/App.tsx` | `MemosProvider` 挂载（`FavoritesProvider` 外层，全局不按学期） |
| `src/index.css` | `.filter-bar__search-aside` / `.filter-bar__memo-toggle` / `.memo-modal*` 样式 |
| `src/types/index.ts` | `MemoNote` / `MemosState` 类型 |

## 测试

- `memos.test.ts`(8) + `MemosContext.test.ts`(2) + `MemoModal.test.ts`(3)：memo 相关 **13 个用例全过**
- `FilterBar.test.ts`：包 `MemosProvider` 适配（FilterBar 现内嵌 MemoModal）
- `pnpm tsc -b` / `pnpm lint` / `pnpm build` 通过

测试用项目惯例：`.test.ts` + `createElement`（无 JSX）+ `createRoot`/`act` + `IS_REACT_ACT_ENVIRONMENT`，参考 `BottomModalInteraction.test.ts`。

## 已知问题

`updateAwareness.test.ts` 有 1 个**预先存在失败**（已用 git stash 验证在 main `e587bbc` 上同样失败），是之前数据刷新改了 `APP_RELEASES` 但未更新测试断言所致，**与本 PR 无关**，建议单独修。

## 待手动验证

建议 `pnpm dev` 浏览器确认：
1. 搜索框右下角「备忘录」按钮，样式与「查询任课老师」一致
2. 点击弹出弹窗，样式与「最近更新」一致
3. 新增/编辑/删除笔记
4. 刷新页面笔记仍在（localStorage 持久化）
5. 弹窗焦点行为（Esc/遮罩关闭）

实现计划：`docs/superpowers/plans/2026-07-23-memo-feature.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)