### PR TITLE
feat: 备忘录识别课程号/课堂号并导入新课表

### DIFF
--- a/src/components/MemoModal.test.ts
+++ b/src/components/MemoModal.test.ts
@@ -1,9 +1,31 @@
 // @vitest-environment jsdom
 import { act, createElement, type ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import MemoModal from './MemoModal';
 import { MemosProvider } from '@/memos/MemosContext';
+
+vi.mock('@/store/plansContext', () => ({
+  usePlans: () => ({
+    state: { plans: [], activePlanId: null },
+    activePlan: null,
+    dispatch: vi.fn(),
+  }),
+}));
+vi.mock('@/data/SemesterCatalogContext', () => ({
+  useSemesterCatalog: () => ({
+    courseMap: new Map(),
+    groupsByCode: new Map(),
+    manifest: { schemaVersion: 1, defaultSemester: 'test', semesters: [] },
+    catalog: { schemaVersion: 1, generatedAt: '', source: {}, semester: {}, courses: [], detailsBySection: {}, revision: 'r' },
+    courses: [],
+    groups: [],
+    groupByKey: new Map(),
+    filterOptions: { departments: [], categories: [], levels: [], courseTypes: [], sectionTypes: [], examTypes: [], gradings: [], languages: [] },
+    status: { phase: 'ready', targetSemesterKey: null, error: null },
+    switchSemester: vi.fn(),
+  }),
+}));
 
 async function mount(node: ReactNode): Promise<void> {
   const host = document.createElement('div');

--- a/src/components/MemoModal.tsx
+++ b/src/components/MemoModal.tsx
@@ -1,6 +1,7 @@
 import { Button } from 'antd';
 import { useState } from 'react';
 import BottomModal from './BottomModal';
+import MemoRecognizeButton from './MemoRecognizeButton';
 import { useMemos } from '@/memos/MemosContext';
 
 interface Props {
@@ -82,6 +83,7 @@ export default function MemoModal({ open, onClose }: Props) {
                 <>
                   <p className="memo-modal__text">{note.text}</p>
                   <div className="memo-modal__actions">
+                    <MemoRecognizeButton noteText={note.text} />
                     <Button size="small" onClick={() => startEdit(note.id, note.text)}>编辑</Button>
                     <Button size="small" danger onClick={() => removeNote(note.id)}>删除</Button>
                   </div>

--- a/src/components/MemoRecognizeButton.tsx
+++ b/src/components/MemoRecognizeButton.tsx
@@ -1,0 +1,42 @@
+import { Button, message } from 'antd';
+import { useState } from 'react';
+import { useSemesterCatalog } from '@/data/SemesterCatalogContext';
+import { usePlans } from '@/store/plansContext';
+import { extractCourseRefs, type RecognizedRef } from '@/utils/courseRefs';
+import MemoRecognizeModal from './MemoRecognizeModal';
+
+interface Props {
+  noteText: string;
+}
+
+export default function MemoRecognizeButton({ noteText }: Props) {
+  const { dispatch } = usePlans();
+  const { courseMap, groupsByCode } = useSemesterCatalog();
+  const [open, setOpen] = useState(false);
+  const [refs, setRefs] = useState<RecognizedRef[]>([]);
+
+  const handleRecognize = () => {
+    setRefs(extractCourseRefs(noteText, { courseMap, groupsByCode }));
+    setOpen(true);
+  };
+
+  const handleImport = (sectionIds: string[]) => {
+    if (sectionIds.length === 0) return;
+    dispatch({ type: 'createPlan' });
+    dispatch({ type: 'addCourses', courseIds: sectionIds });
+    setOpen(false);
+    message.success(`已导入 ${sectionIds.length} 个课堂到新课表`);
+  };
+
+  return (
+    <>
+      <Button size="small" onClick={handleRecognize}>识别</Button>
+      <MemoRecognizeModal
+        open={open}
+        refs={refs}
+        onClose={() => setOpen(false)}
+        onImport={handleImport}
+      />
+    </>
+  );
+}

--- a/src/components/MemoRecognizeModal.test.ts
+++ b/src/components/MemoRecognizeModal.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { act, createElement, type ReactNode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import MemoRecognizeModal from './MemoRecognizeModal';
+import type { RecognizedRef } from '@/utils/courseRefs';
+
+async function mount(node: ReactNode): Promise<void> {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const root = createRoot(host);
+  await act(async () => {
+    root.render(node);
+  });
+}
+
+function findButton(textContains: string): HTMLButtonElement | undefined {
+  return Array.from(document.querySelectorAll<HTMLButtonElement>('button')).find((b) =>
+    b.textContent?.replace(/\s/g, '').includes(textContains.replace(/\s/g, '')),
+  );
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const refs: RecognizedRef[] = [
+  { type: 'course', courseCode: '001101', courseName: '计算概论', sectionIds: ['001101.01', '001101.02'] },
+  { type: 'section', sectionId: '001102.01', courseCode: '001102', courseName: '数据结构' },
+];
+
+describe('MemoRecognizeModal', () => {
+  it('渲染识别项并默认全选导入', async () => {
+    const onImport = vi.fn();
+    await mount(createElement(MemoRecognizeModal, { open: true, refs, onClose: () => {}, onImport }));
+    expect(document.body.textContent).toContain('计算概论');
+    expect(document.body.textContent).toContain('001102.01');
+    const importBtn = findButton('导入到新课表');
+    expect(importBtn?.disabled).toBe(false);
+    await act(async () => {
+      importBtn!.click();
+    });
+    expect(onImport).toHaveBeenCalledWith(['001101.01', '001101.02', '001102.01']);
+  });
+
+  it('无识别项时显示空状态', async () => {
+    await mount(createElement(MemoRecognizeModal, { open: true, refs: [], onClose: () => {}, onImport: () => {} }));
+    expect(document.body.textContent).toContain('未识别到');
+  });
+
+  it('关闭时不渲染', async () => {
+    await mount(createElement(MemoRecognizeModal, { open: false, refs, onClose: () => {}, onImport: () => {} }));
+    expect(document.querySelector('.bottom-modal')).toBeNull();
+  });
+
+  it('展开课程分组显示班次', async () => {
+    await mount(createElement(MemoRecognizeModal, { open: true, refs, onClose: () => {}, onImport: () => {} }));
+    const expandBtn = findButton('展开');
+    await act(async () => {
+      expandBtn!.click();
+    });
+    expect(document.body.textContent).toContain('001101.01');
+    expect(document.body.textContent).toContain('001101.02');
+  });
+});

--- a/src/components/MemoRecognizeModal.tsx
+++ b/src/components/MemoRecognizeModal.tsx
@@ -1,0 +1,122 @@
+import { Button, Checkbox } from 'antd';
+import { useEffect, useState } from 'react';
+import BottomModal from './BottomModal';
+import type { RecognizedCourseRef, RecognizedRef } from '@/utils/courseRefs';
+
+interface Props {
+  open: boolean;
+  refs: RecognizedRef[];
+  onClose: () => void;
+  onImport: (sectionIds: string[]) => void;
+}
+
+function allSectionIds(refs: readonly RecognizedRef[]): string[] {
+  return refs.flatMap((r) => (r.type === 'course' ? r.sectionIds : [r.sectionId]));
+}
+
+export default function MemoRecognizeModal({ open, refs, onClose, onImport }: Props) {
+  const [selected, setSelected] = useState<Set<string>>(() => new Set(allSectionIds(refs)));
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    setSelected(new Set(allSectionIds(refs)));
+    setExpanded(new Set());
+  }, [refs]);
+
+  const toggle = (id: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  const toggleCourse = (ref: RecognizedCourseRef) => {
+    const allSelected = ref.sectionIds.every((id) => selected.has(id));
+    setSelected((prev) => {
+      const next = new Set(prev);
+      ref.sectionIds.forEach((id) => (allSelected ? next.delete(id) : next.add(id)));
+      return next;
+    });
+  };
+
+  const toggleExpand = (code: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(code)) next.delete(code);
+      else next.add(code);
+      return next;
+    });
+
+  const handleImport = () => onImport([...selected]);
+
+  return (
+    <BottomModal
+      open={open}
+      title="识别到的课程"
+      onClose={onClose}
+      width={560}
+      className="memo-recognize-modal"
+      footer={
+        <>
+          <Button onClick={onClose}>取消</Button>
+          <Button type="primary" disabled={selected.size === 0} onClick={handleImport}>
+            导入到新课表
+          </Button>
+        </>
+      }
+    >
+      <div className="memo-recognize__body">
+        {refs.length === 0 ? (
+          <p className="memo-recognize__empty">未识别到当前学期的课程号或课堂号</p>
+        ) : (
+          <ul className="memo-recognize__list">
+            {refs.map((ref) =>
+              ref.type === 'course' ? (
+                <li key={ref.courseCode} className="memo-recognize__group">
+                  <div className="memo-recognize__group-head">
+                    <Checkbox
+                      checked={ref.sectionIds.every((id) => selected.has(id))}
+                      onChange={() => toggleCourse(ref)}
+                    >
+                      {ref.courseName}（{ref.courseCode}）
+                    </Checkbox>
+                    <button
+                      type="button"
+                      className="memo-recognize__expand"
+                      onClick={() => toggleExpand(ref.courseCode)}
+                    >
+                      {expanded.has(ref.courseCode)
+                        ? '收起'
+                        : `展开 ${ref.sectionIds.length} 个班次`}
+                    </button>
+                  </div>
+                  {expanded.has(ref.courseCode) ? (
+                    <ul className="memo-recognize__sections">
+                      {ref.sectionIds.map((id) => (
+                        <li key={id}>
+                          <Checkbox checked={selected.has(id)} onChange={() => toggle(id)}>
+                            {id}
+                          </Checkbox>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </li>
+              ) : (
+                <li key={ref.sectionId} className="memo-recognize__item">
+                  <Checkbox
+                    checked={selected.has(ref.sectionId)}
+                    onChange={() => toggle(ref.sectionId)}
+                  >
+                    {ref.courseName}（{ref.sectionId}）
+                  </Checkbox>
+                </li>
+              ),
+            )}
+          </ul>
+        )}
+      </div>
+    </BottomModal>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -612,6 +612,73 @@ html {
 }
 
 /* ============================================================
+ * MemoRecognize
+ * ============================================================ */
+.memo-recognize__body {
+  display: grid;
+  gap: 10px;
+}
+
+.memo-recognize__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.memo-recognize__group {
+  display: grid;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--accent-soft, #d9d9d9);
+  border-radius: var(--radius-md);
+}
+
+.memo-recognize__group-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.memo-recognize__expand {
+  color: var(--text-sub);
+  font-size: 12px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.memo-recognize__expand:hover {
+  color: var(--text);
+}
+
+.memo-recognize__sections {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 24px;
+  display: grid;
+  gap: 4px;
+}
+
+.memo-recognize__item {
+  padding: 6px 10px;
+  border: 1px solid var(--accent-soft, #d9d9d9);
+  border-radius: var(--radius-md);
+}
+
+.memo-recognize__empty {
+  color: var(--text-sub);
+  font-size: 13px;
+  text-align: center;
+  padding: 12px 0;
+  margin: 0;
+}
+
+/* ============================================================
  * CoursePool
  * ============================================================ */
 .course-pool {

--- a/src/utils/courseRefs.test.ts
+++ b/src/utils/courseRefs.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import type { CourseGroup, CourseSection } from '@/types';
+import { extractCourseRefs } from './courseRefs';
+
+function makeCourse(id: string, name: string): CourseSection {
+  return { id, courseName: name } as unknown as CourseSection;
+}
+function makeGroup(code: string, name: string, sectionIds: string[]): CourseGroup {
+  return { courseCode: code, courseName: name, sectionIds } as unknown as CourseGroup;
+}
+
+const ctx = {
+  courseMap: new Map<string, CourseSection>([
+    ['001101.01', makeCourse('001101.01', '计算概论')],
+    ['001101.02', makeCourse('001101.02', '计算概论')],
+    ['001661EX.01', makeCourse('001661EX.01', '英语')],
+  ]),
+  groupsByCode: new Map<string, CourseGroup[]>([
+    ['001101', [makeGroup('001101', '计算概论', ['001101.01', '001101.02'])]],
+    ['001661EX', [makeGroup('001661EX', '英语', ['001661EX.01'])]],
+  ]),
+};
+
+describe('extractCourseRefs', () => {
+  it('识别课堂号并过滤不存在的', () => {
+    const refs = extractCourseRefs('选 001101.01 和 999999.99', ctx);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({ type: 'section', sectionId: '001101.01', courseName: '计算概论' });
+  });
+
+  it('识别纯课程号并展开为分组', () => {
+    const refs = extractCourseRefs('要选 001101', ctx);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({ type: 'course', courseCode: '001101' });
+    expect((refs[0] as { sectionIds: string[] }).sectionIds).toEqual(['001101.01', '001101.02']);
+  });
+
+  it('课程号不误匹配课堂号前缀', () => {
+    // 001101.01 是课堂号，不应再把 001101 当纯课程号
+    const refs = extractCourseRefs('001101.01', ctx);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].type).toBe('section');
+  });
+
+  it('纯课程号覆盖其课堂号，避免重复', () => {
+    // 同时出现 001101（纯）和 001101.01（课堂号）：保留分组，不单独展示课堂号
+    const refs = extractCourseRefs('001101 和 001101.01', ctx);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].type).toBe('course');
+  });
+
+  it('兼容字母后缀课程号', () => {
+    const refs = extractCourseRefs('英语 001661EX.01', ctx);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({ sectionId: '001661EX.01' });
+  });
+
+  it('不误识别日期数字为课程号', () => {
+    const refs = extractCourseRefs('2026-08-30 开学', ctx);
+    expect(refs).toHaveLength(0);
+  });
+
+  it('无识别时返回空数组', () => {
+    expect(extractCourseRefs('没有课程号', ctx)).toEqual([]);
+  });
+});

--- a/src/utils/courseRefs.test.ts
+++ b/src/utils/courseRefs.test.ts
@@ -14,10 +14,16 @@ const ctx = {
     ['001101.01', makeCourse('001101.01', '计算概论')],
     ['001101.02', makeCourse('001101.02', '计算概论')],
     ['001661EX.01', makeCourse('001661EX.01', '英语')],
+    ['001661.01', makeCourse('001661.01', '前缀课')],
+    ['MARX1014.01', makeCourse('MARX1014.01', '马原')],
+    ['003154e.01', makeCourse('003154e.01', '小写课')],
   ]),
   groupsByCode: new Map<string, CourseGroup[]>([
     ['001101', [makeGroup('001101', '计算概论', ['001101.01', '001101.02'])]],
     ['001661EX', [makeGroup('001661EX', '英语', ['001661EX.01'])]],
+    ['001661', [makeGroup('001661', '前缀课', ['001661.01'])]],
+    ['MARX1014', [makeGroup('MARX1014', '马原', ['MARX1014.01'])]],
+    ['003154e', [makeGroup('003154e', '小写课', ['003154e.01'])]],
   ]),
 };
 
@@ -53,6 +59,25 @@ describe('extractCourseRefs', () => {
     const refs = extractCourseRefs('英语 001661EX.01', ctx);
     expect(refs).toHaveLength(1);
     expect(refs[0]).toMatchObject({ sectionId: '001661EX.01' });
+  });
+
+  it('识别字母开头的课程号', () => {
+    const refs = extractCourseRefs('选 MARX1014', ctx);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({ type: 'course', courseCode: 'MARX1014', courseName: '马原' });
+  });
+
+  it('识别小写后缀课堂号', () => {
+    const refs = extractCourseRefs('003154e.01', ctx);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({ type: 'section', sectionId: '003154e.01' });
+  });
+
+  it('前缀课程号不误识别（001661EX.01 不应回溯匹配 001661）', () => {
+    const refs = extractCourseRefs('001661EX.01', ctx);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({ sectionId: '001661EX.01' });
+    expect(refs.some((r) => r.type === 'course' && r.courseCode === '001661')).toBe(false);
   });
 
   it('不误识别日期数字为课程号', () => {

--- a/src/utils/courseRefs.ts
+++ b/src/utils/courseRefs.ts
@@ -23,10 +23,11 @@ export interface CourseRefContext {
   groupsByCode: ReadonlyMap<string, CourseGroup[]>;
 }
 
-/** 课堂号：6位数字+可选字母后缀+ . +2位数字，如 001101.01 / 001661EX.01 */
-const SECTION_ID_RE = /\b\d{6}[A-Z]*\.\d{2}\b/g;
-/** 纯课程号：6位数字+可选字母后缀，且后面不跟 ".数字"（排除课堂号前缀），如 001101 / 001661EX */
-const COURSE_CODE_RE = /\b\d{6}[A-Z]*(?!\.\d)/g;
+/** 课堂号：字母数字串（含至少一个数字）+ . +2位班次，如 001101.01 / 001661EX.01 / MARX1014.01 */
+const SECTION_ID_RE = /\b[A-Za-z0-9]*\d[A-Za-z0-9]*\.\d{2}\b/g;
+/** 纯课程号：字母数字串（含至少一个数字），且后面不跟 ".数字"（排除课堂号前缀）。
+ *  末尾 \b 阻止贪婪回溯误匹配前缀课程号（如 001661EX.01 不应回溯匹配 001661）。 */
+const COURSE_CODE_RE = /\b[A-Za-z0-9]*\d[A-Za-z0-9]*\b(?!\.\d)/g;
 
 export function extractCourseRefs(text: string, ctx: CourseRefContext): RecognizedRef[] {
   const { courseMap, groupsByCode } = ctx;

--- a/src/utils/courseRefs.ts
+++ b/src/utils/courseRefs.ts
@@ -1,0 +1,70 @@
+import type { CourseGroup, CourseSection } from '@/types';
+import { getCourseCode } from './courseGroup';
+import { idsForCourse } from './courseSelection';
+
+export interface RecognizedCourseRef {
+  type: 'course';
+  courseCode: string;
+  courseName: string;
+  sectionIds: string[];
+}
+
+export interface RecognizedSectionRef {
+  type: 'section';
+  sectionId: string;
+  courseCode: string;
+  courseName: string;
+}
+
+export type RecognizedRef = RecognizedCourseRef | RecognizedSectionRef;
+
+export interface CourseRefContext {
+  courseMap: ReadonlyMap<string, CourseSection>;
+  groupsByCode: ReadonlyMap<string, CourseGroup[]>;
+}
+
+/** 课堂号：6位数字+可选字母后缀+ . +2位数字，如 001101.01 / 001661EX.01 */
+const SECTION_ID_RE = /\b\d{6}[A-Z]*\.\d{2}\b/g;
+/** 纯课程号：6位数字+可选字母后缀，且后面不跟 ".数字"（排除课堂号前缀），如 001101 / 001661EX */
+const COURSE_CODE_RE = /\b\d{6}[A-Z]*(?!\.\d)/g;
+
+export function extractCourseRefs(text: string, ctx: CourseRefContext): RecognizedRef[] {
+  const { courseMap, groupsByCode } = ctx;
+
+  const sectionIds = new Set<string>();
+  for (const match of text.matchAll(SECTION_ID_RE)) {
+    const id = match[0];
+    if (courseMap.has(id)) sectionIds.add(id);
+  }
+
+  const plainCodes = new Set<string>();
+  for (const match of text.matchAll(COURSE_CODE_RE)) {
+    const code = match[0];
+    if (groupsByCode.has(code)) plainCodes.add(code);
+  }
+
+  // 纯课程号 -> 分组（含全部班次）；其 courseCode 下的单独课堂号不再重复展示
+  const courseRefs: RecognizedCourseRef[] = [...plainCodes].map((code) => {
+    const groups = groupsByCode.get(code)!;
+    return {
+      type: 'course',
+      courseCode: code,
+      courseName: groups[0]?.courseName ?? code,
+      sectionIds: idsForCourse(code, groupsByCode),
+    };
+  });
+
+  const sectionRefs: RecognizedSectionRef[] = [...sectionIds]
+    .filter((id) => !plainCodes.has(getCourseCode(id)))
+    .map((id) => {
+      const course = courseMap.get(id)!;
+      return {
+        type: 'section',
+        sectionId: id,
+        courseCode: getCourseCode(id),
+        courseName: course.courseName,
+      };
+    });
+
+  return [...courseRefs, ...sectionRefs];
+}


### PR DESCRIPTION
## 功能

在每条备忘录旁加「识别」按钮，点击后识别 note 文本里出现的课程号/课堂号，弹出复选框（课程号可折叠分组默认全选、课堂号单独项），用户勾选确认后自动创建新课表（默认方案名）并导入选中课堂。

## 实现

| 文件 | 职责 |
|---|---|
| `src/utils/courseRefs.ts` | `extractCourseRefs` 纯函数：正则识别 + 用 courseMap/groupsByCode 过滤存在的 |
| `src/components/MemoRecognizeModal.tsx` | 识别结果弹窗（BottomModal + Checkbox 列表，课程号可折叠分组默认全选） |
| `src/components/MemoRecognizeButton.tsx` | 识别按钮（调 usePlans/useSemesterCatalog，确认时 dispatch createPlan + addCourses） |
| `src/components/MemoModal.tsx` | note 旁渲染 MemoRecognizeButton |
| `src/index.css` | `.memo-recognize*` 样式 |

复用现有 `createPlan` + `addCourses` action，不改 reducer/types。

## 识别正则

实际数据课程号格式多样（纯数字 `001101`、数字+字母 `001661EX`/`003154e`、字母开头 `MARX1014`）。正则 `\b[A-Za-z0-9]*\d[A-Za-z0-9]*`（字母数字含至少一数字）覆盖所有格式；末尾 `\b` 阻止贪婪回溯误匹配前缀课程号（`001661EX.01` 不回溯匹配 `001661`，实际数据有 15 个前缀对）；用 courseMap/groupsByCode 过滤不存在的候选。

## 测试

- `courseRefs.test.ts`（10）：正则识别 + 过滤 + 前缀对不误识别
- `MemoRecognizeModal.test.ts`（4）：渲染/默认全选导入/空状态/展开分组
- `MemoModal.test.ts`（3）：vi.mock usePlans/useSemesterCatalog，现有用例保持
- `pnpm tsc -b` / `pnpm lint` / `pnpm build` 通过；`pnpm test` 356/356 全过无回归

## 待手动验证

`pnpm dev` 确认：识别按钮、弹窗、课程分组展开/收起 + 全选/取消、导入到新课表（默认名）、空状态提示。

## 备注

按 MAINTENANCE.md 第五节，合并后需追加 `APP_RELEASES` 版本日志（新用户可感知功能）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)