### PR TITLE
feat: 强冲突时段标注

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -371,6 +371,8 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
   const appliedGroups = appliedArrangement?.groups ?? EMPTY_GROUPS;
   const committedBlockedSlots = calculation.committed?.settings.blockedSlots
     ?? EMPTY_BLOCKED_SLOTS;
+  const committedHardConflictSlots = calculation.committed?.settings.hardConflictSlots
+    ?? EMPTY_BLOCKED_SLOTS;
 
   const { conflictGroupKeys } = useConflicts(appliedGroups, committedBlockedSlots);
 
@@ -902,6 +904,7 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
             onExport={handleExport}
             exporting={exporting}
             blockedSlots={committedBlockedSlots}
+            hardConflictSlots={committedHardConflictSlots}
             onOpenCustomization={() => {
               setCustomizationInitialPage('main');
               setCustomizationOpen(true);

--- a/src/components/ArrangementPanel.test.ts
+++ b/src/components/ArrangementPanel.test.ts
@@ -174,4 +174,9 @@ describe('ArrangementPanel viewport height', () => {
 
     expect(resultPanelRule).not.toContain('border-top');
   });
+
+  it('shows hard conflict count on arrangement cards when present', () => {
+    expect(source).toContain('hardConflictCount');
+    expect(source).toContain('强冲突');
+  });
 });

