### PR TITLE
feat: 备忘录识别兼容噪音编号 + 追加版本日志

### DIFF
--- a/src/updates/appUpdates.ts
+++ b/src/updates/appUpdates.ts
@@ -93,6 +93,15 @@ export const APP_RELEASES: AppRelease[] = [
       '新增备忘录功能，内容仅保存在当前浏览器。',
     ],
   },
+  {
+    version: '2026.07.24.2',
+    publishedAt: '2026-07-24',
+    title: '备忘录识别导入',
+    items: [
+      '备忘录新增识别按钮，自动识别文本中的课程号与课堂号，可勾选后导入到新课表。',
+      '识别兼容被文字包围的编号，以及字母开头、小写后缀等多种课程号格式。',
+    ],
+  },
 ];
 
 export const CURRENT_APP_VERSION = APP_RELEASES.at(-1)?.version ?? '0';

--- a/src/updates/updateAwareness.test.ts
+++ b/src/updates/updateAwareness.test.ts
@@ -77,17 +77,17 @@ function impact(kind: CourseImpactEvent['kind']): CourseImpactEvent {
 }
 
 describe('update awareness rules', () => {
-  test('publishes the July 24 shared-plan and memo update', () => {
+  test('publishes the July 24 memo recognize update', () => {
     expect(APP_RELEASES.at(-1)).toEqual({
-      version: '2026.07.24.1',
+      version: '2026.07.24.2',
       publishedAt: '2026-07-24',
-      title: '方案分享与备忘录',
+      title: '备忘录识别导入',
       items: [
-        '新增选课方案分享功能。',
-        '新增备忘录功能，内容仅保存在当前浏览器。',
+        '备忘录新增识别按钮，自动识别文本中的课程号与课堂号，可勾选后导入到新课表。',
+        '识别兼容被文字包围的编号，以及字母开头、小写后缀等多种课程号格式。',
       ],
     });
-    expect(CURRENT_APP_VERSION).toBe('2026.07.24.1');
+    expect(CURRENT_APP_VERSION).toBe('2026.07.24.2');
   });
 
   test('does not treat the catalog provider persisted semester as prior use', () => {

--- a/src/utils/courseRefs.test.ts
+++ b/src/utils/courseRefs.test.ts
@@ -17,6 +17,7 @@ const ctx = {
     ['001661.01', makeCourse('001661.01', '前缀课')],
     ['MARX1014.01', makeCourse('MARX1014.01', '马原')],
     ['003154e.01', makeCourse('003154e.01', '小写课')],
+    ['001108.01', makeCourse('001108.01', '线代')],
   ]),
   groupsByCode: new Map<string, CourseGroup[]>([
     ['001101', [makeGroup('001101', '计算概论', ['001101.01', '001101.02'])]],
@@ -24,6 +25,7 @@ const ctx = {
     ['001661', [makeGroup('001661', '前缀课', ['001661.01'])]],
     ['MARX1014', [makeGroup('MARX1014', '马原', ['MARX1014.01'])]],
     ['003154e', [makeGroup('003154e', '小写课', ['003154e.01'])]],
+    ['001108', [makeGroup('001108', '线代', ['001108.01'])]],
   ]),
 };
 
@@ -78,6 +80,15 @@ describe('extractCourseRefs', () => {
     expect(refs).toHaveLength(1);
     expect(refs[0]).toMatchObject({ sectionId: '001661EX.01' });
     expect(refs.some((r) => r.type === 'course' && r.courseCode === '001661')).toBe(false);
+  });
+
+  it('识别被噪音文字包围的编号', () => {
+    const refs = extractCourseRefs('001101.01wfw..001108aodfd', ctx);
+    expect(refs).toHaveLength(2);
+    const course = refs.find((r) => r.type === 'course');
+    const section = refs.find((r) => r.type === 'section');
+    expect(course).toMatchObject({ courseCode: '001108', courseName: '线代' });
+    expect(section).toMatchObject({ sectionId: '001101.01' });
   });
 
   it('不误识别日期数字为课程号', () => {

--- a/src/utils/courseRefs.ts
+++ b/src/utils/courseRefs.ts
@@ -23,28 +23,64 @@ export interface CourseRefContext {
   groupsByCode: ReadonlyMap<string, CourseGroup[]>;
 }
 
-/** 课堂号：字母数字串（含至少一个数字）+ . +2位班次，如 001101.01 / 001661EX.01 / MARX1014.01 */
-const SECTION_ID_RE = /\b[A-Za-z0-9]*\d[A-Za-z0-9]*\.\d{2}\b/g;
-/** 纯课程号：字母数字串（含至少一个数字），且后面不跟 ".数字"（排除课堂号前缀）。
- *  末尾 \b 阻止贪婪回溯误匹配前缀课程号（如 001661EX.01 不应回溯匹配 001661）。 */
-const COURSE_CODE_RE = /\b[A-Za-z0-9]*\d[A-Za-z0-9]*\b(?!\.\d)/g;
+/** 在 text 中查找 key 的所有出现位置（起始索引）。 */
+function findAllIndices(text: string, key: string): number[] {
+  const indices: number[] = [];
+  if (!key) return indices;
+  let from = 0;
+  let idx = text.indexOf(key, from);
+  while (idx !== -1) {
+    indices.push(idx);
+    from = idx + 1;
+    idx = text.indexOf(key, from);
+  }
+  return indices;
+}
 
+/** 判断 [start, end) 是否被任一区间完全包含。 */
+function isContained(
+  start: number,
+  end: number,
+  ranges: readonly (readonly [number, number])[],
+): boolean {
+  return ranges.some(([s, e]) => start >= s && end <= e);
+}
+
+/**
+ * 从文本识别当前学期存在的课程号与课堂号。
+ *
+ * 不依赖正则边界，而是遍历 courseMap / groupsByCode 的 key 在文本中查找子串，
+ * 这样能识别被噪音文字包围的编号（如 "001101.01wfw..001108aodfd"）。
+ * 用位置重叠排除"课程号仅作为课堂号前缀/子串出现"的误识别
+ * （如文本 "001101.01" 里的 "001101" 不应再当纯课程号）。
+ */
 export function extractCourseRefs(text: string, ctx: CourseRefContext): RecognizedRef[] {
   const { courseMap, groupsByCode } = ctx;
 
+  // 课堂号：遍历 courseMap 的 key，记录在文本中出现的位置区间。
+  const sectionRanges: Array<readonly [number, number]> = [];
   const sectionIds = new Set<string>();
-  for (const match of text.matchAll(SECTION_ID_RE)) {
-    const id = match[0];
-    if (courseMap.has(id)) sectionIds.add(id);
+  for (const id of courseMap.keys()) {
+    const indices = findAllIndices(text, id);
+    if (indices.length === 0) continue;
+    sectionIds.add(id);
+    for (const start of indices) {
+      sectionRanges.push([start, start + id.length] as const);
+    }
   }
 
+  // 课程号：遍历 groupsByCode 的 key，只要有任一出现位置不被课堂号区间包含，即识别。
   const plainCodes = new Set<string>();
-  for (const match of text.matchAll(COURSE_CODE_RE)) {
-    const code = match[0];
-    if (groupsByCode.has(code)) plainCodes.add(code);
+  for (const code of groupsByCode.keys()) {
+    const indices = findAllIndices(text, code);
+    if (indices.length === 0) continue;
+    const hasIndependent = indices.some(
+      (start) => !isContained(start, start + code.length, sectionRanges),
+    );
+    if (hasIndependent) plainCodes.add(code);
   }
 
-  // 纯课程号 -> 分组（含全部班次）；其 courseCode 下的单独课堂号不再重复展示
+  // 纯课程号 -> 分组（含全部班次）；其 courseCode 下的单独课堂号不再重复展示。
   const courseRefs: RecognizedCourseRef[] = [...plainCodes].map((code) => {
     const groups = groupsByCode.get(code)!;
     return {


### PR DESCRIPTION
## 改动

两件事：

### 1. 加强识别功能（处理噪音包围编号）

原正则方案无法识别被文字包围的编号，如 `001101.01wfw..001108aodfd`：
- `001101.01` 后贴 `wfw`：正则尾部 `\b` 在 `01`/`w` 间无边界，漏识别
- `001108` 后贴 `aodfd`：正则贪婪整体匹配 `001108aodfd`，过滤，漏识别前缀 `001108`

改为**遍历 courseMap/groupsByCode 的 key + indexOf + 位置重叠排除**：
- 遍历 key 找子串出现，识别被噪音包围的编号
- 用位置重叠排除"课程号仅作为课堂号前缀/子串出现"的误识别（如 `001101.01` 里的 `001101` 不当纯课程号）
- 兼容前缀课程号对（`001661`/`001661EX`）、字母开头（`MARX1014`）、小写后缀（`003154e`）

新增测试用例 `识别被噪音文字包围的编号`，现有 10 用例保持通过。

### 2. 追加 APP_RELEASES 版本日志

按 MAINTENANCE.md 第五节，备忘录识别功能（PR #36 合并时漏加）现在补登：
- 追加 `2026.07.24.2`（备忘录识别导入）
- 同步 `updateAwareness.test.ts` 的 `APP_RELEASES.at(-1)` 断言

## 验证

- `pnpm tsc -b` / `pnpm lint` 通过
- `pnpm test` 388/388 全过无回归
- `pnpm build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)