### PR TITLE
Enhance memo editing with optional Markdown formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "html-to-image": "^1.11.13",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "react-window": "^2.2.7"
+    "react-markdown": "^10.1.0",
+    "react-window": "^2.2.7",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,15 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
       react-window:
         specifier: ^2.2.7
         version: 2.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@types/node':
         specifier: ^24.13.2
@@ -53,7 +59,7 @@ importers:
         version: 8.1.2(@types/node@24.13.2)(esbuild@0.28.1)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.6(@types/node@24.13.2)(jsdom@29.1.1)(lightningcss@1.32.0)
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.2)(jsdom@29.1.1)(lightningcss@1.32.0)
 
 packages:
 
@@ -984,11 +990,26 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
@@ -1004,6 +1025,15 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
   '@vitejs/plugin-react@6.0.3':
     resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
@@ -1057,6 +1087,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -1064,9 +1097,24 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -1075,6 +1123,9 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
@@ -1105,13 +1156,23 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
@@ -1125,12 +1186,22 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1146,6 +1217,12 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1153,8 +1230,30 @@ packages:
   html-to-image@1.11.13:
     resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-mobile@5.0.0:
     resolution: {integrity: sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -1248,6 +1347,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -1258,8 +1360,140 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1282,6 +1516,9 @@ packages:
       vite-plus:
         optional: true
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
@@ -1303,6 +1540,9 @@ packages:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1315,6 +1555,12 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react-window@2.2.7:
     resolution: {integrity: sha512-SH5nvfUQwGHYyriDUAOt7wfPsfG9Qxd6OdzQxl5oQ4dsSsUicqQvjV7dR+NqZ4coY0fUn3w1jnC5PwzIUWEg5w==}
     peerDependencies:
@@ -1324,6 +1570,18 @@ packages:
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -1356,6 +1614,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -1365,8 +1626,17 @@ packages:
   string-convert@0.2.1:
     resolution: {integrity: sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
@@ -1415,6 +1685,12 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1429,6 +1705,30 @@ packages:
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1573,6 +1873,9 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -2313,9 +2616,27 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
   '@types/estree@1.0.9': {}
+
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@24.13.2':
     dependencies:
@@ -2335,6 +2656,12 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.3': {}
 
   '@vitejs/plugin-react@6.0.3(vite@8.1.2(@types/node@24.13.2)(esbuild@0.28.1))':
     dependencies:
@@ -2441,11 +2768,15 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  bail@2.0.2: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
 
   cac@6.7.14: {}
+
+  ccount@2.0.1: {}
 
   chai@5.3.3:
     dependencies:
@@ -2455,9 +2786,19 @@ snapshots:
       loupe: 3.2.1
       pathval: 2.0.1
 
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
   check-error@2.1.3: {}
 
   clsx@2.1.1: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   compute-scroll-into-view@3.1.1: {}
 
@@ -2483,9 +2824,19 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-eql@5.0.2: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   entities@8.0.0: {}
 
@@ -2520,11 +2871,17 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
 
+  escape-string-regexp@5.0.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
   expect-type@1.4.0: {}
+
+  extend@3.0.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -2532,6 +2889,30 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -2541,7 +2922,24 @@ snapshots:
 
   html-to-image@1.11.13: {}
 
+  html-url-attributes@3.0.1: {}
+
+  inline-style-parser@0.2.7: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
+  is-hexadecimal@2.0.1: {}
+
   is-mobile@5.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -2626,6 +3024,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  longest-streak@3.1.0: {}
+
   loupe@3.2.1: {}
 
   lru-cache@11.5.2: {}
@@ -2634,7 +3034,353 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   mdn-data@2.27.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   ms@2.1.3: {}
 
@@ -2662,6 +3408,16 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.72.0
       '@oxlint/binding-win32-x64-msvc': 1.72.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -2680,6 +3436,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  property-information@7.2.0: {}
+
   punycode@2.3.1: {}
 
   react-dom@19.2.7(react@19.2.7):
@@ -2689,12 +3447,64 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.17
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.7
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react-window@2.2.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
   react@19.2.7: {}
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-from-string@2.0.2: {}
 
@@ -2764,15 +3574,30 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
 
   string-convert@0.2.1: {}
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   stylis@4.4.0: {}
 
@@ -2809,6 +3634,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -2817,6 +3646,49 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici@7.28.0: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-node@3.2.4(@types/node@24.13.2)(lightningcss@1.32.0):
     dependencies:
@@ -2864,7 +3736,7 @@ snapshots:
       esbuild: 0.28.1
       fsevents: 2.3.3
 
-  vitest@3.2.6(@types/node@24.13.2)(jsdom@29.1.1)(lightningcss@1.32.0):
+  vitest@3.2.6(@types/debug@4.1.13)(@types/node@24.13.2)(jsdom@29.1.1)(lightningcss@1.32.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -2890,6 +3762,7 @@ snapshots:
       vite-node: 3.2.4(@types/node@24.13.2)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/debug': 4.1.13
       '@types/node': 24.13.2
       jsdom: 29.1.1
     transitivePeerDependencies:
@@ -2930,3 +3803,5 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  zwitch@2.0.4: {}

--- a/src/components/CustomizationModal.tsx
+++ b/src/components/CustomizationModal.tsx
@@ -12,7 +12,9 @@ import {
 import type { ResidentCampus } from '@/types';
 import BottomModal from './BottomModal';
 import CalculationModePicker from './CalculationModePicker';
-import { PreferenceSwitchVisual } from './onboarding/PreferenceSwitch';
+import {
+  PreferenceToggleButton as PreferenceToggle,
+} from './onboarding/PreferenceSwitch';
 import SelectWithChevron from './SelectWithChevron';
 
 export type CustomizationPage = 'main' | 'blockedSlots' | 'calculationMode';
@@ -27,29 +29,6 @@ interface Props {
   onShowUpdatePopupChange: (show: boolean) => void;
   onOpenUpdateHistory: () => void;
   initialPage?: CustomizationPage;
-}
-
-function PreferenceToggle({
-  checked,
-  label,
-  onChange,
-}: {
-  checked: boolean;
-  label: string;
-  onChange: (checked: boolean) => void;
-}) {
-  return (
-    <button
-      type="button"
-      className="customization__preference-toggle"
-      role="switch"
-      aria-label={label}
-      aria-checked={checked}
-      onClick={() => onChange(!checked)}
-    >
-      <PreferenceSwitchVisual checked={checked} />
-    </button>
-  );
 }
 
 function NavigationRow({

--- a/src/components/MemoMarkdownToolbar.tsx
+++ b/src/components/MemoMarkdownToolbar.tsx
@@ -1,0 +1,85 @@
+import { Button } from 'antd';
+import type { ReactNode } from 'react';
+import { PaperclipIcon } from './icons';
+import type { MemoMarkdownFormat } from '@/memos/markdown';
+
+export type MemoEditorMode = 'edit' | 'preview';
+
+interface Props {
+  mode: MemoEditorMode;
+  activeFormats: ReadonlySet<MemoMarkdownFormat>;
+  recognizeAction: ReactNode;
+  onFormat: (format: MemoMarkdownFormat) => void;
+  onModeChange: (mode: MemoEditorMode) => void;
+}
+
+interface FormatAction {
+  format: MemoMarkdownFormat;
+  label: string;
+  mark: ReactNode;
+}
+
+const FORMAT_ACTIONS: FormatAction[] = [
+  { format: 'heading', label: '标题', mark: 'H' },
+  { format: 'bold', label: '加粗', mark: <strong>B</strong> },
+  { format: 'italic', label: '斜体', mark: <em>I</em> },
+  { format: 'strikethrough', label: '删除线', mark: <s>S</s> },
+  { format: 'unordered-list', label: '无序列表', mark: '•' },
+  { format: 'ordered-list', label: '有序列表', mark: '1.' },
+  { format: 'task-list', label: '待办列表', mark: '☑' },
+  { format: 'blockquote', label: '引用', mark: '❝' },
+  { format: 'inline-code', label: '行内代码', mark: '</>' },
+  {
+    format: 'link',
+    label: '插入链接',
+    mark: <PaperclipIcon />,
+  },
+];
+
+export default function MemoMarkdownToolbar({
+  mode,
+  activeFormats,
+  recognizeAction,
+  onFormat,
+  onModeChange,
+}: Props) {
+  return (
+    <div className="memo-modal__format-toolbar" role="toolbar" aria-label="备忘录格式">
+      <div className="memo-modal__format-actions">
+        {mode === 'edit'
+          ? FORMAT_ACTIONS.map((action) => {
+            const active = activeFormats.has(action.format);
+            return (
+              <Button
+                key={action.format}
+                type="text"
+                size="small"
+                className={`memo-modal__format-button${active ? ' memo-modal__format-button--active' : ''}`}
+                aria-label={action.label}
+                aria-pressed={active}
+                title={action.label}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => onFormat(action.format)}
+              >
+                <span className="memo-modal__format-mark" aria-hidden="true">
+                  {action.mark}
+                </span>
+              </Button>
+            );
+          })
+          : null}
+      </div>
+      <div className="memo-modal__mode-actions" role="group" aria-label="备忘录操作">
+        <Button
+          type="text"
+          size="small"
+          className="memo-modal__mode-button"
+          onClick={() => onModeChange(mode === 'edit' ? 'preview' : 'edit')}
+        >
+          {mode === 'edit' ? '完成' : '编辑'}
+        </Button>
+        {recognizeAction}
+      </div>
+    </div>
+  );
+}

--- a/src/components/MemoModal.test.ts
+++ b/src/components/MemoModal.test.ts
@@ -56,6 +56,16 @@ function findButton(label: string): HTMLButtonElement | undefined {
   );
 }
 
+function findButtonByLabel(label: string): HTMLButtonElement | null {
+  return document.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+}
+
+function findComplexFormatToggle(): HTMLButtonElement {
+  return document.querySelector<HTMLButtonElement>(
+    'button[role="switch"][aria-label="复杂格式"]',
+  )!;
+}
+
 function seedMemos(notes: MemoNote[]): void {
   localStorage.setItem(
     MEMOS_STORAGE_KEY,
@@ -94,6 +104,45 @@ describe('MemoModal', () => {
     expect(document.querySelector('.bottom-modal')).toBeNull();
   });
 
+  it('uses the settings switch beside the title to move between simple and complex editors', async () => {
+    seedMemos([
+      { id: 'note-1', text: '**重点**', updatedAt: 20 },
+    ]);
+    await mount(
+      createElement(MemosProvider, null, createElement(MemoModal, { open: true, onClose: () => {} })),
+    );
+
+    const toggle = document.querySelector<HTMLButtonElement>(
+      'button[role="switch"][aria-label="复杂格式"]',
+    );
+    expect(toggle).toBeTruthy();
+    expect(toggle?.closest('.bottom-modal__title-extra')).toBeTruthy();
+    expect(toggle?.classList.contains('customization__preference-toggle')).toBe(true);
+    expect(toggle?.getAttribute('aria-checked')).toBe('false');
+    expect(toggle?.parentElement?.textContent).toContain('复杂格式');
+    expect(document.querySelector<HTMLTextAreaElement>('.memo-modal__editor')?.value)
+      .toBe('**重点**');
+    expect(document.querySelector('.memo-modal__format-toolbar')).toBeNull();
+    expect(findButton('识别课程')?.closest('.memo-modal__recognize')).toBeTruthy();
+
+    await act(async () => {
+      toggle!.click();
+    });
+
+    expect(toggle?.getAttribute('aria-checked')).toBe('true');
+    expect(document.querySelector('.memo-modal__markdown-preview strong')?.textContent)
+      .toBe('重点');
+    expect(document.querySelector('.memo-modal__editor')).toBeNull();
+    expect(findButton('识别课程')?.closest('.memo-modal__mode-actions')).toBeTruthy();
+
+    await act(async () => {
+      toggle!.click();
+    });
+    expect(document.querySelector<HTMLTextAreaElement>('.memo-modal__editor')?.value)
+      .toBe('**重点**');
+    expect(document.querySelector('.memo-modal__format-toolbar')).toBeNull();
+  });
+
   it('renders a two-pane workspace and selects the newest note', async () => {
     seedMemos([
       { id: 'note-1', text: '第一条备忘录', updatedAt: 1_753_344_000_000 },
@@ -113,6 +162,7 @@ describe('MemoModal', () => {
     expect(deleteButtons).toHaveLength(2);
     expect(document.querySelector<HTMLTextAreaElement>('.memo-modal__editor')?.value)
       .toBe('第一条备忘录');
+    expect(document.querySelector('.memo-modal__markdown-preview')).toBeNull();
     expect(document.querySelector('.memo-modal__nav-item[aria-current="true"]')?.textContent)
       .toContain('第一条备忘录');
     expect(rows[0]?.classList.contains('memo-modal__nav-row--active')).toBe(true);
@@ -131,6 +181,7 @@ describe('MemoModal', () => {
       .toBe(true);
     expect(findButton('添加')).toBeUndefined();
     expect(findButton('编辑')).toBeUndefined();
+    expect(findButton('完成')).toBeUndefined();
     expect(findButton('保存')).toBeUndefined();
     expect(document.querySelector('.memo-modal .bottom-modal__footer')).toBeNull();
   });
@@ -163,16 +214,25 @@ describe('MemoModal', () => {
     expect(editor!.value).toBe('新的选课提醒');
   });
 
-  it('keeps recognition inside the editor surface and enables it after note creation', async () => {
+  it('places recognition after the edit action with the same toolbar button style', async () => {
     await mount(
       createElement(MemosProvider, null, createElement(MemoModal, { open: true, onClose: () => {} })),
     );
 
+    await act(async () => {
+      findComplexFormatToggle().click();
+    });
+
     const recognizeButton = findButton('识别课程');
     expect(recognizeButton).toBeTruthy();
     expect(recognizeButton?.closest('.memo-modal__editor-shell')).toBeTruthy();
-    expect(recognizeButton?.closest('.memo-modal__recognize')).toBeTruthy();
-    expect(recognizeButton?.closest('.memo-modal__toolbar')).toBeNull();
+    const actionGroup = recognizeButton?.closest('.memo-modal__mode-actions');
+    expect(actionGroup?.closest('.memo-modal__format-toolbar')).toBeTruthy();
+    expect(
+      Array.from(actionGroup?.querySelectorAll('button') ?? [], (button) => button.textContent),
+    ).toEqual(['完成', '识别课程']);
+    expect(recognizeButton?.classList.contains('memo-modal__mode-button')).toBe(true);
+    expect(document.querySelector('.memo-modal__recognize')).toBeNull();
     expect(recognizeButton?.disabled).toBe(true);
 
     const editor = document.querySelector<HTMLTextAreaElement>('.memo-modal__editor')!;
@@ -180,6 +240,133 @@ describe('MemoModal', () => {
       setTextareaValue(editor, '001101');
     });
     expect(findButton('识别课程')?.disabled).toBe(false);
+  });
+
+  it('formats the current selection from the top toolbar and saves it immediately', async () => {
+    seedMemos([
+      { id: 'note-1', text: '课程 001101', updatedAt: 20 },
+    ]);
+    await mount(
+      createElement(MemosProvider, null, createElement(MemoModal, { open: true, onClose: () => {} })),
+    );
+
+    await act(async () => {
+      findComplexFormatToggle().click();
+    });
+    await act(async () => {
+      findButton('编辑')!.click();
+    });
+
+    const toolbar = document.querySelector('.memo-modal__format-toolbar');
+    const editor = document.querySelector<HTMLTextAreaElement>('.memo-modal__editor')!;
+    expect(toolbar).toBeTruthy();
+    expect(findButtonByLabel('标题')).toBeTruthy();
+    expect(findButtonByLabel('加粗')).toBeTruthy();
+    expect(findButtonByLabel('斜体')).toBeTruthy();
+    expect(findButtonByLabel('待办列表')).toBeTruthy();
+    expect(findButton('完成')).toBeTruthy();
+
+    editor.focus();
+    editor.setSelectionRange(3, 9);
+    await act(async () => {
+      findButtonByLabel('加粗')!.click();
+    });
+
+    expect(document.querySelector<HTMLTextAreaElement>('.memo-modal__editor')?.value)
+      .toBe('课程 **001101**');
+    expect(readStoredMemos()?.notes[0]?.text).toBe('课程 **001101**');
+
+    expect(findButtonByLabel('加粗')?.getAttribute('aria-pressed')).toBe('true');
+    await act(async () => {
+      findButtonByLabel('加粗')!.click();
+    });
+    expect(document.querySelector<HTMLTextAreaElement>('.memo-modal__editor')?.value)
+      .toBe('课程 001101');
+    expect(readStoredMemos()?.notes[0]?.text).toBe('课程 001101');
+    expect(findButtonByLabel('加粗')?.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('opens saved notes in a safe GFM preview and returns to preview after editing is complete', async () => {
+    seedMemos([
+      {
+        id: 'note-1',
+        text: '**重点**\n- [ ] 记得选课\n<div id="unsafe">内容</div>',
+        updatedAt: 20,
+      },
+    ]);
+    await mount(
+      createElement(MemosProvider, null, createElement(MemoModal, { open: true, onClose: () => {} })),
+    );
+
+    await act(async () => {
+      findComplexFormatToggle().click();
+    });
+
+    const preview = document.querySelector('.memo-modal__markdown-preview');
+    expect(preview?.querySelector('strong')?.textContent).toBe('重点');
+    expect(preview?.querySelector<HTMLInputElement>('input[type="checkbox"]')?.disabled)
+      .toBe(true);
+    expect(preview?.querySelector('#unsafe')).toBeNull();
+    expect(document.querySelector('.memo-modal__editor')).toBeNull();
+
+    await act(async () => {
+      findButton('编辑')!.click();
+    });
+    expect(document.querySelector<HTMLTextAreaElement>('.memo-modal__editor')?.value)
+      .toContain('**重点**');
+
+    await act(async () => {
+      findButton('完成')!.click();
+    });
+    expect(document.querySelector('.memo-modal__editor')).toBeNull();
+    expect(document.querySelector('.memo-modal__markdown-preview strong')?.textContent)
+      .toBe('重点');
+    expect(findButton('编辑')).toBeTruthy();
+    expect(findButton('完成')).toBeUndefined();
+  });
+
+  it('pins favorited memos while preserving order and the current selection', async () => {
+    seedMemos([
+      { id: 'note-1', text: '第一条', updatedAt: 30 },
+      { id: 'note-2', text: '第二条', updatedAt: 20, favorite: true },
+      { id: 'note-3', text: '第三条', updatedAt: 10 },
+    ]);
+    await mount(
+      createElement(MemosProvider, null, createElement(MemoModal, { open: true, onClose: () => {} })),
+    );
+
+    const previews = () => Array.from(
+      document.querySelectorAll('.memo-modal__preview'),
+      (node) => node.textContent,
+    );
+    expect(previews()).toEqual(['第二条', '第一条', '第三条']);
+    expect(document.querySelector('.memo-modal__nav-item[aria-current="true"]')?.textContent)
+      .toContain('第二条');
+    expect(document.querySelectorAll('.memo-modal__nav-favorite')).toHaveLength(3);
+    expect(
+      document.querySelector<HTMLButtonElement>('.memo-modal__nav-favorite')?.getAttribute('aria-pressed'),
+    ).toBe('true');
+
+    await act(async () => {
+      document.querySelector<HTMLButtonElement>(
+        'button[aria-label="收藏备忘录：第三条"]',
+      )!.click();
+    });
+
+    expect(previews()).toEqual(['第二条', '第三条', '第一条']);
+    expect(document.querySelector('.memo-modal__nav-item[aria-current="true"]')?.textContent)
+      .toContain('第二条');
+    expect(readStoredMemos()?.notes.find((note) => note.id === 'note-3')?.favorite)
+      .toBe(true);
+
+    await act(async () => {
+      document.querySelector<HTMLButtonElement>(
+        'button[aria-label="取消收藏备忘录：第三条"]',
+      )!.click();
+    });
+    expect(previews()).toEqual(['第二条', '第一条', '第三条']);
+    expect(readStoredMemos()?.notes.find((note) => note.id === 'note-3')?.favorite)
+      .toBeUndefined();
   });
 
   it('persists edits immediately and labels a cleared note as blank', async () => {
@@ -285,11 +472,29 @@ describe('MemoModal', () => {
     const navDeleteRule = cssSource.match(
       /\.memo-modal__nav-delete\s*\{([^}]*)\}/,
     )?.[1] ?? '';
+    const modeButtonRule = cssSource.match(
+      /#root \.memo-modal \.memo-modal__mode-button\.ant-btn\s*\{([^}]*)\}/,
+    )?.[1] ?? '';
+    const simpleEditorRule = cssSource.match(
+      /\.memo-modal__editor--simple\s*\{([^}]*)\}/,
+    )?.[1] ?? '';
     const recognizeButtonRule = cssSource.match(
       /#root \.memo-modal \.memo-modal__recognize \.ant-btn\s*\{([^}]*)\}/,
     )?.[1] ?? '';
-    const focusRule = cssSource.match(
-      /\.memo-modal__editor:focus,\s*\.memo-modal__editor:focus-visible\s*\{([^}]*)\}/,
+    const editorShellRule = cssSource.match(
+      /\.memo-modal__editor-shell\s*\{([^}]*)\}/,
+    )?.[1] ?? '';
+    const shellFocusRule = cssSource.match(
+      /\.memo-modal__editor-shell:focus-within\s*\{([^}]*)\}/,
+    )?.[1] ?? '';
+    const toolbarRule = cssSource.match(
+      /\.memo-modal__format-toolbar\s*\{([^}]*)\}/,
+    )?.[1] ?? '';
+    const editorRule = cssSource.match(
+      /\.memo-modal__editor\s*\{([^}]*)\}/,
+    )?.[1] ?? '';
+    const previewRule = cssSource.match(
+      /\.memo-modal__markdown-preview\s*\{([^}]*)\}/,
     )?.[1] ?? '';
     const mobileRule = cssSource.match(
       /@media \(max-width: 640px\)\s*\{([\s\S]*?)\n\}/,
@@ -315,18 +520,29 @@ describe('MemoModal', () => {
     expect(cssSource).toMatch(
       /\.memo-modal__editor-shell\s*\{[^}]*position:\s*relative;/,
     );
+    expect(editorShellRule).toContain('display: flex');
+    expect(editorShellRule).toContain('border: 1px solid var(--border)');
+    expect(editorShellRule).toContain('border-radius: var(--radius-xl)');
+    expect(editorShellRule).toContain('overflow: hidden');
+    expect(shellFocusRule).toContain('border-color: var(--accent)');
+    expect(shellFocusRule).toContain('box-shadow: none');
+    expect(toolbarRule).toContain('border-bottom: 1px solid var(--border)');
+    expect(editorRule).toContain('border: 0');
+    expect(previewRule).toContain('overflow: auto');
+    expect(cssSource).toMatch(
+      /\.memo-modal__format-actions\s*\{[^}]*overflow-x:\s*auto;/,
+    );
+    expect(simpleEditorRule).toContain('border: 1px solid var(--border)');
+    expect(simpleEditorRule).toContain('border-radius: var(--radius-xl)');
     expect(cssSource).toMatch(
       /\.memo-modal__recognize\s*\{[^}]*position:\s*absolute;[^}]*right:[^;]+;[^}]*bottom:[^;]+;/,
     );
     expect(cssSource).not.toMatch(/#root \.memo-modal__(?:new|nav-delete|recognize)/);
     expect(cssSource).toMatch(/\.memo-modal \.memo-modal__new\.ant-btn\s*\{/);
-    expect(cssSource).toMatch(/\.memo-modal \.memo-modal__recognize \.ant-btn\s*\{/);
-    expect(recognizeButtonRule).toContain('min-height: 30px');
-    expect(recognizeButtonRule).toContain('padding-inline: 14px');
-    expect(focusRule).toContain('outline: 0');
-    expect(focusRule).toContain('box-shadow: none');
-    expect(focusRule).toContain('border-color: var(--accent)');
-    expect(focusRule).toContain('border-radius: var(--radius-xl)');
+    expect(modeButtonRule).toContain('min-height: 28px');
+    expect(modeButtonRule).toContain('padding-inline: 10px');
+    expect(recognizeButtonRule).toContain('min-height: 38px');
+    expect(recognizeButtonRule).toContain('padding-inline: 18px');
     expect(sidebarRule).not.toContain('border-right');
     expect(cssSource).toMatch(
       /@media \(max-width: 640px\)\s*\{[\s\S]*?\.memo-modal__body\s*\{[^}]*grid-template-columns:\s*1fr;/,

--- a/src/components/MemoModal.tsx
+++ b/src/components/MemoModal.tsx
@@ -1,8 +1,30 @@
 import { Button } from 'antd';
-import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import BottomModal from './BottomModal';
+import { FavoriteButton } from './FavoriteButton';
 import { PlusIcon, TrashIcon } from './icons';
+import MemoMarkdownToolbar, { type MemoEditorMode } from './MemoMarkdownToolbar';
 import MemoRecognizeButton from './MemoRecognizeButton';
+import { PreferenceToggleButton } from './onboarding/PreferenceSwitch';
+import {
+  applyMemoMarkdownFormat,
+  continueMemoOrderedList,
+  isMemoMarkdownFormatActive,
+  MEMO_MARKDOWN_FORMATS,
+  normalizeMemoOrderedLists,
+  type MemoMarkdownEdit,
+  type MemoMarkdownFormat,
+} from '@/memos/markdown';
 import { useMemos } from '@/memos/MemosContext';
 import type { MemoNote } from '@/types';
 
@@ -29,19 +51,49 @@ function memoUpdatedAt(updatedAt: number): string | null {
 }
 
 export default function MemoModal({ open, onClose }: Props) {
-  const { notes, addNote, updateNote, removeNote } = useMemos();
-  const initialNote = notes[0] ?? null;
+  const { notes, addNote, updateNote, toggleFavorite, removeNote } = useMemos();
+  const orderedNotes = useMemo(
+    () => notes
+      .map((note, index) => ({ note, index }))
+      .sort(
+        (left, right) => (
+          Number(Boolean(right.note.favorite)) - Number(Boolean(left.note.favorite))
+          || left.index - right.index
+        ),
+      )
+      .map(({ note }) => note),
+    [notes],
+  );
+  const initialNote = orderedNotes[0] ?? null;
   const [selectedId, setSelectedId] = useState<string | null>(initialNote?.id ?? null);
   const [creating, setCreating] = useState(initialNote === null);
   const [editorText, setEditorText] = useState(initialNote?.text ?? '');
+  const [editorMode, setEditorMode] = useState<MemoEditorMode>(
+    initialNote ? 'preview' : 'edit',
+  );
+  const [complexFormat, setComplexFormat] = useState(false);
+  const [editorSelection, setEditorSelection] = useState({ start: 0, end: 0 });
   const [deleteTarget, setDeleteTarget] = useState<MemoNote | null>(null);
   const wasOpenRef = useRef(false);
   const newNoteRequestedRef = useRef(false);
   const pendingNewTextRef = useRef<string | null>(null);
+  const editorRef = useRef<HTMLTextAreaElement>(null);
+  const pendingSelectionRef = useRef<{ start: number; end: number } | null>(null);
 
   const activeNote = useMemo(
     () => (creating ? null : notes.find((note) => note.id === selectedId) ?? null),
     [creating, notes, selectedId],
+  );
+  const activeFormats = useMemo(
+    () => new Set(
+      MEMO_MARKDOWN_FORMATS.filter((format) => isMemoMarkdownFormatActive(
+        editorText,
+        editorSelection.start,
+        editorSelection.end,
+        format,
+      )),
+    ),
+    [editorSelection.end, editorSelection.start, editorText],
   );
 
   useEffect(() => {
@@ -53,14 +105,17 @@ export default function MemoModal({ open, onClose }: Props) {
     }
     if (wasOpen) return;
 
-    const firstNote = notes[0] ?? null;
+    const firstNote = orderedNotes[0] ?? null;
     setCreating(firstNote === null);
     setSelectedId(firstNote?.id ?? null);
     setEditorText(firstNote?.text ?? '');
+    setEditorMode(firstNote ? 'preview' : 'edit');
+    setEditorSelection({ start: 0, end: 0 });
     newNoteRequestedRef.current = false;
     pendingNewTextRef.current = null;
+    pendingSelectionRef.current = null;
     setDeleteTarget(null);
-  }, [notes, open]);
+  }, [open, orderedNotes]);
 
   useEffect(() => {
     if (!newNoteRequestedRef.current) return;
@@ -73,29 +128,44 @@ export default function MemoModal({ open, onClose }: Props) {
     setCreating(false);
     setSelectedId(createdNote.id);
     setEditorText(pendingText);
+    setEditorSelection({ start: pendingText.length, end: pendingText.length });
     if (pendingText !== createdNote.text) {
       updateNote(createdNote.id, pendingText);
     }
   }, [notes, updateNote]);
 
+  useLayoutEffect(() => {
+    const pendingSelection = pendingSelectionRef.current;
+    if (!pendingSelection || editorMode !== 'edit' || !editorRef.current) return;
+    editorRef.current.focus();
+    editorRef.current.setSelectionRange(pendingSelection.start, pendingSelection.end);
+    setEditorSelection(pendingSelection);
+    pendingSelectionRef.current = null;
+  }, [editorMode, editorText]);
+
   const startNewNote = () => {
     newNoteRequestedRef.current = false;
     pendingNewTextRef.current = null;
+    pendingSelectionRef.current = null;
     setCreating(true);
     setSelectedId(null);
     setEditorText('');
+    setEditorMode('edit');
+    setEditorSelection({ start: 0, end: 0 });
   };
 
   const selectNote = (note: MemoNote) => {
     newNoteRequestedRef.current = false;
     pendingNewTextRef.current = null;
+    pendingSelectionRef.current = null;
     setCreating(false);
     setSelectedId(note.id);
     setEditorText(note.text);
+    setEditorMode('preview');
+    setEditorSelection({ start: 0, end: 0 });
   };
 
-  const handleEditorChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
-    const text = event.target.value;
+  const commitEditorText = (text: string) => {
     setEditorText(text);
 
     if (creating) {
@@ -110,9 +180,110 @@ export default function MemoModal({ open, onClose }: Props) {
     if (selectedId) updateNote(selectedId, text);
   };
 
+  const handleEditorChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    commitEditorText(event.target.value);
+    setEditorSelection({
+      start: event.target.selectionStart,
+      end: event.target.selectionEnd,
+    });
+  };
+
+  const commitMarkdownEdit = (edit: MemoMarkdownEdit) => {
+    pendingSelectionRef.current = {
+      start: edit.selectionStart,
+      end: edit.selectionEnd,
+    };
+    setEditorSelection({
+      start: edit.selectionStart,
+      end: edit.selectionEnd,
+    });
+    commitEditorText(edit.text);
+  };
+
+  const handleComplexEditorChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const edit = normalizeMemoOrderedLists(
+      event.target.value,
+      event.target.selectionStart,
+      event.target.selectionEnd,
+    );
+    if (edit.text !== event.target.value) {
+      pendingSelectionRef.current = {
+        start: edit.selectionStart,
+        end: edit.selectionEnd,
+      };
+    }
+    setEditorSelection({
+      start: edit.selectionStart,
+      end: edit.selectionEnd,
+    });
+    commitEditorText(edit.text);
+  };
+
+  const handleComplexEditorKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (
+      event.key !== 'Enter'
+      || event.shiftKey
+      || event.ctrlKey
+      || event.metaKey
+      || event.altKey
+      || event.nativeEvent.isComposing
+    ) {
+      return;
+    }
+
+    const edit = continueMemoOrderedList(
+      editorText,
+      event.currentTarget.selectionStart,
+      event.currentTarget.selectionEnd,
+    );
+    if (!edit) return;
+
+    event.preventDefault();
+    commitMarkdownEdit(edit);
+  };
+
+  const handleFormat = (format: MemoMarkdownFormat) => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const edit = applyMemoMarkdownFormat(
+      editorText,
+      editor.selectionStart,
+      editor.selectionEnd,
+      format,
+    );
+    commitMarkdownEdit(edit);
+  };
+
+  const syncEditorSelection = () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    setEditorSelection({
+      start: editor.selectionStart,
+      end: editor.selectionEnd,
+    });
+  };
+
+  const handleComplexFormatChange = (checked: boolean) => {
+    pendingSelectionRef.current = null;
+    setComplexFormat(checked);
+    if (checked) setEditorMode(creating ? 'edit' : 'preview');
+  };
+
+  const handleEditorModeChange = (mode: MemoEditorMode) => {
+    if (mode === 'edit') {
+      const edit = normalizeMemoOrderedLists(
+        editorText,
+        editorSelection.start,
+        editorSelection.end,
+      );
+      if (edit.text !== editorText) commitMarkdownEdit(edit);
+    }
+    setEditorMode(mode);
+  };
+
   const deleteNote = (note: MemoNote) => {
-    const noteIndex = notes.findIndex((candidate) => candidate.id === note.id);
-    const remaining = notes.filter((candidate) => candidate.id !== note.id);
+    const noteIndex = orderedNotes.findIndex((candidate) => candidate.id === note.id);
+    const remaining = orderedNotes.filter((candidate) => candidate.id !== note.id);
     removeNote(note.id);
 
     if (activeNote?.id !== note.id) return;
@@ -136,6 +307,16 @@ export default function MemoModal({ open, onClose }: Props) {
       <BottomModal
         open={open}
         title="备忘录"
+        titleExtra={(
+          <div className="memo-modal__format-toggle">
+            <span className="memo-modal__format-toggle-label">复杂格式</span>
+            <PreferenceToggleButton
+              checked={complexFormat}
+              label="复杂格式"
+              onChange={handleComplexFormatChange}
+            />
+          </div>
+        )}
         onClose={onClose}
         width={900}
         className="memo-modal"
@@ -150,7 +331,7 @@ export default function MemoModal({ open, onClose }: Props) {
               新建备忘录
             </Button>
             <ul className="memo-modal__nav">
-              {notes.map((note) => {
+              {orderedNotes.map((note) => {
                 const active = !creating && note.id === selectedId;
                 const updatedAt = memoUpdatedAt(note.updatedAt);
                 const preview = memoPreview(note.text);
@@ -170,6 +351,12 @@ export default function MemoModal({ open, onClose }: Props) {
                       </span>
                       {updatedAt ? <time dateTime={new Date(note.updatedAt).toISOString()}>{updatedAt}</time> : null}
                     </button>
+                    <FavoriteButton
+                      active={Boolean(note.favorite)}
+                      label={`${note.favorite ? '取消收藏' : '收藏'}备忘录：${preview}`}
+                      className="memo-modal__nav-favorite"
+                      onToggle={() => toggleFavorite(note.id)}
+                    />
                     <button
                       type="button"
                       className="memo-modal__nav-delete"
@@ -195,20 +382,70 @@ export default function MemoModal({ open, onClose }: Props) {
           </aside>
 
           <section className="memo-modal__workspace" aria-label="备忘录编辑区">
-            <div className="memo-modal__editor-shell">
-              <textarea
-                className="memo-modal__editor"
-                aria-label="备忘录内容"
-                placeholder="在此键入以创建新的备忘录…"
-                value={editorText}
-                onChange={handleEditorChange}
-              />
-              <div className="memo-modal__recognize">
-                <MemoRecognizeButton
-                  noteText={editorText}
-                  disabled={!activeNote || !editorText.trim()}
-                />
-              </div>
+            <div
+              className={`memo-modal__editor-shell memo-modal__editor-shell--${complexFormat ? 'complex' : 'simple'}`}
+            >
+              {complexFormat ? (
+                <>
+                  <MemoMarkdownToolbar
+                    mode={editorMode}
+                    activeFormats={activeFormats}
+                    recognizeAction={(
+                      <MemoRecognizeButton
+                        noteText={editorText}
+                        disabled={!activeNote || !editorText.trim()}
+                        className="memo-modal__mode-button"
+                        variant="text"
+                      />
+                    )}
+                    onFormat={handleFormat}
+                    onModeChange={handleEditorModeChange}
+                  />
+                  {editorMode === 'edit' ? (
+                    <textarea
+                      ref={editorRef}
+                      className="memo-modal__editor"
+                      aria-label="备忘录内容"
+                      placeholder="在此键入以创建新的备忘录…"
+                      value={editorText}
+                      onChange={handleComplexEditorChange}
+                      onKeyDown={handleComplexEditorKeyDown}
+                      onSelect={syncEditorSelection}
+                    />
+                  ) : (
+                    <div
+                      className="memo-modal__markdown-preview"
+                      aria-label="备忘录预览"
+                    >
+                      {editorText.trim() ? (
+                        <ReactMarkdown remarkPlugins={[remarkGfm]} skipHtml>
+                          {editorText}
+                        </ReactMarkdown>
+                      ) : (
+                        <p className="memo-modal__markdown-empty">暂无内容</p>
+                      )}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <>
+                  <textarea
+                    ref={editorRef}
+                    className="memo-modal__editor memo-modal__editor--simple"
+                    aria-label="备忘录内容"
+                    placeholder="在此键入以创建新的备忘录…"
+                    value={editorText}
+                    onChange={handleEditorChange}
+                    onSelect={syncEditorSelection}
+                  />
+                  <div className="memo-modal__recognize">
+                    <MemoRecognizeButton
+                      noteText={editorText}
+                      disabled={!activeNote || !editorText.trim()}
+                    />
+                  </div>
+                </>
+              )}
             </div>
           </section>
         </div>

--- a/src/components/MemoRecognizeButton.tsx
+++ b/src/components/MemoRecognizeButton.tsx
@@ -1,4 +1,4 @@
-import { Button, message } from 'antd';
+import { Button, message, type ButtonProps } from 'antd';
 import { useState } from 'react';
 import { useSemesterCatalog } from '@/data/SemesterCatalogContext';
 import { usePlans } from '@/store/plansContext';
@@ -8,9 +8,16 @@ import MemoRecognizeModal from './MemoRecognizeModal';
 interface Props {
   noteText: string;
   disabled?: boolean;
+  className?: string;
+  variant?: ButtonProps['type'];
 }
 
-export default function MemoRecognizeButton({ noteText, disabled = false }: Props) {
+export default function MemoRecognizeButton({
+  noteText,
+  disabled = false,
+  className,
+  variant,
+}: Props) {
   const { dispatch } = usePlans();
   const { courseMap, groupsByCode } = useSemesterCatalog();
   const [open, setOpen] = useState(false);
@@ -32,7 +39,15 @@ export default function MemoRecognizeButton({ noteText, disabled = false }: Prop
 
   return (
     <>
-      <Button size="small" disabled={disabled} onClick={handleRecognize}>识别课程</Button>
+      <Button
+        type={variant}
+        size="small"
+        className={className}
+        disabled={disabled}
+        onClick={handleRecognize}
+      >
+        识别课程
+      </Button>
       <MemoRecognizeModal
         open={open}
         refs={refs}

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -184,6 +184,20 @@ export function ExternalLinkIcon(props: IconProps) {
   );
 }
 
+export function PaperclipIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" {...props}>
+      <path
+        d="m20.35 11.65-8.7 8.7a5.5 5.5 0 0 1-7.78-7.78l9.05-9.05a3.75 3.75 0 0 1 5.3 5.3l-9.05 9.05a2 2 0 0 1-2.83-2.83l8.7-8.7"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 export function GearIcon(props: IconProps) {
   return (
     <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" {...props}>

--- a/src/components/onboarding/PreferenceSwitch.tsx
+++ b/src/components/onboarding/PreferenceSwitch.tsx
@@ -6,11 +6,36 @@ interface Props {
   onChange: (checked: boolean) => void;
 }
 
+interface PreferenceToggleButtonProps {
+  checked: boolean;
+  label: string;
+  onChange: (checked: boolean) => void;
+}
+
 export function PreferenceSwitchVisual({ checked }: Pick<Props, 'checked'>) {
   return (
     <span className={`onboarding-preference__switch${checked ? ' onboarding-preference__switch--checked' : ''}`}>
       <span className="onboarding-preference__thumb" />
     </span>
+  );
+}
+
+export function PreferenceToggleButton({
+  checked,
+  label,
+  onChange,
+}: PreferenceToggleButtonProps) {
+  return (
+    <button
+      type="button"
+      className="customization__preference-toggle"
+      role="switch"
+      aria-label={label}
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+    >
+      <PreferenceSwitchVisual checked={checked} />
+    </button>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -766,6 +766,44 @@ html {
   display: inline-flex;
 }
 
+.memo-modal__format-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: 4px;
+}
+
+.memo-modal__format-toggle-label {
+  color: var(--text-sub);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.memo-modal__format-toggle .customization__preference-toggle {
+  flex-basis: 28px;
+  width: 28px;
+  height: 16px;
+}
+
+.memo-modal__format-toggle .onboarding-preference__switch {
+  flex-basis: 28px;
+  width: 28px;
+  height: 16px;
+}
+
+.memo-modal__format-toggle .onboarding-preference__thumb {
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+}
+
+.memo-modal__format-toggle
+  .onboarding-preference__switch--checked
+  .onboarding-preference__thumb {
+  transform: translateX(12px);
+}
+
 .memo-modal__new svg {
   width: 16px;
   height: 16px;
@@ -789,7 +827,7 @@ html {
   width: 100%;
   min-width: 0;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 30px;
+  grid-template-columns: minmax(0, 1fr) 28px 30px;
   align-items: center;
   border: 1px solid transparent;
   border-radius: var(--radius-lg);
@@ -825,6 +863,14 @@ html {
   outline: 0;
 }
 
+.memo-modal__nav-favorite {
+  width: 26px;
+  height: 26px;
+  justify-self: end;
+  opacity: 0;
+  transition: opacity 0.14s ease, background-color 0.14s ease, color 0.14s ease;
+}
+
 .memo-modal__nav-delete {
   width: 26px;
   height: 26px;
@@ -849,9 +895,14 @@ html {
   height: 17px;
 }
 
+.memo-modal__nav-row--active .memo-modal__nav-favorite,
 .memo-modal__nav-row--active .memo-modal__nav-delete,
+.memo-modal__nav-row:hover .memo-modal__nav-favorite,
 .memo-modal__nav-row:hover .memo-modal__nav-delete,
+.memo-modal__nav-row:focus-within .memo-modal__nav-favorite,
 .memo-modal__nav-row:focus-within .memo-modal__nav-delete,
+.memo-modal__nav-favorite.favorite-button--active,
+.memo-modal__nav-favorite:focus-visible,
 .memo-modal__nav-delete:focus-visible {
   opacity: 1;
 }
@@ -895,22 +946,124 @@ html {
   flex: 1;
   min-width: 0;
   min-height: 0;
-}
-
-.memo-modal__editor {
-  display: block;
-  width: 100%;
-  height: 100%;
-  min-height: 0;
-  resize: none;
-  padding: 14px 16px 52px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   border: 1px solid var(--border);
   border-radius: var(--radius-xl);
   background: var(--panel-bg-2);
+  transition: none;
+}
+
+.memo-modal__editor-shell:focus-within {
+  border-color: var(--accent);
+  box-shadow: none;
+}
+
+.memo-modal__editor-shell--simple {
+  overflow: visible;
+  border-width: 0;
+  border-style: solid;
+  border-color: var(--border);
+  border-radius: 0;
+  background: transparent;
+  transition: none;
+}
+
+.memo-modal__editor-shell--simple:focus-within {
+  border-color: var(--border);
+}
+
+.memo-modal__format-toolbar {
+  flex: 0 0 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--text) 2%, var(--panel-bg));
+}
+
+.memo-modal__format-actions {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.memo-modal__format-actions::-webkit-scrollbar {
+  display: none;
+}
+
+#root .memo-modal .memo-modal__format-button.ant-btn {
+  flex: 0 0 auto;
+  width: 28px;
+  min-width: 28px;
+  min-height: 28px;
+  padding: 0;
+  border-radius: var(--radius-sm);
+  color: var(--text-sub);
+}
+
+#root .memo-modal .memo-modal__format-button.ant-btn:not(:disabled):hover,
+#root .memo-modal .memo-modal__format-button.ant-btn:not(:disabled):focus-visible {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+#root .memo-modal .memo-modal__format-button--active.ant-btn {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.memo-modal__format-mark {
+  min-width: 15px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: inherit;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.memo-modal__format-mark svg {
+  width: 15px;
+  height: 15px;
+}
+
+.memo-modal__mode-actions {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+#root .memo-modal .memo-modal__mode-button.ant-btn {
+  min-height: 28px;
+  padding-inline: 10px;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+}
+
+.memo-modal__editor {
+  flex: 1;
+  display: block;
+  width: 100%;
+  height: auto;
+  min-height: 0;
+  resize: none;
+  padding: 14px 16px 52px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--text);
   font: inherit;
   line-height: 1.65;
-  transition: border-color 0.16s ease;
+  appearance: none;
 }
 
 .memo-modal__editor::placeholder {
@@ -921,8 +1074,142 @@ html {
 .memo-modal__editor:focus-visible {
   outline: 0;
   box-shadow: none;
+}
+
+.memo-modal__editor--simple {
+  height: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--panel-bg-2);
+  transition: border-color 0.16s ease;
+}
+
+.memo-modal__editor--simple:focus,
+.memo-modal__editor--simple:focus-visible {
   border-color: var(--accent);
   border-radius: var(--radius-xl);
+}
+
+.memo-modal__markdown-preview {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  padding: 14px 16px 58px;
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.65;
+  overflow-wrap: anywhere;
+}
+
+.memo-modal__markdown-preview > :first-child {
+  margin-top: 0;
+}
+
+.memo-modal__markdown-preview > :last-child {
+  margin-bottom: 0;
+}
+
+.memo-modal__markdown-preview h1,
+.memo-modal__markdown-preview h2,
+.memo-modal__markdown-preview h3 {
+  margin: 1.15em 0 0.5em;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.memo-modal__markdown-preview h1 {
+  font-size: 1.65em;
+}
+
+.memo-modal__markdown-preview h2 {
+  font-size: 1.4em;
+}
+
+.memo-modal__markdown-preview h3 {
+  font-size: 1.18em;
+}
+
+.memo-modal__markdown-preview p,
+.memo-modal__markdown-preview ul,
+.memo-modal__markdown-preview ol,
+.memo-modal__markdown-preview blockquote,
+.memo-modal__markdown-preview pre,
+.memo-modal__markdown-preview table {
+  margin: 0 0 0.85em;
+}
+
+.memo-modal__markdown-preview ul,
+.memo-modal__markdown-preview ol {
+  padding-left: 1.7em;
+}
+
+.memo-modal__markdown-preview li + li {
+  margin-top: 0.2em;
+}
+
+.memo-modal__markdown-preview .contains-task-list {
+  padding-left: 0;
+  list-style: none;
+}
+
+.memo-modal__markdown-preview .task-list-item {
+  list-style: none;
+}
+
+.memo-modal__markdown-preview input[type='checkbox'] {
+  margin: 0 0.45em 0 0;
+  accent-color: var(--accent);
+}
+
+.memo-modal__markdown-preview blockquote {
+  padding: 0.15em 0 0.15em 0.9em;
+  border-left: 3px solid var(--border-strong);
+  color: var(--text-sub);
+}
+
+.memo-modal__markdown-preview code {
+  padding: 0.12em 0.35em;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--text) 7%, transparent);
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 0.92em;
+}
+
+.memo-modal__markdown-preview pre {
+  overflow: auto;
+  padding: 11px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--text) 4%, var(--panel-bg));
+}
+
+.memo-modal__markdown-preview pre code {
+  padding: 0;
+  background: transparent;
+}
+
+.memo-modal__markdown-preview a {
+  color: var(--accent-strong);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+}
+
+.memo-modal__markdown-preview table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.memo-modal__markdown-preview th,
+.memo-modal__markdown-preview td {
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  text-align: left;
+}
+
+.memo-modal__markdown-empty {
+  margin: 0;
+  color: var(--text-faint);
 }
 
 .memo-modal__recognize {
@@ -1077,6 +1364,10 @@ html {
   }
 
   .memo-modal__editor {
+    min-height: 272px;
+  }
+
+  .memo-modal__markdown-preview {
     min-height: 272px;
   }
 

--- a/src/memos/MemosContext.test.ts
+++ b/src/memos/MemosContext.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 });
 
 describe('MemosContext', () => {
-  it('addNote / updateNote / removeNote mutate notes', async () => {
+  it('addNote / updateNote / toggleFavorite / removeNote mutate notes', async () => {
     await mount(createElement(MemosProvider, null, createElement(Consumer)));
     expect(captured!.notes).toEqual([]);
 
@@ -44,6 +44,11 @@ describe('MemosContext', () => {
       captured!.updateNote(id, 'world');
     });
     expect(captured!.notes[0].text).toBe('world');
+
+    await act(async () => {
+      captured!.toggleFavorite(id);
+    });
+    expect(captured!.notes[0].favorite).toBe(true);
 
     await act(async () => {
       captured!.removeNote(id);

--- a/src/memos/MemosContext.tsx
+++ b/src/memos/MemosContext.tsx
@@ -14,6 +14,7 @@ import {
   loadMemos,
   removeNote,
   saveMemos,
+  toggleNoteFavorite,
   updateNoteText,
 } from './memos';
 
@@ -21,6 +22,7 @@ export interface MemosContextValue {
   notes: MemoNote[];
   addNote: (text: string) => void;
   updateNote: (id: string, text: string) => void;
+  toggleFavorite: (id: string) => void;
   removeNote: (id: string) => void;
 }
 
@@ -63,14 +65,23 @@ export function MemosProvider({ children }: MemosProviderProps) {
     saveMemos(next);
   }, []);
 
+  const toggleFavorite = useCallback((id: string) => {
+    const next = toggleNoteFavorite(latestStateRef.current, id);
+    if (next === latestStateRef.current) return;
+    latestStateRef.current = next;
+    setState(next);
+    saveMemos(next);
+  }, []);
+
   const value = useMemo<MemosContextValue>(
     () => ({
       notes: state.notes,
       addNote: addNoteCallback,
       updateNote,
+      toggleFavorite,
       removeNote: removeNoteCallback,
     }),
-    [addNoteCallback, removeNoteCallback, state.notes, updateNote],
+    [addNoteCallback, removeNoteCallback, state.notes, toggleFavorite, updateNote],
   );
 
   return <MemosContext.Provider value={value}>{children}</MemosContext.Provider>;

--- a/src/memos/markdown.test.ts
+++ b/src/memos/markdown.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyMemoMarkdownFormat,
+  continueMemoOrderedList,
+  isMemoMarkdownFormatActive,
+  normalizeMemoOrderedLists,
+} from './markdown';
+
+describe('applyMemoMarkdownFormat', () => {
+  it('wraps the selected text and keeps the inner text selected', () => {
+    expect(applyMemoMarkdownFormat('课程 001101', 3, 9, 'bold')).toEqual({
+      text: '课程 **001101**',
+      selectionStart: 5,
+      selectionEnd: 11,
+    });
+  });
+
+  it('inserts a replaceable Chinese placeholder when the selection is empty', () => {
+    expect(applyMemoMarkdownFormat('', 0, 0, 'bold')).toEqual({
+      text: '**加粗文字**',
+      selectionStart: 2,
+      selectionEnd: 6,
+    });
+  });
+
+  it('formats every selected line as an unordered list', () => {
+    expect(applyMemoMarkdownFormat('第一行\n第二行', 0, 7, 'unordered-list')).toEqual({
+      text: '- 第一行\n- 第二行',
+      selectionStart: 0,
+      selectionEnd: 11,
+    });
+  });
+
+  it('continues numbering when an ordered item is formatted after an existing item', () => {
+    expect(applyMemoMarkdownFormat('1. first\nsecond', 9, 15, 'ordered-list')).toEqual({
+      text: '1. first\n2. second',
+      selectionStart: 9,
+      selectionEnd: 18,
+    });
+  });
+
+  it('formats every selected line as a task list', () => {
+    expect(applyMemoMarkdownFormat('选课\n退课', 0, 5, 'task-list')).toEqual({
+      text: '- [ ] 选课\n- [ ] 退课',
+      selectionStart: 0,
+      selectionEnd: 17,
+    });
+  });
+
+  it('inserts a link and selects its URL placeholder', () => {
+    expect(applyMemoMarkdownFormat('官网', 0, 2, 'link')).toEqual({
+      text: '[官网](https://)',
+      selectionStart: 5,
+      selectionEnd: 13,
+    });
+  });
+
+  it('removes an inline format when the same action is applied again', () => {
+    const formatted = applyMemoMarkdownFormat('课程 001101', 3, 9, 'bold');
+
+    expect(
+      applyMemoMarkdownFormat(
+        formatted.text,
+        formatted.selectionStart,
+        formatted.selectionEnd,
+        'bold',
+      ),
+    ).toEqual({
+      text: '课程 001101',
+      selectionStart: 3,
+      selectionEnd: 9,
+    });
+  });
+
+  it('removes a line format when all selected lines already use it', () => {
+    const formatted = applyMemoMarkdownFormat('选课\n退课', 0, 5, 'task-list');
+
+    expect(
+      applyMemoMarkdownFormat(
+        formatted.text,
+        formatted.selectionStart,
+        formatted.selectionEnd,
+        'task-list',
+      ),
+    ).toEqual({
+      text: '选课\n退课',
+      selectionStart: 0,
+      selectionEnd: 5,
+    });
+  });
+
+  it('removes a generated link when its URL is selected and link is applied again', () => {
+    const formatted = applyMemoMarkdownFormat('官网', 0, 2, 'link');
+
+    expect(
+      applyMemoMarkdownFormat(
+        formatted.text,
+        formatted.selectionStart,
+        formatted.selectionEnd,
+        'link',
+      ),
+    ).toEqual({
+      text: '官网',
+      selectionStart: 0,
+      selectionEnd: 2,
+    });
+  });
+});
+
+describe('normalizeMemoOrderedLists', () => {
+  it('replaces repeated markdown list markers with visible sequential numbers', () => {
+    expect(normalizeMemoOrderedLists('1. first\n1. second\n1. third', 27, 27)).toEqual({
+      text: '1. first\n2. second\n3. third',
+      selectionStart: 27,
+      selectionEnd: 27,
+    });
+  });
+
+  it('keeps a custom starting number and adjusts the selection for wider numbers', () => {
+    expect(normalizeMemoOrderedLists('9. a\n9. b\n9. c', 14, 14)).toEqual({
+      text: '9. a\n10. b\n11. c',
+      selectionStart: 16,
+      selectionEnd: 16,
+    });
+  });
+});
+
+describe('continueMemoOrderedList', () => {
+  it('inserts the next visible number when Enter is pressed in an ordered item', () => {
+    expect(continueMemoOrderedList('1. 第一项', 6, 6)).toEqual({
+      text: '1. 第一项\n2. ',
+      selectionStart: 10,
+      selectionEnd: 10,
+    });
+  });
+
+  it('renumbers following items when a new item is inserted in the middle', () => {
+    expect(continueMemoOrderedList('1. abcd\n2. next', 5, 5)).toEqual({
+      text: '1. ab\n2. cd\n3. next',
+      selectionStart: 9,
+      selectionEnd: 9,
+    });
+  });
+
+  it('exits the ordered list when Enter is pressed on an empty item', () => {
+    expect(continueMemoOrderedList('1. 第一项\n2. ', 10, 10)).toEqual({
+      text: '1. 第一项\n',
+      selectionStart: 7,
+      selectionEnd: 7,
+    });
+  });
+});
+
+describe('isMemoMarkdownFormatActive', () => {
+  it('detects the inline format surrounding the selection without confusing bold for italic', () => {
+    expect(isMemoMarkdownFormatActive('课程 **001101**', 5, 11, 'bold')).toBe(true);
+    expect(isMemoMarkdownFormatActive('课程 **001101**', 5, 11, 'italic')).toBe(false);
+  });
+
+  it('detects a formatted line and a generated link selection', () => {
+    expect(isMemoMarkdownFormatActive('- [ ] 选课', 6, 8, 'task-list')).toBe(true);
+    expect(isMemoMarkdownFormatActive('[官网](https://)', 5, 13, 'link')).toBe(true);
+  });
+});

--- a/src/memos/markdown.ts
+++ b/src/memos/markdown.ts
@@ -1,0 +1,452 @@
+export type MemoMarkdownFormat =
+  | 'heading'
+  | 'bold'
+  | 'italic'
+  | 'strikethrough'
+  | 'unordered-list'
+  | 'ordered-list'
+  | 'task-list'
+  | 'blockquote'
+  | 'inline-code'
+  | 'link';
+
+export const MEMO_MARKDOWN_FORMATS = [
+  'heading',
+  'bold',
+  'italic',
+  'strikethrough',
+  'unordered-list',
+  'ordered-list',
+  'task-list',
+  'blockquote',
+  'inline-code',
+  'link',
+] as const satisfies readonly MemoMarkdownFormat[];
+
+export interface MemoMarkdownEdit {
+  text: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+interface InlineFormat {
+  before: string;
+  after: string;
+  placeholder: string;
+}
+
+interface FormatBounds {
+  outerStart: number;
+  outerEnd: number;
+  innerStart: number;
+  innerEnd: number;
+}
+
+interface TextReplacement {
+  start: number;
+  end: number;
+  text: string;
+}
+
+type LineMarkdownFormat =
+  | 'heading'
+  | 'unordered-list'
+  | 'ordered-list'
+  | 'task-list'
+  | 'blockquote';
+
+const INLINE_FORMATS: Partial<Record<MemoMarkdownFormat, InlineFormat>> = {
+  bold: { before: '**', after: '**', placeholder: '加粗文字' },
+  italic: { before: '*', after: '*', placeholder: '斜体文字' },
+  strikethrough: { before: '~~', after: '~~', placeholder: '删除线文字' },
+  'inline-code': { before: '`', after: '`', placeholder: '代码' },
+};
+
+const LINE_PREFIX_PATTERNS: Record<LineMarkdownFormat, RegExp> = {
+  heading: /^#{1,6}\s+/,
+  'unordered-list': /^-\s+(?!\[[ xX]\]\s+)/,
+  'ordered-list': /^\d+\.\s+/,
+  'task-list': /^-\s+\[[ xX]\]\s+/,
+  blockquote: /^>\s+/,
+};
+
+function clamp(value: number, maximum: number): number {
+  return Math.max(0, Math.min(Math.trunc(value), maximum));
+}
+
+function normalizeSelection(
+  text: string,
+  selectionStart: number,
+  selectionEnd: number,
+): [number, number] {
+  const start = clamp(selectionStart, text.length);
+  const end = clamp(selectionEnd, text.length);
+  return start <= end ? [start, end] : [end, start];
+}
+
+function applyInlineFormat(
+  text: string,
+  start: number,
+  end: number,
+  format: InlineFormat,
+): MemoMarkdownEdit {
+  const bounds = inlineFormatBounds(text, start, end, format);
+  if (bounds) {
+    const content = text.slice(bounds.innerStart, bounds.innerEnd);
+    return {
+      text: `${text.slice(0, bounds.outerStart)}${content}${text.slice(bounds.outerEnd)}`,
+      selectionStart: bounds.outerStart,
+      selectionEnd: bounds.outerStart + content.length,
+    };
+  }
+
+  const selected = text.slice(start, end);
+  const content = selected || format.placeholder;
+  return {
+    text: `${text.slice(0, start)}${format.before}${content}${format.after}${text.slice(end)}`,
+    selectionStart: start + format.before.length,
+    selectionEnd: start + format.before.length + content.length,
+  };
+}
+
+function inlineFormatBounds(
+  text: string,
+  start: number,
+  end: number,
+  format: InlineFormat,
+): FormatBounds | null {
+  const selected = text.slice(start, end);
+  if (
+    selected.length >= format.before.length + format.after.length
+    && selected.startsWith(format.before)
+    && selected.endsWith(format.after)
+  ) {
+    return {
+      outerStart: start,
+      outerEnd: end,
+      innerStart: start + format.before.length,
+      innerEnd: end - format.after.length,
+    };
+  }
+
+  const outerStart = start - format.before.length;
+  const outerEnd = end + format.after.length;
+  if (
+    outerStart < 0
+    || text.slice(outerStart, start) !== format.before
+    || text.slice(end, outerEnd) !== format.after
+  ) {
+    return null;
+  }
+
+  // A bold marker contains a single "*" on both sides as well. Do not report
+  // the inner selection of **text** as italic.
+  if (
+    format.before === '*'
+    && (
+      text.slice(start - 2, start) === '**'
+      || text.slice(end, end + 2) === '**'
+    )
+  ) {
+    return null;
+  }
+
+  return {
+    outerStart,
+    outerEnd,
+    innerStart: start,
+    innerEnd: end,
+  };
+}
+
+function lineBounds(text: string, start: number, end: number): [number, number] {
+  const lineStart = text.lastIndexOf('\n', Math.max(0, start - 1)) + 1;
+  const nextLineBreak = text.indexOf('\n', end);
+  return [lineStart, nextLineBreak === -1 ? text.length : nextLineBreak];
+}
+
+function isLineFormat(format: MemoMarkdownFormat): format is LineMarkdownFormat {
+  return Object.prototype.hasOwnProperty.call(LINE_PREFIX_PATTERNS, format);
+}
+
+function lineFormatActive(
+  text: string,
+  start: number,
+  end: number,
+  format: LineMarkdownFormat,
+): boolean {
+  const [blockStart, blockEnd] = lineBounds(text, start, end);
+  const nonEmptyLines = text.slice(blockStart, blockEnd).split('\n').filter(Boolean);
+  return (
+    nonEmptyLines.length > 0
+    && nonEmptyLines.every((line) => LINE_PREFIX_PATTERNS[format].test(line))
+  );
+}
+
+function linePrefix(
+  format: MemoMarkdownFormat,
+  index: number,
+): { prefix: string; placeholder: string } {
+  switch (format) {
+    case 'heading':
+      return { prefix: '## ', placeholder: '标题' };
+    case 'unordered-list':
+      return { prefix: '- ', placeholder: '列表项' };
+    case 'ordered-list':
+      return { prefix: `${index + 1}. `, placeholder: '列表项' };
+    case 'task-list':
+      return { prefix: '- [ ] ', placeholder: '待办事项' };
+    case 'blockquote':
+      return { prefix: '> ', placeholder: '引用内容' };
+    default:
+      throw new Error(`Unsupported line format: ${format}`);
+  }
+}
+
+function mapPositionThroughReplacements(
+  position: number,
+  replacements: readonly TextReplacement[],
+): number {
+  let delta = 0;
+
+  for (const replacement of replacements) {
+    if (position <= replacement.start) break;
+    if (position < replacement.end) {
+      return replacement.start
+        + delta
+        + Math.min(position - replacement.start, replacement.text.length);
+    }
+    delta += replacement.text.length - (replacement.end - replacement.start);
+  }
+
+  return position + delta;
+}
+
+export function normalizeMemoOrderedLists(
+  text: string,
+  selectionStart: number,
+  selectionEnd: number,
+): MemoMarkdownEdit {
+  const [start, end] = normalizeSelection(text, selectionStart, selectionEnd);
+  const replacements: TextReplacement[] = [];
+  let expectedNumber: number | null = null;
+  let lineStart = 0;
+
+  for (const line of text.split('\n')) {
+    const marker = line.match(/^(\d+)(?=\.\s+)/);
+    if (!marker) {
+      expectedNumber = null;
+    } else {
+      const currentNumber = Number(marker[1]);
+      if (!Number.isSafeInteger(currentNumber)) {
+        expectedNumber = null;
+      } else {
+        if (expectedNumber === null) expectedNumber = currentNumber;
+        const nextMarker = String(expectedNumber);
+        if (nextMarker !== marker[1]) {
+          replacements.push({
+            start: lineStart,
+            end: lineStart + marker[1].length,
+            text: nextMarker,
+          });
+        }
+        expectedNumber = Number.isSafeInteger(expectedNumber + 1)
+          ? expectedNumber + 1
+          : null;
+      }
+    }
+    lineStart += line.length + 1;
+  }
+
+  if (replacements.length === 0) {
+    return { text, selectionStart: start, selectionEnd: end };
+  }
+
+  let normalizedText = '';
+  let sourcePosition = 0;
+  for (const replacement of replacements) {
+    normalizedText += text.slice(sourcePosition, replacement.start);
+    normalizedText += replacement.text;
+    sourcePosition = replacement.end;
+  }
+  normalizedText += text.slice(sourcePosition);
+
+  return {
+    text: normalizedText,
+    selectionStart: mapPositionThroughReplacements(start, replacements),
+    selectionEnd: mapPositionThroughReplacements(end, replacements),
+  };
+}
+
+export function continueMemoOrderedList(
+  text: string,
+  selectionStart: number,
+  selectionEnd: number,
+): MemoMarkdownEdit | null {
+  const [start, end] = normalizeSelection(text, selectionStart, selectionEnd);
+  if (start !== end) return null;
+
+  const [currentLineStart, currentLineEnd] = lineBounds(text, start, end);
+  const currentLine = text.slice(currentLineStart, currentLineEnd);
+  const marker = currentLine.match(/^(\d+)\.\s+/);
+  if (!marker || start < currentLineStart + marker[0].length) return null;
+
+  const currentNumber = Number(marker[1]);
+  if (!Number.isSafeInteger(currentNumber) || !Number.isSafeInteger(currentNumber + 1)) {
+    return null;
+  }
+
+  if (!currentLine.slice(marker[0].length).trim()) {
+    const withoutEmptyItem = `${text.slice(0, currentLineStart)}${text.slice(currentLineEnd)}`;
+    return normalizeMemoOrderedLists(
+      withoutEmptyItem,
+      currentLineStart,
+      currentLineStart,
+    );
+  }
+
+  const nextPrefix = `\n${currentNumber + 1}. `;
+  const continuedText = `${text.slice(0, start)}${nextPrefix}${text.slice(end)}`;
+  const nextPosition = start + nextPrefix.length;
+  return normalizeMemoOrderedLists(continuedText, nextPosition, nextPosition);
+}
+
+function applyLineFormat(
+  text: string,
+  start: number,
+  end: number,
+  format: LineMarkdownFormat,
+): MemoMarkdownEdit {
+  const [blockStart, blockEnd] = lineBounds(text, start, end);
+  const block = text.slice(blockStart, blockEnd);
+
+  if (!block) {
+    const { prefix, placeholder } = linePrefix(format, 0);
+    return {
+      text: `${text.slice(0, blockStart)}${prefix}${placeholder}${text.slice(blockEnd)}`,
+      selectionStart: blockStart + prefix.length,
+      selectionEnd: blockStart + prefix.length + placeholder.length,
+    };
+  }
+
+  if (lineFormatActive(text, start, end, format)) {
+    const unformatted = block
+      .split('\n')
+      .map((line) => line.replace(LINE_PREFIX_PATTERNS[format], ''))
+      .join('\n');
+    return {
+      text: `${text.slice(0, blockStart)}${unformatted}${text.slice(blockEnd)}`,
+      selectionStart: blockStart,
+      selectionEnd: blockStart + unformatted.length,
+    };
+  }
+
+  let formattedLineIndex = 0;
+  const formatted = block
+    .split('\n')
+    .map((line) => {
+      if (!line) return line;
+      const { prefix } = linePrefix(format, formattedLineIndex);
+      formattedLineIndex += 1;
+      return `${prefix}${line}`;
+    })
+    .join('\n');
+
+  return {
+    text: `${text.slice(0, blockStart)}${formatted}${text.slice(blockEnd)}`,
+    selectionStart: blockStart,
+    selectionEnd: blockStart + formatted.length,
+  };
+}
+
+function linkFormatBounds(
+  text: string,
+  start: number,
+  end: number,
+): FormatBounds | null {
+  const selected = text.slice(start, end);
+  const fullLink = selected.match(/^\[([^\]\n]+)\]\(([^)\n]*)\)$/);
+  if (fullLink) {
+    return {
+      outerStart: start,
+      outerEnd: end,
+      innerStart: start + 1,
+      innerEnd: start + 1 + fullLink[1].length,
+    };
+  }
+
+  const beforeUrl = text.slice(0, start).match(/\[([^\]\n]+)\]\($/);
+  if (beforeUrl && text[end] === ')') {
+    const outerStart = start - beforeUrl[0].length;
+    return {
+      outerStart,
+      outerEnd: end + 1,
+      innerStart: outerStart + 1,
+      innerEnd: outerStart + 1 + beforeUrl[1].length,
+    };
+  }
+
+  if (text[start - 1] === '[') {
+    const afterLabel = text.slice(end).match(/^\]\(([^)\n]*)\)/);
+    if (afterLabel) {
+      return {
+        outerStart: start - 1,
+        outerEnd: end + afterLabel[0].length,
+        innerStart: start,
+        innerEnd: end,
+      };
+    }
+  }
+
+  return null;
+}
+
+export function applyMemoMarkdownFormat(
+  text: string,
+  selectionStart: number,
+  selectionEnd: number,
+  format: MemoMarkdownFormat,
+): MemoMarkdownEdit {
+  const [start, end] = normalizeSelection(text, selectionStart, selectionEnd);
+  const inlineFormat = INLINE_FORMATS[format];
+  if (inlineFormat) return applyInlineFormat(text, start, end, inlineFormat);
+
+  if (format === 'link') {
+    const bounds = linkFormatBounds(text, start, end);
+    if (bounds) {
+      const label = text.slice(bounds.innerStart, bounds.innerEnd);
+      return {
+        text: `${text.slice(0, bounds.outerStart)}${label}${text.slice(bounds.outerEnd)}`,
+        selectionStart: bounds.outerStart,
+        selectionEnd: bounds.outerStart + label.length,
+      };
+    }
+
+    const label = text.slice(start, end) || '链接文字';
+    const url = 'https://';
+    return {
+      text: `${text.slice(0, start)}[${label}](${url})${text.slice(end)}`,
+      selectionStart: start + label.length + 3,
+      selectionEnd: start + label.length + 3 + url.length,
+    };
+  }
+
+  if (!isLineFormat(format)) return { text, selectionStart: start, selectionEnd: end };
+  const edit = applyLineFormat(text, start, end, format);
+  return format === 'ordered-list'
+    ? normalizeMemoOrderedLists(edit.text, edit.selectionStart, edit.selectionEnd)
+    : edit;
+}
+
+export function isMemoMarkdownFormatActive(
+  text: string,
+  selectionStart: number,
+  selectionEnd: number,
+  format: MemoMarkdownFormat,
+): boolean {
+  const [start, end] = normalizeSelection(text, selectionStart, selectionEnd);
+  const inlineFormat = INLINE_FORMATS[format];
+  if (inlineFormat) return inlineFormatBounds(text, start, end, inlineFormat) !== null;
+  if (format === 'link') return linkFormatBounds(text, start, end) !== null;
+  return isLineFormat(format) && lineFormatActive(text, start, end, format);
+}

--- a/src/memos/memos.test.ts
+++ b/src/memos/memos.test.ts
@@ -6,6 +6,7 @@ import {
   loadMemos,
   removeNote,
   saveMemos,
+  toggleNoteFavorite,
   updateNoteText,
   type StorageLike,
 } from './memos';
@@ -32,7 +33,7 @@ describe('memos persistence', () => {
     const storage = new MemoryStorage();
     const state: MemosState = {
       version: 1,
-      notes: [{ id: 'n1', text: '选课备注', updatedAt: 1000 }],
+      notes: [{ id: 'n1', text: '选课备注', updatedAt: 1000, favorite: true }],
     };
     saveMemos(state, storage);
     expect(loadMemos(storage)).toEqual(state);
@@ -79,5 +80,15 @@ describe('memos reducers', () => {
     const next = removeNote(base, 'n1');
     expect(next.notes).toEqual([]);
     expect(removeNote(next, 'n1')).toBe(next);
+  });
+
+  it('toggleNoteFavorite toggles a note without changing its content order or timestamp', () => {
+    const favorited = toggleNoteFavorite(base, 'n1');
+    expect(favorited.notes).toEqual([
+      { id: 'n1', text: 'a', updatedAt: 1, favorite: true },
+    ]);
+
+    expect(toggleNoteFavorite(favorited, 'n1')).toEqual(base);
+    expect(toggleNoteFavorite(base, 'missing')).toBe(base);
   });
 });

--- a/src/memos/memos.ts
+++ b/src/memos/memos.ts
@@ -28,7 +28,12 @@ function normalizeNotes(value: unknown): MemoNote[] {
         ? record.updatedAt
         : 0;
     seen.add(id);
-    notes.push({ id, text: record.text, updatedAt });
+    notes.push({
+      id,
+      text: record.text,
+      updatedAt,
+      ...(record.favorite === true ? { favorite: true } : {}),
+    });
   }
   return notes;
 }
@@ -95,4 +100,18 @@ export function removeNote(state: MemosState, id: string): MemosState {
   if (!normalizedId) return state;
   if (!state.notes.some((item) => item.id === normalizedId)) return state;
   return { ...state, notes: state.notes.filter((item) => item.id !== normalizedId) };
+}
+
+export function toggleNoteFavorite(state: MemosState, id: string): MemosState {
+  const normalizedId = id.trim();
+  if (!normalizedId) return state;
+  let changed = false;
+  const notes = state.notes.map((item) => {
+    if (item.id !== normalizedId) return item;
+    changed = true;
+    if (!item.favorite) return { ...item, favorite: true };
+    const { favorite: _favorite, ...rest } = item;
+    return rest;
+  });
+  return changed ? { ...state, notes } : state;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -104,6 +104,7 @@ export interface MemoNote {
   id: string;
   text: string;
   updatedAt: number;
+  favorite?: boolean;
 }
 
 export interface MemosState {


### PR DESCRIPTION
## Summary

- Add a compact **Complex formatting** switch beside the memo title while keeping the existing simple editor as the default.
- Add an optional Markdown toolbar and rendered preview for headings, emphasis, lists, task items, quotes, inline code, and links.
- Keep course recognition in the editor toolbar.
- Add favorite controls so important memos stay at the top of the sidebar.
- Refine memo layout, focus states, delete confirmation, action alignment, and shared preference-switch styling.