--- a/src/components/ArrangementPanel.test.ts
+++ b/src/components/ArrangementPanel.test.ts
@@ -16,10 +16,10 @@ function ruleBody(selector: string): string {
 describe('ArrangementPanel viewport height', () => {
   const arrangements: Arrangement[] = [
     {
-      id: 'first', groups: [], conflictCount: 0, courseCount: 3, totalCredits: 6, totalHours: 96,
+      id: 'first', groups: [], conflictCount: 0, courseCount: 3, totalCredits: 6, totalHours: 96, hardConflictCount: 0,
     },
     {
-      id: 'second', groups: [], conflictCount: 1, courseCount: 3, totalCredits: 6, totalHours: 96,
+      id: 'second', groups: [], conflictCount: 1, courseCount: 3, totalCredits: 6, totalHours: 96, hardConflictCount: 0,
     },
   ];
   const baseProps = {

--- a/src/components/ArrangementPanel.tsx
+++ b/src/components/ArrangementPanel.tsx
@@ -72,6 +72,11 @@ export default function ArrangementPanel({
                     >
                       {conflictFree ? '无冲突' : `${a.conflictCount} 冲突`}
                     </Tag>
+                    {a.hardConflictCount > 0 ? (
+                      <Tag color="red" className="arrangement-card__hard-conflict">
+                        {a.hardConflictCount} 强冲突
+                      </Tag>
+                    ) : null}
                   </div>
                 </button>
                 <FavoriteButton

--- a/src/components/CourseTable.tsx
+++ b/src/components/CourseTable.tsx
@@ -52,6 +52,7 @@ interface Props {
   onExport: () => void | Promise<void>;
   exporting?: boolean;
   blockedSlots: string[];
+  hardConflictSlots: string[];
   onOpenCustomization: () => void;
   calendar: TermCalendar;
   catalogGeneratedAt: string;
@@ -68,6 +69,7 @@ interface TimetableViewProps {
   themeMode: 'light' | 'dark';
   onOpenDetail?: (id: string) => void;
   blockedSlots: string[];
+  hardConflictSlots: string[];
   calendar: TermCalendar;
 }
 
@@ -170,6 +172,13 @@ const BLOCKED_COLOR: CourseColor = {
   stripe: 'var(--timetable-placeholder-stripe)',
   bg: 'var(--timetable-placeholder-bg)',
   fg: 'var(--timetable-placeholder-fg)',
+};
+
+const HARD_COLOR: CourseColor = {
+  name: 'hard',
+  stripe: 'var(--timetable-hardconflict-stripe)',
+  bg: 'var(--timetable-hardconflict-bg)',
+  fg: 'var(--timetable-hardconflict-fg)',
 };
 
 function buildEntries(
@@ -280,19 +289,22 @@ function getRowSpanEntries(
   starting: TimetableEntry[],
   covers: Map<string, TimetableEntry[]>,
   blockedSlots: Set<string>,
-): { entries: TimetableEntry[]; span: number; blockedPeriods: number[] } | null {
+  hardConflictSlots: Set<string>,
+): { entries: TimetableEntry[]; span: number; blockedPeriods: number[]; hardPeriods: number[] } | null {
   if (covering.length === 0 || starting.length === 0) return null;
   if (covering.some((entry) => entry.start < period)) return null;
 
   const day = starting[0].displayDay;
   const cluster = new Map(starting.map((entry) => [entry.id, entry]));
   const blockedPeriods: number[] = [];
+  const hardPeriods: number[] = [];
   let clusterEnd = Math.max(...starting.map((entry) => entry.end));
 
   // Build the complete overlapping cluster, including courses that start later
   // inside another course's span. Each entry keeps its own vertical time range.
   for (let p = period; p <= clusterEnd; p += 1) {
     if (blockedSlots.has(blockedSlotKey(day, p))) blockedPeriods.push(p);
+    if (hardConflictSlots.has(blockedSlotKey(day, p))) hardPeriods.push(p);
     for (const entry of covers.get(keyFor(day, p)) ?? []) {
       if (entry.start < period) return null;
       cluster.set(entry.id, entry);
@@ -303,7 +315,7 @@ function getRowSpanEntries(
   const entries = [...cluster.values()].sort(
     (a, b) => a.start - b.start || b.end - a.end || a.id.localeCompare(b.id),
   );
-  return { entries, span: clusterEnd - period + 1, blockedPeriods };
+  return { entries, span: clusterEnd - period + 1, blockedPeriods, hardPeriods };
 }
 
 function colorStyle(color: CourseColor): CSSProperties {
@@ -319,6 +331,8 @@ function TimetableCell({
   entries,
   blocked,
   blockedPeriods = [],
+  hard,
+  hardPeriods = [],
   rowSpan,
   startPeriod,
   onOpenDetail,
@@ -327,6 +341,9 @@ function TimetableCell({
   entries: TimetableEntry[];
   blocked: boolean;
   blockedPeriods?: number[];
+  hard: boolean;
+  hardConflictSlots: Set<string>;
+  hardPeriods?: number[];
   rowSpan?: number;
   startPeriod?: number;
   onOpenDetail?: (id: string) => void;
@@ -342,9 +359,19 @@ function TimetableCell({
       color: BLOCKED_COLOR,
     }))
     : [];
+  const hardEntries: BlockedTimetableEntry[] = rowSpan && startPeriod
+    ? hardPeriods.map((period) => ({
+      id: `hard-${day}-${period}`,
+      start: period,
+      end: period,
+      span: 1,
+      color: HARD_COLOR,
+    }))
+    : [];
   const layoutEntries: Array<TimetableEntry | BlockedTimetableEntry> = [
     ...entries,
     ...blockedEntries,
+    ...hardEntries,
   ];
   const visualItemCount = layoutEntries.length + (blocked && blockedEntries.length === 0 ? 1 : 0);
   const isParallel = Boolean(rowSpan && startPeriod && layoutEntries.length > 1);
@@ -432,13 +459,19 @@ function TimetableCell({
   const renderBlockedButton = (
     entry: BlockedTimetableEntry,
     mobileGroup?: (typeof mobileGroups)[number],
+    variant: 'blocked' | 'hard' = 'blocked',
   ) => {
     const lane = laneLayout?.laneById.get(entry.id);
+    const isHard = variant === 'hard';
     return (
       <div
         key={entry.id}
-        className="timetable-course timetable-placeholder"
-        aria-label="自定义占位时间"
+        className={[
+          'timetable-course',
+          'timetable-placeholder',
+          isHard ? 'timetable-placeholder--hard' : '',
+        ].filter(Boolean).join(' ')}
+        aria-label={isHard ? '强冲突时段' : '自定义占位时间'}
         style={{
           ...colorStyle(entry.color),
           ...(!mobileGroup && lane !== undefined && startPeriod ? {
@@ -447,7 +480,7 @@ function TimetableCell({
           } : {}),
         }}
       >
-        <span>有事</span>
+        <span>{isHard ? '强冲突' : '有事'}</span>
       </div>
     );
   };
@@ -473,8 +506,17 @@ function TimetableCell({
             <span>有事</span>
           </div>
         ) : null}
+        {hard && hardEntries.length === 0 ? (
+          <div
+            className="timetable-course timetable-placeholder timetable-placeholder--hard"
+            aria-label="强冲突时段"
+          >
+            <span>强冲突</span>
+          </div>
+        ) : null}
         {entries.map((entry) => renderCourseButton(entry))}
         {blockedEntries.map((entry) => renderBlockedButton(entry))}
+        {hardEntries.map((entry) => renderBlockedButton(entry, undefined, 'hard'))}
       </div>
       {hasMobileContainment ? (
         <>
@@ -511,7 +553,11 @@ function TimetableCell({
                     {groupEntries.map((entry) => (
                       'groupKey' in entry
                         ? renderCourseButton(entry, group)
-                        : renderBlockedButton(entry, group)
+                        : renderBlockedButton(
+                            entry,
+                            group,
+                            entry.id.startsWith('hard-') ? 'hard' : 'blocked',
+                          )
                     ))}
                   </div>
                 </div>
@@ -554,10 +600,12 @@ function TimetableView({
   themeMode,
   onOpenDetail,
   blockedSlots,
+  hardConflictSlots,
   calendar,
 }: TimetableViewProps) {
   const colorTheme = exportMode ? 'light' : themeMode;
   const blockedSlotSet = useMemo(() => new Set(blockedSlots), [blockedSlots]);
+  const hardConflictSlotSet = useMemo(() => new Set(hardConflictSlots), [hardConflictSlots]);
   const entries = useMemo(
     () => buildEntries(groups, weekSelection, colorTheme, blockedSlotSet, calendar),
     [blockedSlotSet, calendar, groups, weekSelection, colorTheme],
@@ -620,8 +668,10 @@ function TimetableView({
                   starting,
                   covers,
                   blockedSlotSet,
+                  hardConflictSlotSet,
                 );
                 const blocked = blockedSlotSet.has(cellKey);
+                const hard = hardConflictSlotSet.has(cellKey);
 
                 if (rowSpanBlock) {
                   for (let p = period + 1; p < period + rowSpanBlock.span; p += 1) {
@@ -633,7 +683,10 @@ function TimetableView({
                       day={day}
                       entries={rowSpanBlock.entries}
                       blocked={false}
+                      hard={false}
+                      hardConflictSlots={hardConflictSlotSet}
                       blockedPeriods={rowSpanBlock.blockedPeriods}
+                      hardPeriods={rowSpanBlock.hardPeriods}
                       rowSpan={rowSpanBlock.span}
                       startPeriod={period}
                       onOpenDetail={onOpenDetail}
@@ -647,6 +700,8 @@ function TimetableView({
                     day={day}
                     entries={starting}
                     blocked={blocked}
+                    hard={hard}
+                    hardConflictSlots={hardConflictSlotSet}
                     onOpenDetail={onOpenDetail}
                   />
                 );
@@ -670,6 +725,7 @@ export default function CourseTable({
   onExport,
   exporting = false,
   blockedSlots,
+  hardConflictSlots,
   onOpenCustomization,
   calendar,
   catalogGeneratedAt,
@@ -785,6 +841,7 @@ export default function CourseTable({
           groups={groups}
           themeMode={themeMode}
           blockedSlots={blockedSlots}
+          hardConflictSlots={hardConflictSlots}
           calendar={calendar}
           onOpenDetail={onOpenDetail}
         />
@@ -828,6 +885,7 @@ export default function CourseTable({
           exportMode
           themeMode="light"
           blockedSlots={blockedSlots}
+          hardConflictSlots={hardConflictSlots}
           calendar={calendar}
         />
       </div>

--- a/src/components/CourseTable.tsx
+++ b/src/components/CourseTable.tsx
@@ -373,7 +373,9 @@ function TimetableCell({
     ...blockedEntries,
     ...hardEntries,
   ];
-  const visualItemCount = layoutEntries.length + (blocked && blockedEntries.length === 0 ? 1 : 0);
+  const visualItemCount = layoutEntries.length
+    + (blocked && blockedEntries.length === 0 ? 1 : 0)
+    + (hard && hardEntries.length === 0 ? 1 : 0);
   const isParallel = Boolean(rowSpan && startPeriod && layoutEntries.length > 1);
   const laneLayout = isParallel ? assignTimetableLanes(layoutEntries) : null;
   const parallelSizing = laneLayout ? getParallelLaneSizing(laneLayout.laneCount) : null;

--- a/src/components/CourseTablePrecision.test.ts
+++ b/src/components/CourseTablePrecision.test.ts
@@ -112,4 +112,11 @@ describe('CourseTable precise conflict marking', () => {
     expect(source).toContain('links.offsetTop > update.offsetTop');
     expect(source).toContain("footerWrapped ? ' course-table__project-footer--wrapped' : ''");
   });
+
+  it('renders hard conflict slots with a distinct color', () => {
+    const source = readFileSync(new URL('./CourseTable.tsx', import.meta.url), 'utf8');
+    expect(source).toContain('hardConflictSlots');
+    expect(source).toContain('HARD_COLOR');
+    expect(source).toContain('timetable-placeholder--hard');
+  });
 });

--- a/src/components/CustomizationModal.test.ts
+++ b/src/components/CustomizationModal.test.ts
@@ -77,3 +77,18 @@ describe('CustomizationModal grouped settings navigation', () => {
     expect(onboarding).not.toContain('这可能会导致方案被错误排序');
   });
 });
+
+describe('CustomizationModal hard conflict three-state grid', () => {
+  it('renders a three-state availability grid cycling empty -> blocked -> hard', () => {
+    expect(source).toContain('draftHardConflictSlots');
+    expect(source).toContain('hardConflictSlotSet');
+    expect(source).toContain('availability-grid__cell--${state}');
+    expect(styles).toContain('availability-grid__cell--hard');
+    expect(source).toMatch(/空闲.*有事.*强冲突|强冲突.*有事.*空闲/);
+  });
+
+  it('applies hard conflict slots back to settings and keeps them exclusive with blocked', () => {
+    expect(source).toContain('hardConflictSlots: draftHardConflictSlots');
+    expect(source).toContain('清空占位');
+  });
+});

--- a/src/components/CustomizationModal.tsx
+++ b/src/components/CustomizationModal.tsx
@@ -167,42 +167,32 @@ export default function CustomizationModal({
 
   const toggleSlot = (day: number, period: number) => {
     const key = blockedSlotKey(day, period);
-    setDraftBlockedSlots((currentBlocked) => {
-      const nextBlocked = new Set(currentBlocked);
-      setDraftHardConflictSlots((currentHard) => {
-        const nextHard = new Set(currentHard);
-        if (nextBlocked.has(key)) {
-          nextBlocked.delete(key);
-          nextHard.add(key);
-        } else if (nextHard.has(key)) {
-          nextHard.delete(key);
-        } else {
-          nextBlocked.add(key);
-        }
-        return [...nextHard].sort();
-      });
-      return [...nextBlocked].sort();
+    const current = hardConflictSlotSet.has(key) ? 'hard'
+      : blockedSlotSet.has(key) ? 'blocked' : 'empty';
+    const target = current === 'empty' ? 'blocked'
+      : current === 'blocked' ? 'hard' : 'empty';
+    setDraftBlockedSlots((cur) => {
+      const next = new Set(cur);
+      if (target === 'blocked') next.add(key); else next.delete(key);
+      return [...next].sort();
+    });
+    setDraftHardConflictSlots((cur) => {
+      const next = new Set(cur);
+      if (target === 'hard') next.add(key); else next.delete(key);
+      return [...next].sort();
     });
   };
 
   const paintSlot = (key: string, targetState: 'blocked' | 'hard' | 'empty') => {
-    setDraftBlockedSlots((currentBlocked) => {
-      const nextBlocked = new Set(currentBlocked);
-      setDraftHardConflictSlots((currentHard) => {
-        const nextHard = new Set(currentHard);
-        if (targetState === 'blocked') {
-          nextBlocked.add(key);
-          nextHard.delete(key);
-        } else if (targetState === 'hard') {
-          nextHard.add(key);
-          nextBlocked.delete(key);
-        } else {
-          nextBlocked.delete(key);
-          nextHard.delete(key);
-        }
-        return [...nextHard].sort();
-      });
-      return [...nextBlocked].sort();
+    setDraftBlockedSlots((cur) => {
+      const next = new Set(cur);
+      if (targetState === 'blocked') next.add(key); else next.delete(key);
+      return [...next].sort();
+    });
+    setDraftHardConflictSlots((cur) => {
+      const next = new Set(cur);
+      if (targetState === 'hard') next.add(key); else next.delete(key);
+      return [...next].sort();
     });
   };
 

--- a/src/components/CustomizationModal.tsx
+++ b/src/components/CustomizationModal.tsx
@@ -92,15 +92,22 @@ export default function CustomizationModal({
   const [page, setPage] = useState<CustomizationPage>(initialPage);
   const [draftBlockedSlots, setDraftBlockedSlots] = useState(settings.blockedSlots);
   const blockedSlotSet = useMemo(() => new Set(draftBlockedSlots), [draftBlockedSlots]);
+  const [draftHardConflictSlots, setDraftHardConflictSlots] = useState(settings.hardConflictSlots);
+  const hardConflictSlotSet = useMemo(() => new Set(draftHardConflictSlots), [draftHardConflictSlots]);
   const modalBodyRef = useRef<HTMLDivElement>(null);
-  const dragStateRef = useRef({ active: false, selecting: true, lastKey: '' });
+  const dragStateRef = useRef<{ active: boolean; targetState: 'blocked' | 'hard' | 'empty'; lastKey: string }>({
+    active: false,
+    targetState: 'blocked',
+    lastKey: '',
+  });
   const lastGridPointerTypeRef = useRef('');
 
   useEffect(() => {
     if (!open) return;
     setDraftBlockedSlots(settings.blockedSlots);
+    setDraftHardConflictSlots(settings.hardConflictSlots);
     setPage(initialPage);
-  }, [initialPage, open, settings.blockedSlots]);
+  }, [initialPage, open, settings.blockedSlots, settings.hardConflictSlots]);
 
   useEffect(() => {
     if (!open) return;
@@ -158,46 +165,69 @@ export default function CustomizationModal({
     message.success('排课方案展示数量已更新');
   };
 
-  const toggleBlockedSlot = (day: number, period: number) => {
+  const toggleSlot = (day: number, period: number) => {
     const key = blockedSlotKey(day, period);
-    setDraftBlockedSlots((current) => {
-      const next = new Set(current);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return [...next].sort();
+    setDraftBlockedSlots((currentBlocked) => {
+      const nextBlocked = new Set(currentBlocked);
+      setDraftHardConflictSlots((currentHard) => {
+        const nextHard = new Set(currentHard);
+        if (nextBlocked.has(key)) {
+          nextBlocked.delete(key);
+          nextHard.add(key);
+        } else if (nextHard.has(key)) {
+          nextHard.delete(key);
+        } else {
+          nextBlocked.add(key);
+        }
+        return [...nextHard].sort();
+      });
+      return [...nextBlocked].sort();
     });
   };
 
-  const paintBlockedSlot = (key: string, selecting: boolean) => {
-    setDraftBlockedSlots((current) => {
-      const next = new Set(current);
-      if (next.has(key) === selecting) return current;
-      if (selecting) next.add(key);
-      else next.delete(key);
-      return [...next].sort();
+  const paintSlot = (key: string, targetState: 'blocked' | 'hard' | 'empty') => {
+    setDraftBlockedSlots((currentBlocked) => {
+      const nextBlocked = new Set(currentBlocked);
+      setDraftHardConflictSlots((currentHard) => {
+        const nextHard = new Set(currentHard);
+        if (targetState === 'blocked') {
+          nextBlocked.add(key);
+          nextHard.delete(key);
+        } else if (targetState === 'hard') {
+          nextHard.add(key);
+          nextBlocked.delete(key);
+        } else {
+          nextBlocked.delete(key);
+          nextHard.delete(key);
+        }
+        return [...nextHard].sort();
+      });
+      return [...nextBlocked].sort();
     });
   };
 
-  const applyBlockedSlots = () => {
-    if (draftBlockedSlots.join('|') === settings.blockedSlots.join('|')) return;
-    onChange({ ...settings, blockedSlots: draftBlockedSlots });
+  const applySlots = () => {
+    const blockedChanged = draftBlockedSlots.join('|') !== settings.blockedSlots.join('|');
+    const hardChanged = draftHardConflictSlots.join('|') !== settings.hardConflictSlots.join('|');
+    if (!blockedChanged && !hardChanged) return;
+    onChange({ ...settings, blockedSlots: draftBlockedSlots, hardConflictSlots: draftHardConflictSlots });
   };
 
   const returnToMain = () => {
-    applyBlockedSlots();
+    applySlots();
     setPage('main');
   };
 
   const closeAndApply = () => {
-    applyBlockedSlots();
+    applySlots();
     onClose();
   };
 
   const calculationModeLabel = CALCULATION_MODE_OPTIONS.find(
     (option) => option.value === settings.calculationMode,
   )?.label ?? '自动排课';
-  const blockedSlotsLabel = draftBlockedSlots.length > 0
-    ? `已选择 ${draftBlockedSlots.length} 个时段`
+  const blockedSlotsLabel = draftBlockedSlots.length > 0 || draftHardConflictSlots.length > 0
+    ? `${draftBlockedSlots.length} 有事 / ${draftHardConflictSlots.length} 强冲突`
     : '未设置';
 
   return (
@@ -334,11 +364,14 @@ export default function CustomizationModal({
             <div className="customization__subpage-header">
               <div className="customization__subpage-copy">
                 <h3>占位时间</h3>
-                <p>点击或按住鼠标拖动选择时间；从已选格开始拖动可连续取消。</p>
+                <p>点击循环切换 空闲 → 有事 → 强冲突 → 空闲；按住鼠标拖动可连续标注为按下时的目标状态。</p>
               </div>
               <Button
-                disabled={draftBlockedSlots.length === 0}
-                onClick={() => setDraftBlockedSlots([])}
+                disabled={draftBlockedSlots.length === 0 && draftHardConflictSlots.length === 0}
+                onClick={() => {
+                  setDraftBlockedSlots([]);
+                  setDraftHardConflictSlots([]);
+                }}
               >
                 清空占位
               </Button>
@@ -354,7 +387,7 @@ export default function CustomizationModal({
                     const key = target?.dataset.slotKey;
                     if (!key || drag.lastKey === key) return;
                     drag.lastKey = key;
-                    paintBlockedSlot(key, drag.selecting);
+                    paintSlot(key, drag.targetState);
                   }}
                 >
                   <thead>
@@ -368,30 +401,38 @@ export default function CustomizationModal({
                       <tr key={period}>
                         <th scope="row">{period}</th>
                         {DAYS.map((day) => {
-                          const selected = blockedSlotSet.has(blockedSlotKey(day, period));
+                          const key = blockedSlotKey(day, period);
+                          const state = hardConflictSlotSet.has(key)
+                            ? 'hard'
+                            : blockedSlotSet.has(key) ? 'blocked' : 'empty';
                           return (
                             <td key={day}>
                               <button
                                 type="button"
                                 data-slot-key={blockedSlotKey(day, period)}
-                                className={`availability-grid__cell${selected ? ' availability-grid__cell--selected' : ''}`}
-                                aria-label={`${DAY_LABELS[day]}第 ${period} 节${selected ? '有事' : '空闲'}`}
-                                aria-pressed={selected}
+                                className={`availability-grid__cell availability-grid__cell--${state}`}
+                                aria-label={`${DAY_LABELS[day]}第 ${period} 节${state === 'empty' ? '空闲' : state === 'blocked' ? '有事' : '强冲突'}`}
+                                aria-pressed={state !== 'empty'}
                                 onPointerDown={(event) => {
                                   lastGridPointerTypeRef.current = event.pointerType;
                                   if (event.pointerType !== 'mouse' || event.button !== 0) return;
                                   event.preventDefault();
                                   const key = blockedSlotKey(day, period);
+                                  const current = hardConflictSlotSet.has(key)
+                                    ? 'hard'
+                                    : blockedSlotSet.has(key) ? 'blocked' : 'empty';
+                                  const targetState = current === 'empty' ? 'blocked'
+                                    : current === 'blocked' ? 'hard' : 'empty';
                                   dragStateRef.current = {
                                     active: true,
-                                    selecting: !selected,
+                                    targetState,
                                     lastKey: key,
                                   };
-                                  paintBlockedSlot(key, !selected);
+                                  paintSlot(key, targetState);
                                 }}
                                 onClick={(event) => {
                                   if (event.detail === 0 || lastGridPointerTypeRef.current !== 'mouse') {
-                                    toggleBlockedSlot(day, period);
+                                    toggleSlot(day, period);
                                   }
                                   lastGridPointerTypeRef.current = '';
                                 }}

--- a/src/components/CustomizationModalBehavior.test.ts
+++ b/src/components/CustomizationModalBehavior.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import CustomizationModal from './CustomizationModal';
+import { DEFAULT_CUSTOM_SETTINGS } from '@/utils/customization';
+
+interface MountedRoot {
+  host: HTMLDivElement;
+  root: Root;
+}
+
+const mountedRoots: MountedRoot[] = [];
+
+async function mount(node: ReactNode): Promise<MountedRoot> {
+  const host = document.createElement('div');
+  host.dataset.testRoot = 'true';
+  document.body.append(host);
+  const root = createRoot(host);
+  const mounted: MountedRoot = { host, root };
+  mountedRoots.push(mounted);
+  await act(async () => {
+    root.render(node);
+  });
+  return mounted;
+}
+
+function getGridCell(day: number, period: number): HTMLButtonElement {
+  const key = `${day}-${period}`;
+  const cell = document.querySelector<HTMLButtonElement>(`[data-slot-key="${key}"]`);
+  if (!cell) throw new Error(`Missing availability-grid cell for key ${key}`);
+  return cell;
+}
+
+const originalScrollTo = HTMLElement.prototype.scrollTo;
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  // jsdom does not implement scrolling APIs; CustomizationModal calls scrollTo on its body ref.
+  HTMLElement.prototype.scrollTo = () => {};
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const { root } of mountedRoots.splice(0).reverse()) root.unmount();
+    await Promise.resolve();
+  });
+  document.body.replaceChildren();
+  HTMLElement.prototype.scrollTo = originalScrollTo;
+  vi.useRealTimers();
+});
+
+describe('CustomizationModal blocked-slots grid behavior', () => {
+  test('clicking an empty cell cycles 空闲 -> 有事 -> 强冲突 -> 空闲', async () => {
+    await mount(
+      createElement(CustomizationModal, {
+        open: true,
+        settings: DEFAULT_CUSTOM_SETTINGS,
+        onChange: vi.fn(),
+        onClose: vi.fn(),
+        onRestartOnboarding: vi.fn(),
+        showUpdatePopup: true,
+        onShowUpdatePopupChange: vi.fn(),
+        onOpenUpdateHistory: vi.fn(),
+        initialPage: 'blockedSlots',
+      }),
+    );
+
+    const cell = getGridCell(1, 1);
+    expect(cell.getAttribute('aria-label')).toContain('空闲');
+
+    act(() => {
+      cell.click();
+    });
+    expect(cell.getAttribute('aria-label')).toContain('有事');
+
+    act(() => {
+      cell.click();
+    });
+    expect(cell.getAttribute('aria-label')).toContain('强冲突');
+
+    act(() => {
+      cell.click();
+    });
+    expect(cell.getAttribute('aria-label')).toContain('空闲');
+  });
+
+  test('clicking a second cell independently marks it 有事 without affecting the first', async () => {
+    await mount(
+      createElement(CustomizationModal, {
+        open: true,
+        settings: DEFAULT_CUSTOM_SETTINGS,
+        onChange: vi.fn(),
+        onClose: vi.fn(),
+        onRestartOnboarding: vi.fn(),
+        showUpdatePopup: true,
+        onShowUpdatePopupChange: vi.fn(),
+        onOpenUpdateHistory: vi.fn(),
+        initialPage: 'blockedSlots',
+      }),
+    );
+
+    const first = getGridCell(1, 1);
+    const second = getGridCell(2, 2);
+    expect(first.getAttribute('aria-label')).toContain('空闲');
+    expect(second.getAttribute('aria-label')).toContain('空闲');
+
+    act(() => {
+      first.click();
+    });
+    expect(first.getAttribute('aria-label')).toContain('有事');
+
+    act(() => {
+      second.click();
+    });
+    expect(second.getAttribute('aria-label')).toContain('有事');
+    expect(first.getAttribute('aria-label')).toContain('有事');
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -1667,6 +1667,9 @@ html {
   --timetable-placeholder-stripe: color-mix(in srgb, var(--text-sub) 76%, var(--panel-bg));
   --timetable-placeholder-bg: color-mix(in srgb, var(--text-sub) 22%, var(--panel-bg));
   --timetable-placeholder-fg: var(--text-sub);
+  --timetable-hardconflict-stripe: #d93025;
+  --timetable-hardconflict-bg: rgba(217, 48, 37, 0.18);
+  --timetable-hardconflict-fg: #b3261e;
   --timetable-border: #232323;
   --timetable-grid: #b9b9b9;
 }
@@ -5308,6 +5311,9 @@ html.theme-transitioning #root .plan-switcher__icon-button.ant-btn {
   --timetable-placeholder-stripe: #7b8796;
   --timetable-placeholder-bg: #303946;
   --timetable-placeholder-fg: #d8dee6;
+  --timetable-hardconflict-stripe: #f28b82;
+  --timetable-hardconflict-bg: rgba(242, 139, 130, 0.22);
+  --timetable-hardconflict-fg: #f3a9a4;
   background: var(--timetable-cell-bg);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -4971,6 +4971,29 @@ html.theme-transitioning #root .plan-switcher__icon-button.ant-btn {
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-sub) 62%, var(--border));
 }
 
+.availability-grid__cell--blocked {
+  background: color-mix(in srgb, var(--text-sub) 28%, var(--panel-bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-sub) 62%, var(--border));
+}
+
+.availability-grid__cell--blocked:hover {
+  outline: 0;
+  background: color-mix(in srgb, var(--text-sub) 28%, var(--panel-bg));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-sub) 62%, var(--border));
+}
+
+.availability-grid__cell--hard {
+  background: var(--timetable-hardconflict-bg, #ffe0e0);
+  border-color: var(--timetable-hardconflict-stripe, #d93025);
+  box-shadow: inset 0 0 0 1px var(--timetable-hardconflict-stripe, #d93025);
+}
+
+.availability-grid__cell--hard:hover {
+  outline: 0;
+  background: var(--timetable-hardconflict-bg, #ffe0e0);
+  box-shadow: inset 0 0 0 1px var(--timetable-hardconflict-stripe, #d93025);
+}
+
 @media (max-width: 900px) {
   .selected-courses-toolbar--filters {
     grid-template-columns: minmax(220px, 1fr) minmax(120px, 168px);
@@ -5686,6 +5709,18 @@ html.theme-transitioning #root .plan-switcher__icon-button.ant-btn {
 :root[data-theme='dark'] .availability-grid__cell--selected:hover {
   background: #36414f;
   box-shadow: inset 0 0 0 1px #637184;
+}
+
+:root[data-theme='dark'] .availability-grid__cell--blocked,
+:root[data-theme='dark'] .availability-grid__cell--blocked:hover {
+  background: #36414f;
+  box-shadow: inset 0 0 0 1px #637184;
+}
+
+:root[data-theme='dark'] .availability-grid__cell--hard,
+:root[data-theme='dark'] .availability-grid__cell--hard:hover {
+  background: #5c2a2a;
+  box-shadow: inset 0 0 0 1px #b94a4a;
 }
 
 :root[data-theme='dark'] #root .course-table__export-button.ant-btn,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -308,4 +308,6 @@ export interface Arrangement {
   totalCredits: number;
   /** 总学时 */
   totalHours: number;
+  /** 撞强冲突时段的 group key 数（独立于 conflictCount） */
+  hardConflictCount: number;
 }

--- a/src/updates/appUpdates.ts
+++ b/src/updates/appUpdates.ts
@@ -102,6 +102,15 @@ export const APP_RELEASES: AppRelease[] = [
       '识别兼容被文字包围的编号，以及字母开头、小写后缀等多种课程号格式。',
     ],
   },
+  {
+    version: '2026.07.24.3',
+    publishedAt: '2026-07-24',
+    title: '占位时间三态标注与强冲突避让',
+    items: [
+      '占位时间网格支持三态标注：空闲 / 有事 / 强冲突。',
+      '强冲突时段在排课时被尽量避开（多时间组自动选不撞的组，单时间组等额惩罚不影响相对顺序）。',
+    ],
+  },
 ];
 
 export const CURRENT_APP_VERSION = APP_RELEASES.at(-1)?.version ?? '0';

--- a/src/updates/updateAwareness.test.ts
+++ b/src/updates/updateAwareness.test.ts
@@ -79,15 +79,15 @@ function impact(kind: CourseImpactEvent['kind']): CourseImpactEvent {
 describe('update awareness rules', () => {
   test('publishes the July 24 memo recognize update', () => {
     expect(APP_RELEASES.at(-1)).toEqual({
-      version: '2026.07.24.2',
+      version: '2026.07.24.3',
       publishedAt: '2026-07-24',
-      title: '备忘录识别导入',
+      title: '占位时间三态标注与强冲突避让',
       items: [
-        '备忘录新增识别按钮，自动识别文本中的课程号与课堂号，可勾选后导入到新课表。',
-        '识别兼容被文字包围的编号，以及字母开头、小写后缀等多种课程号格式。',
+        '占位时间网格支持三态标注：空闲 / 有事 / 强冲突。',
+        '强冲突时段在排课时被尽量避开（多时间组自动选不撞的组，单时间组等额惩罚不影响相对顺序）。',
       ],
     });
-    expect(CURRENT_APP_VERSION).toBe('2026.07.24.2');
+    expect(CURRENT_APP_VERSION).toBe('2026.07.24.3');
   });
 
   test('does not treat the catalog provider persisted semester as prior use', () => {

--- a/src/utils/arrangementCalculationState.test.ts
+++ b/src/utils/arrangementCalculationState.test.ts
@@ -33,6 +33,7 @@ function settings(
     preferAvoidCampusTransfers: true,
     residentCampus: '本部',
     blockedSlots: [],
+    hardConflictSlots: [],
     ...overrides,
   };
 }

--- a/src/utils/arrangementCalculationState.test.ts
+++ b/src/utils/arrangementCalculationState.test.ts
@@ -405,6 +405,20 @@ describe('arrangement calculation state', () => {
     expect(state.draft.settings.calculationMode).toBe('manual');
   });
 
+  it('treats hard conflict slots changes as a dirty input', () => {
+    const groups = [group('A', 'a')];
+    const base = settings({});
+    const changed = settings({ hardConflictSlots: ['1-1'] });
+    let state = createArrangementCalculationState('scope', groups, base);
+    state = completeArrangementCalculation(startArrangementCalculation(state, 1), 1, [
+      arrangement('a', groups),
+    ]);
+    expect(state.phase).toBe('ready');
+
+    const synced = syncArrangementCalculationInputs(state, 'scope', groups, changed);
+    expect(synced.phase).toBe('dirty');
+  });
+
   it('does not synchronize a stale mode-only projection over a newer completion', () => {
     const groups = [group('A', 'a')];
     const rendered = startArrangementCalculation(

--- a/src/utils/arrangementCalculationState.test.ts
+++ b/src/utils/arrangementCalculationState.test.ts
@@ -59,6 +59,7 @@ function arrangement(id: string, groups: CourseGroup[]): Arrangement {
     courseCount: groups.length,
     totalCredits: 0,
     totalHours: 0,
+    hardConflictCount: 0,
   };
 }
 

--- a/src/utils/arrangementCalculationState.ts
+++ b/src/utils/arrangementCalculationState.ts
@@ -39,6 +39,7 @@ function copySettings(settings: CustomScheduleSettings): CustomScheduleSettings 
   return {
     ...settings,
     blockedSlots: [...settings.blockedSlots],
+    hardConflictSlots: [...settings.hardConflictSlots],
   };
 }
 
@@ -103,6 +104,7 @@ export function calculationInputKey(
     preferAvoidCampusTransfers: settings.preferAvoidCampusTransfers,
     residentCampus: settings.residentCampus,
     blockedSlots: [...settings.blockedSlots].sort(),
+    hardConflictSlots: [...settings.hardConflictSlots].sort(),
     favorites: {
       arrangementIds: [...favorites.arrangementIds].sort(),
       timeGroupKeys: [...favorites.timeGroupKeys].sort(),

--- a/src/utils/arrangementEngine.test.ts
+++ b/src/utils/arrangementEngine.test.ts
@@ -103,6 +103,7 @@ function makeGroup(
 function makeRank(overrides: Partial<ArrangementRank> = {}): ArrangementRank {
   return {
     favoriteArrangement: false,
+    hardConflictCount: 0,
     conflictCount: 0,
     favoriteCourseCount: 0,
     campusTransitionCount: 0,
@@ -131,6 +132,14 @@ describe('compareArrangementRanks', () => {
     expect(compareArrangementRanks(
       makeRank({ conflictCount: 0, favoriteCourseCount: 2 }),
       makeRank({ conflictCount: 0, favoriteCourseCount: 1 }),
+      NO_PREFERENCES,
+    )).toBeLessThan(0);
+  });
+
+  it('ranks hard conflict count ahead of timetable conflicts', () => {
+    expect(compareArrangementRanks(
+      makeRank({ hardConflictCount: 0, conflictCount: 1 }),
+      makeRank({ hardConflictCount: 1, conflictCount: 0 }),
       NO_PREFERENCES,
     )).toBeLessThan(0);
   });
@@ -399,6 +408,48 @@ describe('exact Top-8 differential contract', () => {
     expect(results.map((result) => [result.id, result.conflictCount])).toEqual([
       ['b-locked||z-free', 0],
       ['a-blocked||b-locked', 1],
+    ]);
+  });
+
+  it('makes multi-group courses avoid hard conflict slots and keeps single-group impact neutral', () => {
+    const groups = [
+      makeGroup('A', 'a-hard', [{ weeks: [1, 2], day: 1, periods: [1], room: '', campus: '本部' }]),
+      makeGroup('A', 'z-free', [{ weeks: [1, 2], day: 2, periods: [3], room: '', campus: '本部' }]),
+      makeGroup('B', 'b-locked', [{ weeks: [1, 2], day: 1, periods: [1], room: '', campus: '本部' }]),
+    ];
+    const settings: CustomScheduleSettings = {
+      ...NO_PREFERENCES,
+      hardConflictSlots: ['1-1'],
+    };
+
+    const results = enumerateArrangements(groups, settings);
+
+    // 多组课 A 选不撞强冲突的 z-free；b-locked 单组撞强冲突，两个方案各带 b-locked 的 1，
+    // 但 z-free 方案总强冲突数（1）小于 a-hard 方案（2），因此 z-free 方案排前
+    expect(results.map((result) => [result.id, result.hardConflictCount])).toEqual([
+      ['b-locked||z-free', 1],
+      ['a-hard||b-locked', 2],
+    ]);
+  });
+
+  it('keeps hard conflict count independent from blocked-slot conflict count', () => {
+    const groups = [
+      makeGroup('A', 'a-hard', [{ weeks: [1, 2], day: 1, periods: [1], room: '', campus: '本部' }]),
+      makeGroup('A', 'z-free', [{ weeks: [1, 2], day: 2, periods: [3], room: '', campus: '本部' }]),
+    ];
+    const settings: CustomScheduleSettings = {
+      ...NO_PREFERENCES,
+      blockedSlots: ['2-3'],
+      hardConflictSlots: ['1-1'],
+    };
+
+    const results = enumerateArrangements(groups, settings);
+
+    // a-hard 撞强冲突(1-1) hardConflictCount=1；z-free 撞占位(2-3) conflictCount=1
+    // 强冲突优先于冲突数：z-free(0 强冲突) 排前
+    expect(results.map((result) => [result.id, result.hardConflictCount, result.conflictCount])).toEqual([
+      ['z-free', 0, 1],
+      ['a-hard', 1, 0],
     ]);
   });
 

--- a/src/utils/arrangementEngine.test.ts
+++ b/src/utils/arrangementEngine.test.ts
@@ -25,6 +25,7 @@ const NO_PREFERENCES: CustomScheduleSettings = {
   preferAvoidCampusTransfers: false,
   residentCampus: '本部',
   blockedSlots: [],
+  hardConflictSlots: [],
 };
 
 describe('exact conflict-free result policy', () => {
@@ -144,6 +145,7 @@ describe('compareArrangementRanks', () => {
       preferAvoidCampusTransfers: true,
       residentCampus: '本部',
       blockedSlots: [],
+      hardConflictSlots: [],
     };
 
     expect(compareArrangementRanks(
@@ -275,6 +277,7 @@ describe('exact Top-8 differential contract', () => {
             preferAvoidCampusTransfers,
             residentCampus: seed % 2 === 0 ? '本部' : '高新区',
             blockedSlots: blockedSlotsForSeed(seed),
+            hardConflictSlots: [],
           };
           const favorites = favoriteSnapshotForGroups(groups);
           const expected = enumerateArrangementsOracle(groups, settings, favorites);
@@ -466,6 +469,7 @@ describe('exact Top-8 differential contract', () => {
       preferAvoidCampusTransfers: false,
       residentCampus: '本部',
       blockedSlots: afternoonBlocks,
+      hardConflictSlots: [],
     }).map((result) => result.id)).toEqual([
       'z-free-afternoon',
       'a-busy-afternoon',
@@ -484,6 +488,7 @@ describe('exact Top-8 differential contract', () => {
       preferAvoidCampusTransfers: false,
       residentCampus: '本部',
       blockedSlots: [],
+      hardConflictSlots: [],
     }).map((result) => result.id)).toEqual(['z-late', 'a-early']);
   });
 

--- a/src/utils/arrangementEngine.ts
+++ b/src/utils/arrangementEngine.ts
@@ -40,6 +40,7 @@ export interface ArrangementEnumerationOptions {
 
 export interface ArrangementRank {
   favoriteArrangement: boolean;
+  hardConflictCount: number;
   conflictCount: number;
   favoriteCourseCount: number;
   campusTransitionCount: number;
@@ -65,6 +66,7 @@ interface PrecomputedGroup {
   earlyMorningDays: number[];
   campusVisits: CampusVisit[];
   blockedSlotHit: boolean;
+  hardConflictHit: boolean;
   credits: number;
   hours: number;
   conflictNeighbors: number[];
@@ -101,6 +103,9 @@ export function compareArrangementRanks(
 ): number {
   if (left.favoriteArrangement !== right.favoriteArrangement) {
     return left.favoriteArrangement ? -1 : 1;
+  }
+  if (left.hardConflictCount !== right.hardConflictCount) {
+    return left.hardConflictCount - right.hardConflictCount;
   }
   if (left.conflictCount !== right.conflictCount) {
     return left.conflictCount - right.conflictCount;
@@ -207,11 +212,13 @@ class BoundedCandidateHeap {
 function precomputeGroups(
   groups: CourseGroup[],
   blockedSlots: Set<string>,
+  hardConflictSlots: Set<string>,
   favoriteTimeGroupKeys: Set<string>,
   favoriteSectionIds: Set<string>,
 ): PrecomputedGroup[] {
   const keyIds = new Map<string, number>();
   const blockedByDay = blockedMinuteIntervalsByDay(blockedSlots);
+  const hardByDay = blockedMinuteIntervalsByDay(hardConflictSlots);
   const records = groups.map((group): PrecomputedGroup => {
     let keyId = keyIds.get(group.key);
     if (keyId === undefined) {
@@ -223,6 +230,7 @@ function precomputeGroups(
     const occupiedDayPeriods = new Set<string>();
     const earlyMorningDays = new Set<number>();
     let blockedSlotHit = false;
+    let hardConflictHit = false;
     for (const slot of group.schedule) {
       const minuteIntervals = scheduleSlotMinuteIntervals(slot);
       for (const week of expandWeeks(slot.weeks)) {
@@ -245,6 +253,9 @@ function precomputeGroups(
       if (scheduleSlotOverlapsBlocked(slot, blockedByDay)) {
         blockedSlotHit = true;
       }
+      if (scheduleSlotOverlapsBlocked(slot, hardByDay)) {
+        hardConflictHit = true;
+      }
     }
     const representative = group.sections[0];
     return {
@@ -257,6 +268,7 @@ function precomputeGroups(
       earlyMorningDays: [...earlyMorningDays],
       campusVisits: campusVisitsForGroup(group),
       blockedSlotHit,
+      hardConflictHit,
       credits: representative ? representative.credits : 0,
       hours: representative ? representative.hours : 0,
       conflictNeighbors: [],
@@ -300,6 +312,7 @@ class IncrementalSearchState {
   private readonly selected: boolean[];
   private readonly blockedConflictRefs: number[];
   private readonly overlapConflictRefs: number[];
+  private readonly hardConflictRefs: number[];
   private readonly occupiedDayPeriodRefs = new Map<string, number>();
   private readonly earlyMorningDayRefs = new Map<number, number>();
   private readonly campusVisitsByBucket = new Map<string, CampusVisit[]>();
@@ -307,6 +320,7 @@ class IncrementalSearchState {
   private readonly trackCampusTransfers: boolean;
 
   conflictCount = 0;
+  hardConflictCount = 0;
   favoriteCourseCount = 0;
   campusTransitionCount = 0;
   earlyMorningDayCount = 0;
@@ -326,6 +340,7 @@ class IncrementalSearchState {
     const keyCount = records.reduce((highest, record) => Math.max(highest, record.keyId + 1), 0);
     this.blockedConflictRefs = Array.from({ length: keyCount }, () => 0);
     this.overlapConflictRefs = Array.from({ length: keyCount }, () => 0);
+    this.hardConflictRefs = Array.from({ length: keyCount }, () => 0);
     for (const key of blockedSlots) {
       const [day, period] = key.split('-').map(Number);
       if (day >= 1 && day <= 7) this.incrementMap(this.occupiedDayPeriodRefs, `${day}-${period}`);
@@ -341,6 +356,7 @@ class IncrementalSearchState {
     this.selected[groupIndex] = true;
     if (record.favoriteCourse) this.favoriteCourseCount += 1;
     if (record.blockedSlotHit) this.adjustConflictRef(this.blockedConflictRefs, record.keyId, 1);
+    if (record.hardConflictHit) this.adjustHardConflictRef(record.keyId, 1);
     for (const neighborIndex of record.conflictNeighbors) {
       if (!this.selected[neighborIndex]) continue;
       this.adjustConflictRef(this.overlapConflictRefs, record.keyId, 1);
@@ -367,6 +383,7 @@ class IncrementalSearchState {
   remove(groupIndex: number, snapshot: TotalsSnapshot): void {
     const record = this.records[groupIndex];
     if (record.blockedSlotHit) this.adjustConflictRef(this.blockedConflictRefs, record.keyId, -1);
+    if (record.hardConflictHit) this.adjustHardConflictRef(record.keyId, -1);
     for (const neighborIndex of record.conflictNeighbors) {
       if (!this.selected[neighborIndex]) continue;
       this.adjustConflictRef(this.overlapConflictRefs, record.keyId, -1);
@@ -430,6 +447,13 @@ class IncrementalSearchState {
     if (wasConflicted !== isConflicted) this.conflictCount += isConflicted ? 1 : -1;
   }
 
+  private adjustHardConflictRef(keyId: number, delta: 1 | -1): void {
+    const was = this.hardConflictRefs[keyId] > 0;
+    this.hardConflictRefs[keyId] += delta;
+    const is = this.hardConflictRefs[keyId] > 0;
+    if (was !== is) this.hardConflictCount += is ? 1 : -1;
+  }
+
   private incrementMap<Key>(map: Map<Key, number>, key: Key): void {
     map.set(key, (map.get(key) ?? 0) + 1);
   }
@@ -484,12 +508,14 @@ export function enumerateArrangementResultsExact(
   }
 
   const blockedSlots = new Set(settings.blockedSlots);
+  const hardConflictSlots = new Set(settings.hardConflictSlots);
   const favoriteArrangementIds = new Set(favorites?.arrangementIds ?? []);
   const favoriteTimeGroupKeys = new Set(favorites?.timeGroupKeys ?? []);
   const favoriteSectionIds = new Set(favorites?.sectionIds ?? []);
   const records = precomputeGroups(
     groups,
     blockedSlots,
+    hardConflictSlots,
     favoriteTimeGroupKeys,
     favoriteSectionIds,
   );
@@ -545,6 +571,7 @@ export function enumerateArrangementResultsExact(
         id,
         rank: {
           favoriteArrangement: favoriteArrangementIds.has(id),
+          hardConflictCount: state.hardConflictCount,
           conflictCount: state.conflictCount,
           favoriteCourseCount: state.favoriteCourseCount,
           campusTransitionCount: settings.preferAvoidCampusTransfers
@@ -593,6 +620,7 @@ export function enumerateArrangementResultsExact(
     id: candidate.id,
     groups: candidate.groupIndices.map((index) => records[index].group),
     conflictCount: candidate.rank.conflictCount,
+    hardConflictCount: candidate.rank.hardConflictCount,
     courseCount: candidate.groupIndices.length,
     totalCredits: candidate.rank.totalCredits,
     totalHours: candidate.totalHours,

--- a/src/utils/arrangementFavorites.test.ts
+++ b/src/utils/arrangementFavorites.test.ts
@@ -25,6 +25,7 @@ const arrangement = (id: string): Arrangement => ({
   courseCount: 1,
   totalCredits: 2,
   totalHours: 32,
+  hardConflictCount: 0,
 });
 
 describe('arrangement favorite metadata', () => {

--- a/src/utils/arrangementOracle.ts
+++ b/src/utils/arrangementOracle.ts
@@ -60,6 +60,18 @@ function countConflicts(groups: CourseGroup[], blockedSlots: Set<string>): numbe
   return seen.size;
 }
 
+function countHardConflicts(groups: CourseGroup[], hardConflictSlots: Set<string>): number {
+  if (hardConflictSlots.size === 0) return 0;
+  const hardByDay = blockedMinuteIntervalsByDay(hardConflictSlots);
+  const seen = new Set<string>();
+  for (const group of groups) {
+    if (group.schedule.some((slot) => scheduleSlotOverlapsBlocked(slot, hardByDay))) {
+      seen.add(group.key);
+    }
+  }
+  return seen.size;
+}
+
 function occupiedPeriodsByDay(
   groups: CourseGroup[],
   blockedSlots: Set<string>,
@@ -148,6 +160,7 @@ export function enumerateArrangementsOracle(
 ): Arrangement[] {
   if (groups.length === 0) return [];
   const blockedSlots = new Set(settings.blockedSlots);
+  const hardConflictSlots = new Set(settings.hardConflictSlots);
   const favoriteArrangementIds = new Set(favorites?.arrangementIds ?? []);
   const favoriteTimeGroupKeys = new Set(favorites?.timeGroupKeys ?? []);
   const favoriteSectionIds = new Set(favorites?.sectionIds ?? []);
@@ -180,6 +193,7 @@ export function enumerateArrangementsOracle(
       id: arrangementId(allGroups),
       groups: allGroups,
       conflictCount: countConflicts(allGroups, blockedSlots),
+      hardConflictCount: countHardConflicts(allGroups, hardConflictSlots),
       courseCount: allGroups.length,
       totalCredits: sumCredits(allGroups),
       totalHours: sumHours(allGroups),
@@ -197,6 +211,9 @@ export function enumerateArrangementsOracle(
   arrs.sort((a, b) => {
     if (a.favoriteArrangement !== b.favoriteArrangement) {
       return a.favoriteArrangement ? -1 : 1;
+    }
+    if (a.arrangement.hardConflictCount !== b.arrangement.hardConflictCount) {
+      return a.arrangement.hardConflictCount - b.arrangement.hardConflictCount;
     }
     if (a.arrangement.conflictCount !== b.arrangement.conflictCount) {
       return a.arrangement.conflictCount - b.arrangement.conflictCount;

--- a/src/utils/arrangementWorkerClient.test.ts
+++ b/src/utils/arrangementWorkerClient.test.ts
@@ -94,10 +94,10 @@ describe('arrangement Worker client', () => {
       type: 'result',
       generation: 1,
       arrangements: [{
-        id: 'a', groupKeys: ['a'], conflictCount: 0, courseCount: 1, totalCredits: 0, totalHours: 0,
+        id: 'a', groupKeys: ['a'], conflictCount: 0, hardConflictCount: 0, courseCount: 1, totalCredits: 0, totalHours: 0,
       }],
       conflictFreePreview: [{
-        id: 'a', groupKeys: ['a'], conflictCount: 0, courseCount: 1, totalCredits: 0, totalHours: 0,
+        id: 'a', groupKeys: ['a'], conflictCount: 0, hardConflictCount: 0, courseCount: 1, totalCredits: 0, totalHours: 0,
       }],
       totalConflictFreeCount: 1,
     });
@@ -136,6 +136,7 @@ describe('arrangement Worker client', () => {
         preferAvoidCampusTransfers: true,
         residentCampus: '本部',
         blockedSlots: [],
+        hardConflictSlots: [],
       },
     }]);
     worker.reply({
@@ -145,6 +146,7 @@ describe('arrangement Worker client', () => {
         id: 'a||b',
         groupKeys: ['a', 'b'],
         conflictCount: 2,
+        hardConflictCount: 3,
         courseCount: 2,
         totalCredits: 5,
         totalHours: 64,
@@ -158,7 +160,7 @@ describe('arrangement Worker client', () => {
       id: 'a||b',
       groups,
       conflictCount: 2,
-      hardConflictCount: 0,
+      hardConflictCount: 3,
       courseCount: 2,
       totalCredits: 5,
       totalHours: 64,
@@ -207,12 +209,13 @@ describe('arrangement Worker client', () => {
         id: 'b',
         groupKeys: ['b'],
         conflictCount: 0,
+        hardConflictCount: 0,
         courseCount: 1,
         totalCredits: 0,
         totalHours: 0,
       }],
       conflictFreePreview: [{
-        id: 'b', groupKeys: ['b'], conflictCount: 0, courseCount: 1, totalCredits: 0, totalHours: 0,
+        id: 'b', groupKeys: ['b'], conflictCount: 0, hardConflictCount: 0, courseCount: 1, totalCredits: 0, totalHours: 0,
       }],
       totalConflictFreeCount: 1,
     });
@@ -266,6 +269,7 @@ describe('arrangement Worker client', () => {
         id: 'missing',
         groupKeys: ['missing'],
         conflictCount: 0,
+        hardConflictCount: 0,
         courseCount: 1,
         totalCredits: 0,
         totalHours: 0,

--- a/src/utils/arrangementWorkerClient.test.ts
+++ b/src/utils/arrangementWorkerClient.test.ts
@@ -20,6 +20,7 @@ const SETTINGS: CustomScheduleSettings = {
   preferAvoidCampusTransfers: true,
   residentCampus: '本部',
   blockedSlots: [],
+  hardConflictSlots: [],
 };
 
 function group(

--- a/src/utils/arrangementWorkerClient.test.ts
+++ b/src/utils/arrangementWorkerClient.test.ts
@@ -158,6 +158,7 @@ describe('arrangement Worker client', () => {
       id: 'a||b',
       groups,
       conflictCount: 2,
+      hardConflictCount: 0,
       courseCount: 2,
       totalCredits: 5,
       totalHours: 64,

--- a/src/utils/arrangementWorkerClient.ts
+++ b/src/utils/arrangementWorkerClient.ts
@@ -151,6 +151,9 @@ function rehydrateArrangement(
     id: dto.id,
     groups,
     conflictCount: dto.conflictCount,
+    // Worker 协议当前不传递 hardConflictSlots（恒为空），强冲突数始终为 0；
+    // 后续任务接入 hardConflictSlots 时需同步更新 DTO 与此处。
+    hardConflictCount: 0,
     courseCount: dto.courseCount,
     totalCredits: dto.totalCredits,
     totalHours: dto.totalHours,

--- a/src/utils/arrangementWorkerClient.ts
+++ b/src/utils/arrangementWorkerClient.ts
@@ -124,6 +124,7 @@ function parseWorkerResponse(value: unknown): ArrangementWorkerResponse {
       id: item.id,
       groupKeys: item.groupKeys,
       conflictCount: item.conflictCount,
+      hardConflictCount: isFiniteNumber(item.hardConflictCount) ? item.hardConflictCount : 0,
       courseCount: item.courseCount,
       totalCredits: item.totalCredits,
       totalHours: item.totalHours,
@@ -151,9 +152,7 @@ function rehydrateArrangement(
     id: dto.id,
     groups,
     conflictCount: dto.conflictCount,
-    // Worker 协议当前不传递 hardConflictSlots（恒为空），强冲突数始终为 0；
-    // 后续任务接入 hardConflictSlots 时需同步更新 DTO 与此处。
-    hardConflictCount: 0,
+    hardConflictCount: dto.hardConflictCount ?? 0,
     courseCount: dto.courseCount,
     totalCredits: dto.totalCredits,
     totalHours: dto.totalHours,

--- a/src/utils/customization.test.ts
+++ b/src/utils/customization.test.ts
@@ -85,6 +85,24 @@ describe('custom schedule settings persistence', () => {
       .toBe('auto');
   });
 
+  it('defaults hard conflict slots to empty and dedupes/sorts entries', () => {
+    expect(DEFAULT_CUSTOM_SETTINGS.hardConflictSlots).toEqual([]);
+    expect(normalizeCustomScheduleSettings({}).hardConflictSlots).toEqual([]);
+    expect(normalizeCustomScheduleSettings({
+      hardConflictSlots: ['2-6', 'bad', '2-6', '1-1'],
+    }).hardConflictSlots).toEqual(['1-1', '2-6']);
+  });
+
+  it('makes hard conflict slots take precedence over blocked slots when overlapping', () => {
+    expect(normalizeCustomScheduleSettings({
+      blockedSlots: ['1-1', '3-8'],
+      hardConflictSlots: ['1-1'],
+    })).toMatchObject({
+      blockedSlots: ['3-8'],
+      hardConflictSlots: ['1-1'],
+    });
+  });
+
   it('retains legacy preference migration and blocked-slot validation', () => {
     expect(parseCustomScheduleSettings(JSON.stringify({
       schedulePreference: 'half-day',
@@ -98,6 +116,7 @@ describe('custom schedule settings persistence', () => {
       preferAvoidCampusTransfers: true,
       residentCampus: '本部',
       blockedSlots: ['1-1', '2-6'],
+      hardConflictSlots: [],
     });
   });
 });

--- a/src/utils/customization.ts
+++ b/src/utils/customization.ts
@@ -40,6 +40,7 @@ export interface CustomScheduleSettings {
   preferAvoidCampusTransfers: boolean;
   residentCampus: ResidentCampus;
   blockedSlots: string[];
+  hardConflictSlots: string[];
 }
 
 export const RESIDENT_CAMPUS_OPTIONS = [
@@ -58,6 +59,7 @@ export const DEFAULT_CUSTOM_SETTINGS: CustomScheduleSettings = {
   preferAvoidCampusTransfers: true,
   residentCampus: '本部',
   blockedSlots: [],
+  hardConflictSlots: [],
 };
 
 export function blockedSlotKey(day: number, period: number): string {
@@ -78,6 +80,10 @@ export function normalizeCustomScheduleSettings(value: unknown): CustomScheduleS
   const source = value && typeof value === 'object'
     ? value as Record<string, unknown>
     : {};
+  const hardConflictSlots = Array.isArray(source.hardConflictSlots)
+    ? [...new Set(source.hardConflictSlots.filter(isBlockedSlot))].sort()
+    : [];
+  const hardSet = new Set(hardConflictSlots);
   return {
     calculationMode: source.calculationMode === 'manual' ? 'manual' : 'auto',
     arrangementDisplayCount: isArrangementDisplayCount(source.arrangementDisplayCount)
@@ -96,8 +102,9 @@ export function normalizeCustomScheduleSettings(value: unknown): CustomScheduleS
       ? source.preferAvoidCampusTransfers
       : DEFAULT_CUSTOM_SETTINGS.preferAvoidCampusTransfers,
     residentCampus: source.residentCampus === '高新区' ? '高新区' : '本部',
+    hardConflictSlots,
     blockedSlots: Array.isArray(source.blockedSlots)
-      ? [...new Set(source.blockedSlots.filter(isBlockedSlot))].sort()
+      ? [...new Set(source.blockedSlots.filter((slot) => isBlockedSlot(slot) && !hardSet.has(slot)))].sort()
       : [],
   };
 }

--- a/src/workers/arrangementProtocol.test.ts
+++ b/src/workers/arrangementProtocol.test.ts
@@ -92,6 +92,18 @@ describe('arrangement Worker precise schedule protocol', () => {
     expect(request.mode).toBe('recommended');
   });
 
+  it('serializes hard conflict slots in the worker settings dto and result', () => {
+    const groups = [group('A', schedule([1]), ['A.01'])];
+    const request = createArrangementWorkerRequest(1, groups, {
+      ...SETTINGS,
+      hardConflictSlots: ['1-1', '2-6'],
+    });
+    expect(request.settings.hardConflictSlots).toEqual(['1-1', '2-6']);
+
+    const result = executeArrangementWorkerRequest(request);
+    expect(result.arrangements[0].hardConflictCount).toBe(1);
+  });
+
   it('ranks a lexicographically later group first when its section is favorited', () => {
     const early = group('A::early', [], ['A.01']);
     const late = group('A::late', [], ['A.02']);

--- a/src/workers/arrangementProtocol.test.ts
+++ b/src/workers/arrangementProtocol.test.ts
@@ -16,6 +16,7 @@ const SETTINGS: CustomScheduleSettings = {
   preferAvoidCampusTransfers: true,
   residentCampus: '高新区',
   blockedSlots: [],
+  hardConflictSlots: [],
 };
 
 function schedule(

--- a/src/workers/arrangementProtocol.ts
+++ b/src/workers/arrangementProtocol.ts
@@ -163,6 +163,7 @@ export function executeArrangementWorkerRequest(
     preferAvoidCampusTransfers: request.settings.preferAvoidCampusTransfers,
     residentCampus: request.settings.residentCampus,
     blockedSlots: request.settings.blockedSlots,
+    hardConflictSlots: [],
   };
   const result = enumerateArrangementResultsExact(
     request.groups.map(rehydrateWorkerInputGroup),

--- a/src/workers/arrangementProtocol.ts
+++ b/src/workers/arrangementProtocol.ts
@@ -39,6 +39,7 @@ export interface ArrangementWorkerSettingsDto {
   preferAvoidCampusTransfers: boolean;
   residentCampus: ResidentCampus;
   blockedSlots: string[];
+  hardConflictSlots: string[];
 }
 
 export interface ArrangementWorkerRequest {
@@ -54,6 +55,7 @@ export interface ArrangementResultDto {
   id: string;
   groupKeys: string[];
   conflictCount: number;
+  hardConflictCount: number;
   courseCount: number;
   totalCredits: number;
   totalHours: number;
@@ -108,6 +110,7 @@ export function createArrangementWorkerRequest(
       preferAvoidCampusTransfers: settings.preferAvoidCampusTransfers,
       residentCampus: settings.residentCampus,
       blockedSlots: [...settings.blockedSlots],
+      hardConflictSlots: [...settings.hardConflictSlots],
     },
     favorites: copyFavoritePreferences(favorites),
   };
@@ -163,7 +166,7 @@ export function executeArrangementWorkerRequest(
     preferAvoidCampusTransfers: request.settings.preferAvoidCampusTransfers,
     residentCampus: request.settings.residentCampus,
     blockedSlots: request.settings.blockedSlots,
-    hardConflictSlots: [],
+    hardConflictSlots: request.settings.hardConflictSlots ?? [],
   };
   const result = enumerateArrangementResultsExact(
     request.groups.map(rehydrateWorkerInputGroup),
@@ -177,6 +180,7 @@ export function executeArrangementWorkerRequest(
     id: arrangement.id,
     groupKeys: arrangement.groups.map((group) => group.key),
     conflictCount: arrangement.conflictCount,
+    hardConflictCount: arrangement.hardConflictCount,
     courseCount: arrangement.courseCount,
     totalCredits: arrangement.totalCredits,
     totalHours: arrangement.totalHours,


### PR DESCRIPTION
## 强冲突时段标注

新增"强冲突"时段标注：撞强冲突的排课方案在排序里被压到最后（仅次于收藏方案），多时间组的课自动避开、单时间组的课等额惩罚无影响。复用占位网格三态标注（空闲 -> 有事 -> 强冲突）。

### 设计要点
- **高权重排序惩罚，非硬排除**：不动枚举逻辑，给撞强冲突的方案一个高优先级排序键。
- **独立于冲突数**：`hardConflictCount` 不计入 `conflictCount`，排序键 `收藏方案 > 强冲突惩罚 > 冲突数 > 收藏课程 > 校区 > 空半天 > 早八 > 字典序 > 学分`。
- **互斥**：`hardConflictSlots` 与 `blockedSlots` 互斥，强冲突优先；normalize 兜底。

### 改动
- `customization.ts`：`hardConflictSlots` 字段 + normalize 互斥
- `arrangementEngine.ts` / `arrangementOracle.ts`：`hardConflictCount` 排序（引擎 + 预言机同步）
- `arrangementProtocol.ts` / `arrangementCalculationState.ts`：Worker 协议 + 计算输入键
- `CustomizationModal.tsx`：占位网格三态循环 + 拖动涂抹
- `CourseTable.tsx`：强冲突色块（底层，不参与冲突标记）
- `ArrangementPanel.tsx`：方案卡显示强冲突数
- `appUpdates.ts`：版本日志 2026.07.24.3

### 测试
401 测试通过（含新增三态循环行为测试），tsc / lint / build 全过。final whole-branch review 通过（1 个 Critical 嵌套 setState 已修 + 行为测试防护回归）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)