### PR TITLE
Add experimental time-based course finder

### DIFF
--- a/public/data/semesters/2026-fall/updates.json
+++ b/public/data/semesters/2026-fall/updates.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "semesterKey": "2026-fall",
-  "currentRevision": "6a10a9e3813591e40361a5b578c9ad699a9bc371fb7bbc058628923c2289cbb6",
+  "currentRevision": "a72799997bae83bf18693e16bff922cbe1cdc7c261fa614ebe95529246e238d3",
   "entries": [
     {
       "id": "2026-fall:c0cbaf189652cc27",
@@ -132781,6 +132781,34031 @@
               "label": "课容量",
               "before": 30,
               "after": 40
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2026-fall:a72799997bae83bf",
+      "revision": "a72799997bae83bf18693e16bff922cbe1cdc7c261fa614ebe95529246e238d3",
+      "previousRevision": "6a10a9e3813591e40361a5b578c9ad699a9bc371fb7bbc058628923c2289cbb6",
+      "publishedAt": "2026-07-30T12:17:37Z",
+      "summary": {
+        "added": 3,
+        "removed": 28,
+        "modified": 212
+      },
+      "added": [
+        {
+          "id": "001548.09",
+          "courseCode": "001548",
+          "courseName": "复变函数B",
+          "teacher": "黄腾",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                1,
+                10
+              ],
+              "room": "3C101",
+              "day": 3,
+              "periods": [
+                6,
+                7
+              ],
+              "campus": "本部"
+            },
+            {
+              "weeks": [
+                1,
+                10
+              ],
+              "room": "3C101",
+              "day": 5,
+              "periods": [
+                6,
+                7
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "FL1017.13",
+          "courseCode": "FL1017",
+          "courseName": "科普英语交流",
+          "teacher": "陈静",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                1,
+                7
+              ],
+              "room": "2205",
+              "day": 5,
+              "periods": [
+                6,
+                7
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "ME1901.01",
+          "courseCode": "ME1901",
+          "courseName": "节能减排创新实践",
+          "teacher": "倪青",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                16
+              ],
+              "room": "3A102",
+              "day": 4,
+              "periods": [
+                8,
+                9,
+                10
+              ],
+              "campus": "本部"
+            }
+          ]
+        }
+      ],
+      "removed": [
+        {
+          "course": {
+            "id": "CHEM1505.01",
+            "courseCode": "CHEM1505",
+            "courseName": "厨房化学",
+            "teacher": "吴强华,吴红,张国庆,方思敏,李玲玲,李红春,蒋俊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "东区环资楼普通化学实验室301",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "CS1514.01",
+            "courseCode": "CS1514",
+            "courseName": "面向交叉学科的Python程序设计与跨学科实践",
+            "teacher": "邢凯",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "3C101",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "EDUS1001.15",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "EDUS1001.01",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.02",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.03",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.04",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.05",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.06",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.07",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.08",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.09",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.10",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.11",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.12",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.13",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.14",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.17",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.18",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.19",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.20",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.21",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "EDUS1001.25",
+              "courseCode": "EDUS1001",
+              "courseName": "劳动教育",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.14",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.15",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.16",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.17",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.18",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.19",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.20",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.21",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.22",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.23",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.24",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.25",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.26",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.27",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.49",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "HS1003.01",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.02",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.03",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.04",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.05",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.06",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.07",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.08",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.09",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.10",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.11",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.12",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.13",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.28",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.29",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.30",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.31",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.32",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.33",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.34",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.35",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.36",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.37",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.38",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.39",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.40",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.41",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.42",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.43",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.44",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.45",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.46",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.47",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "HS1003.48",
+              "courseCode": "HS1003",
+              "courseName": "艺术实践",
+              "teacher": "谢羿",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1632.01",
+            "courseCode": "HS1632",
+            "courseName": "声乐演唱基础",
+            "teacher": "朱晓慧",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "MARX1006.15",
+            "courseCode": "MARX1006",
+            "courseName": "形势与政策(讲座)",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "replacementCandidates": [
+            {
+              "id": "MARX1006.01",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "虎旭昕",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.02",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "虎旭昕",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.03",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "虎旭昕",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.04",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.05",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "虎旭昕",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.06",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "虎旭昕",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.07",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.08",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.09",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.10",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.11",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "虎旭昕",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.12",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "虎旭昕",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.13",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "虎旭昕",
+              "level": "本科",
+              "schedule": []
+            },
+            {
+              "id": "MARX1006.14",
+              "courseCode": "MARX1006",
+              "courseName": "形势与政策(讲座)",
+              "teacher": "",
+              "level": "本科",
+              "schedule": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.12",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PE00001.01",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.02",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.03",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.04",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.05",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.06",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.07",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.08",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.09",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.10",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.11",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.13",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.14",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.15",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.16",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.17",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.18",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.19",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.20",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.21",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.22",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.23",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.24",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.25",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.26",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.27",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.28",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.29",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.30",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.31",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.32",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.33",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.35",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.36",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.37",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.38",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.39",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.40",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.41",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.42",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.43",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.44",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.45",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.46",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.47",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.48",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.49",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.50",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.51",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.52",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.53",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.54",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.55",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.56",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.57",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.58",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.60",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "杨旭东",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.61",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "杨旭东",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.62",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.63",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.64",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.65",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.66",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.67",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.68",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.69",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.70",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.71",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.72",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.73",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.74",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.76",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.79",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.80",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.81",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.82",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.83",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.85",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.86",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.34",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PE00001.01",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.02",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.03",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.04",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.05",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.06",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.07",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.08",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.09",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.10",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.11",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.13",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.14",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.15",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.16",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.17",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.18",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.19",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.20",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.21",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.22",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.23",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.24",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.25",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.26",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.27",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.28",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.29",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.30",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.31",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.32",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.33",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.35",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.36",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.37",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.38",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.39",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.40",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.41",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.42",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.43",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.44",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.45",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.46",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.47",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.48",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.49",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.50",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.51",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.52",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.53",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.54",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.55",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.56",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.57",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.58",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.60",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "杨旭东",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.61",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "杨旭东",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.62",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.63",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.64",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.65",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.66",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.67",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.68",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.69",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.70",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.71",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.72",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.73",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.74",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.76",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.79",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.80",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.81",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.82",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.83",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.85",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.86",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.75",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PE00001.01",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.02",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.03",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.04",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.05",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.06",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.07",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.08",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.09",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.10",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.11",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.13",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.14",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.15",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.16",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.17",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.18",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.19",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.20",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.21",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.22",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.23",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.24",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.25",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.26",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.27",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.28",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.29",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.30",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.31",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.32",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.33",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.35",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.36",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.37",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.38",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.39",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.40",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.41",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.42",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.43",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.44",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.45",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.46",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.47",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.48",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.49",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.50",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.51",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.52",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.53",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.54",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.55",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.56",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.57",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.58",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.60",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "杨旭东",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.61",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "杨旭东",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.62",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.63",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.64",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.65",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.66",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.67",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.68",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.69",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.70",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.71",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.72",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.73",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.74",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.76",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.79",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.80",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.81",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.82",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.83",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.85",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.86",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.77",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PE00001.01",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.02",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.03",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.04",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.05",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.06",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.07",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.08",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.09",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.10",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.11",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.13",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.14",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.15",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.16",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.17",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.18",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.19",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.20",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.21",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.22",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.23",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.24",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.25",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.26",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.27",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.28",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.29",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.30",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.31",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.32",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.33",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.35",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.36",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.37",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.38",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.39",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.40",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.41",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.42",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.43",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.44",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.45",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.46",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.47",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.48",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.49",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.50",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.51",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.52",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.53",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.54",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.55",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.56",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.57",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.58",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.60",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "杨旭东",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.61",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "杨旭东",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.62",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.63",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.64",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.65",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.66",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.67",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.68",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.69",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.70",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.71",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.72",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.73",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.74",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.76",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.79",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.80",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.81",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.82",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.83",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.85",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.86",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.78",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PE00001.01",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.02",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.03",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.04",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.05",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.06",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.07",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "胡洋",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.08",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.09",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.10",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.11",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.13",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.14",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.15",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李少松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.16",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.17",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.18",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.19",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.20",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "渠思源",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.21",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.22",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.23",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.24",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙劲松",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.25",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.26",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.27",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "唐莉",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.28",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.29",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.30",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.31",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.32",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.33",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.35",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.36",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李达",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.37",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "李朴",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.38",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.39",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.40",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "刘德海",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.41",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.42",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.43",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "马震",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.44",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.45",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "司友志",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.46",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.47",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.48",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.49",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "殷剑巍",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.50",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.51",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.52",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王永",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.53",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.54",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.55",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "吴成林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.56",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.57",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.58",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖腾飞",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.60",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "杨旭东",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.61",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "杨旭东",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.62",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.63",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.64",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.65",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "窦盛凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.66",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.67",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.68",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.69",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "孙璐璐",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区活动中心四楼(女生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.70",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.71",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.72",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "曾妮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS403",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.73",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.74",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.76",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.79",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.80",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.81",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.82",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.83",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "王佳滢",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "ARTS404",
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.85",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "东区操场(男生)",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00001.86",
+              "courseCode": "PE00001",
+              "courseName": "基础体育",
+              "teacher": "肖阳",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "room": "西区操场(男生)",
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00120.05",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区操场",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PE00120.01",
+              "courseCode": "PE00120",
+              "courseName": "体适能II",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "西区操场",
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00120.02",
+              "courseCode": "PE00120",
+              "courseName": "体适能II",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "东区操场",
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00120.03",
+              "courseCode": "PE00120",
+              "courseName": "体适能II",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "东区操场",
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00120.04",
+              "courseCode": "PE00120",
+              "courseName": "体适能II",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "东区操场",
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00120.06",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区操场",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PE00120.01",
+              "courseCode": "PE00120",
+              "courseName": "体适能II",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "西区操场",
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00120.02",
+              "courseCode": "PE00120",
+              "courseName": "体适能II",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "东区操场",
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00120.03",
+              "courseCode": "PE00120",
+              "courseName": "体适能II",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "东区操场",
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00120.04",
+              "courseCode": "PE00120",
+              "courseName": "体适能II",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "东区操场",
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00120.07",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区操场",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PE00120.01",
+              "courseCode": "PE00120",
+              "courseName": "体适能II",
+              "teacher": "陈若涵",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "西区操场",
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00120.02",
+              "courseCode": "PE00120",
+              "courseName": "体适能II",
+              "teacher": "汤涛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "东区操场",
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00120.03",
+              "courseCode": "PE00120",
+              "courseName": "体适能II",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "东区操场",
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PE00120.04",
+              "courseCode": "PE00120",
+              "courseName": "体适能II",
+              "teacher": "王林",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "东区操场",
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "modified": [
+        {
+          "course": {
+            "id": "001548.01",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "郭经纬"
+          },
+          "previous": {
+            "id": "001548.01",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "郭经纬",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C101",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C101",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "001548.01",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "郭经纬",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C101",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C101",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 110,
+              "after": 115
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "001548.02",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "黄腾"
+          },
+          "previous": {
+            "id": "001548.02",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "黄腾",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C304",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C304",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "001548.02",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "黄腾",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C304",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C304",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 110,
+              "after": 115
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "001548.03",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "马啸"
+          },
+          "previous": {
+            "id": "001548.03",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "马啸",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C303",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C303",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "001548.03",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "马啸",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C303",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C303",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 110,
+              "after": 115
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "001548.04",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "赵立璐"
+          },
+          "previous": {
+            "id": "001548.04",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "赵立璐",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C103",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C103",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "001548.04",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "赵立璐",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C103",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C103",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 110,
+              "after": 115
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "001548.05",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "俞建青"
+          },
+          "previous": {
+            "id": "001548.05",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "俞建青",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C302",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C302",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "001548.05",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "俞建青",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C302",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C302",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 110,
+              "after": 115
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "001548.06",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "马啸"
+          },
+          "previous": {
+            "id": "001548.06",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "马啸",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C304",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C304",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "001548.06",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "马啸",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C304",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C304",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 110,
+              "after": 115
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "001548.07",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "张永兵"
+          },
+          "previous": {
+            "id": "001548.07",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "张永兵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C304",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C304",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "001548.07",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "张永兵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C304",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C304",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 110,
+              "after": 115
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "001548.08",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "周辉煌"
+          },
+          "previous": {
+            "id": "001548.08",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "周辉煌",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C102",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C102",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "001548.08",
+            "courseCode": "001548",
+            "courseName": "复变函数B",
+            "teacher": "周辉煌",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C102",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "3C102",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 110,
+              "after": 115
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "002075.01",
+            "courseCode": "002075",
+            "courseName": "凝聚态物理基础",
+            "teacher": "翁明其,朱弘,程广珲"
+          },
+          "previous": {
+            "id": "002075.01",
+            "courseCode": "002075",
+            "courseName": "凝聚态物理基础",
+            "teacher": "朱弘,翁明其",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "1302",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "1302",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "1302",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "1302",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "002075.01",
+            "courseCode": "002075",
+            "courseName": "凝聚态物理基础",
+            "teacher": "翁明其,朱弘,程广珲",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "1302",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1302",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "1302",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "1302",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1302",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "1302",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "朱弘,翁明其",
+              "after": "翁明其,朱弘,程广珲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "004040.03",
+            "courseCode": "004040",
+            "courseName": "计算物理B",
+            "teacher": "魏逸丰"
+          },
+          "previous": {
+            "id": "004040.03",
+            "courseCode": "004040",
+            "courseName": "计算物理B",
+            "teacher": "魏逸丰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2321",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "004040.03",
+            "courseCode": "004040",
+            "courseName": "计算物理B",
+            "teacher": "魏逸丰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2321",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 75,
+              "after": 80
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "004040.04",
+            "courseCode": "004040",
+            "courseName": "计算物理B",
+            "teacher": "高阳"
+          },
+          "previous": {
+            "id": "004040.04",
+            "courseCode": "004040",
+            "courseName": "计算物理B",
+            "teacher": "高阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1102",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "004040.04",
+            "courseCode": "004040",
+            "courseName": "计算物理B",
+            "teacher": "高阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1102",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 70,
+              "after": 85
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "006174.02",
+            "courseCode": "006174",
+            "courseName": "电磁场理论",
+            "teacher": "王刚"
+          },
+          "previous": {
+            "id": "006174.02",
+            "courseCode": "006174",
+            "courseName": "电磁场理论",
+            "teacher": "王刚",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B110",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B110",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "006174.02",
+            "courseCode": "006174",
+            "courseName": "电磁场理论",
+            "teacher": "王刚",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B110",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B110",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 70,
+              "after": 71
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "007001.01",
+            "courseCode": "007001",
+            "courseName": "流体力学",
+            "teacher": "郑建秋,袁仁民,蒋诗威"
+          },
+          "previous": {
+            "id": "007001.01",
+            "courseCode": "007001",
+            "courseName": "流体力学",
+            "teacher": "郑建秋,袁仁民",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "007001.01",
+            "courseCode": "007001",
+            "courseName": "流体力学",
+            "teacher": "郑建秋,袁仁民,蒋诗威",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "郑建秋,袁仁民",
+              "after": "郑建秋,袁仁民,蒋诗威"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "007026.01",
+            "courseCode": "007026",
+            "courseName": "大气物理学基础",
+            "teacher": "王雨,王冲"
+          },
+          "previous": {
+            "id": "007026.01",
+            "courseCode": "007026",
+            "courseName": "大气物理学基础",
+            "teacher": "王雨",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "5205",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "5205",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "007026.01",
+            "courseCode": "007026",
+            "courseName": "大气物理学基础",
+            "teacher": "王雨,王冲",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "5205",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "5205",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "王雨",
+              "after": "王雨,王冲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "008704.01",
+            "courseCode": "008704",
+            "courseName": "细胞生物学I",
+            "teacher": "梅一德,姚雪彪,杨振业"
+          },
+          "previous": {
+            "id": "008704.01",
+            "courseCode": "008704",
+            "courseName": "细胞生物学I",
+            "teacher": "梅一德,姚雪彪,杨振业",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "3A303",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  7
+                ],
+                "room": "3A303",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  12
+                ],
+                "room": "3A303",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "008704.01",
+            "courseCode": "008704",
+            "courseName": "细胞生物学I",
+            "teacher": "梅一德,姚雪彪,杨振业",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "3A303",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  7
+                ],
+                "room": "3A303",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  12
+                ],
+                "room": "3A303",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 48
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "008704.02",
+            "courseCode": "008704",
+            "courseName": "细胞生物学I",
+            "teacher": "刘行,胡青松,姚雪彪"
+          },
+          "previous": {
+            "id": "008704.02",
+            "courseCode": "008704",
+            "courseName": "细胞生物学I",
+            "teacher": "刘行,胡青松,姚雪彪",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "3A104",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  10
+                ],
+                "room": "3A104",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  12
+                ],
+                "room": "3A104",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "008704.02",
+            "courseCode": "008704",
+            "courseName": "细胞生物学I",
+            "teacher": "刘行,胡青松,姚雪彪",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "3A104",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  10
+                ],
+                "room": "3A104",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  12
+                ],
+                "room": "3A104",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 34,
+              "after": 35
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "009055.01",
+            "courseCode": "009055",
+            "courseName": "机电系统设计",
+            "teacher": "王洪波,辛晨"
+          },
+          "previous": {
+            "id": "009055.01",
+            "courseCode": "009055",
+            "courseName": "机电系统设计",
+            "teacher": "王洪波",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A107",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "009055.01",
+            "courseCode": "009055",
+            "courseName": "机电系统设计",
+            "teacher": "王洪波,辛晨",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A107",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "王洪波",
+              "after": "王洪波,辛晨"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "009175.01",
+            "courseCode": "009175",
+            "courseName": "传感器及测试技术",
+            "teacher": "冯志华,张礁石"
+          },
+          "previous": {
+            "id": "009175.01",
+            "courseCode": "009175",
+            "courseName": "传感器及测试技术",
+            "teacher": "冯志华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "3A412",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "3A412",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "009175.01",
+            "courseCode": "009175",
+            "courseName": "传感器及测试技术",
+            "teacher": "冯志华,张礁石",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "3A412",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "3A412",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "冯志华",
+              "after": "冯志华,张礁石"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "011144.01",
+            "courseCode": "011144",
+            "courseName": "计算机网络",
+            "teacher": "华蓓"
+          },
+          "previous": {
+            "id": "011144.01",
+            "courseCode": "011144",
+            "courseName": "计算机网络",
+            "teacher": "华蓓",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B112",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B112",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "011144.01",
+            "courseCode": "011144",
+            "courseName": "计算机网络",
+            "teacher": "华蓓",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B112",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B112",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 120,
+              "after": 140
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "011163.02",
+            "courseCode": "011163",
+            "courseName": "编译原理和技术",
+            "teacher": "李诚,徐伟"
+          },
+          "previous": {
+            "id": "011163.02",
+            "courseCode": "011163",
+            "courseName": "编译原理和技术",
+            "teacher": "李诚,徐伟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B112",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B112",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "011163.02",
+            "courseCode": "011163",
+            "courseName": "编译原理和技术",
+            "teacher": "李诚,徐伟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B112",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B112",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 120,
+              "after": 150
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "014066.01",
+            "courseCode": "014066",
+            "courseName": "材料科学基础实验",
+            "teacher": "高海英,傅正平,卫涛"
+          },
+          "previous": {
+            "id": "014066.01",
+            "courseCode": "014066",
+            "courseName": "材料科学基础实验",
+            "teacher": "高海英,傅正平,卫涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "材料科学基础实验室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "材料科学基础实验室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  8,
+                  18
+                ],
+                "room": "材料科学基础实验室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "院系安排",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "院系安排",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  8,
+                  18
+                ],
+                "room": "院系安排",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "014066.01",
+            "courseCode": "014066",
+            "courseName": "材料科学基础实验",
+            "teacher": "高海英,傅正平,卫涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "材料科学基础实验室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "材料科学基础实验室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  8,
+                  18
+                ],
+                "room": "材料科学基础实验室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "院系安排",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "院系安排",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  8,
+                  18
+                ],
+                "room": "院系安排",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 31,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "015005.01",
+            "courseCode": "015005",
+            "courseName": "微观经济学",
+            "teacher": "周亚平,程丽红"
+          },
+          "previous": {
+            "id": "015005.01",
+            "courseCode": "015005",
+            "courseName": "微观经济学",
+            "teacher": "周亚平",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16,
+                  18
+                ],
+                "room": "1301",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1301",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "015005.01",
+            "courseCode": "015005",
+            "courseName": "微观经济学",
+            "teacher": "周亚平,程丽红",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1301",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16,
+                  18
+                ],
+                "room": "1301",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1301",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "周亚平",
+              "after": "周亚平,程丽红"
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    4,
+                    6,
+                    8,
+                    10,
+                    12,
+                    14,
+                    16,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    4,
+                    6,
+                    8,
+                    10,
+                    12,
+                    14,
+                    16,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "015707.01",
+            "courseCode": "015707",
+            "courseName": "管理信息系统",
+            "teacher": "刘和福,李慧芳,孙培樑"
+          },
+          "previous": {
+            "id": "015707.01",
+            "courseCode": "015707",
+            "courseName": "管理信息系统",
+            "teacher": "刘和福,李慧芳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "015707.01",
+            "courseCode": "015707",
+            "courseName": "管理信息系统",
+            "teacher": "刘和福,李慧芳,孙培樑",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "刘和福,李慧芳",
+              "after": "刘和福,李慧芳,孙培樑"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "017123.01",
+            "courseCode": "017123",
+            "courseName": "计量经济学",
+            "teacher": "叶五一"
+          },
+          "previous": {
+            "id": "017123.01",
+            "courseCode": "017123",
+            "courseName": "计量经济学",
+            "teacher": "叶五一",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1102",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "017123.01",
+            "courseCode": "017123",
+            "courseName": "计量经济学",
+            "teacher": "叶五一",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1102",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 27,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "017137.01",
+            "courseCode": "017137",
+            "courseName": "金融学导论",
+            "teacher": "赵朕领,潘然"
+          },
+          "previous": {
+            "id": "017137.01",
+            "courseCode": "017137",
+            "courseName": "金融学导论",
+            "teacher": "赵朕领,潘然",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "2303",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  9
+                ],
+                "room": "2303",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "2303",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  9
+                ],
+                "room": "2303",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "017137.01",
+            "courseCode": "017137",
+            "courseName": "金融学导论",
+            "teacher": "赵朕领,潘然",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "2303",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  9
+                ],
+                "room": "2303",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "2303",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  9
+                ],
+                "room": "2303",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 25
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "017139.01",
+            "courseCode": "017139",
+            "courseName": "金融经济学基础",
+            "teacher": "张力"
+          },
+          "previous": {
+            "id": "017139.01",
+            "courseCode": "017139",
+            "courseName": "金融经济学基础",
+            "teacher": "张力",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5307",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "017139.01",
+            "courseCode": "017139",
+            "courseName": "金融经济学基础",
+            "teacher": "张力",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5307",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "017146.01",
+            "courseCode": "017146",
+            "courseName": "回归分析",
+            "teacher": "杨亚宁"
+          },
+          "previous": {
+            "id": "017146.01",
+            "courseCode": "017146",
+            "courseName": "回归分析",
+            "teacher": "杨亚宁",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5303",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "017146.01",
+            "courseCode": "017146",
+            "courseName": "回归分析",
+            "teacher": "杨亚宁",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5303",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 57,
+              "after": 90
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "017166.01",
+            "courseCode": "017166",
+            "courseName": "凸优化",
+            "teacher": "张靖南"
+          },
+          "previous": {
+            "id": "017166.01",
+            "courseCode": "017166",
+            "courseName": "凸优化",
+            "teacher": "张靖南",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5306",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "017166.01",
+            "courseCode": "017166",
+            "courseName": "凸优化",
+            "teacher": "张靖南",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5402",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 72,
+              "after": 95
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5306",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5402",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "017703.01",
+            "courseCode": "017703",
+            "courseName": "金融衍生品",
+            "teacher": "吴遵"
+          },
+          "previous": {
+            "id": "017703.01",
+            "courseCode": "017703",
+            "courseName": "金融衍生品",
+            "teacher": "吴遵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2507",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "017703.01",
+            "courseCode": "017703",
+            "courseName": "金融衍生品",
+            "teacher": "吴遵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2507",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "019128.01",
+            "courseCode": "019128",
+            "courseName": "化工原理",
+            "teacher": "江鸿,张颖,吴亮,关艳芳"
+          },
+          "previous": {
+            "id": "019128.01",
+            "courseCode": "019128",
+            "courseName": "化工原理",
+            "teacher": "江鸿,张颖,吴亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "1101",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  9
+                ],
+                "room": "1101",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "1101",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "019128.01",
+            "courseCode": "019128",
+            "courseName": "化工原理",
+            "teacher": "江鸿,张颖,吴亮,关艳芳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "1101",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1101",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  9
+                ],
+                "room": "1101",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "1101",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "江鸿,张颖,吴亮",
+              "after": "江鸿,张颖,吴亮,关艳芳"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "019145.01",
+            "courseCode": "019145",
+            "courseName": "结晶化学",
+            "teacher": "唐凯斌,朱永春,杨阳"
+          },
+          "previous": {
+            "id": "019145.01",
+            "courseCode": "019145",
+            "courseName": "结晶化学",
+            "teacher": "唐凯斌,朱永春",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "2405",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  12
+                ],
+                "room": "2405",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  5
+                ],
+                "room": "2405",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  18
+                ],
+                "room": "2405",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  12
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  5
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  18
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "019145.01",
+            "courseCode": "019145",
+            "courseName": "结晶化学",
+            "teacher": "唐凯斌,朱永春,杨阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "2405",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  12
+                ],
+                "room": "2405",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2405",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  5
+                ],
+                "room": "2405",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  18
+                ],
+                "room": "2405",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  12
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  5
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  18
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "唐凯斌,朱永春",
+              "after": "唐凯斌,朱永春,杨阳"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "019163.01",
+            "courseCode": "019163",
+            "courseName": "化学原理B",
+            "teacher": "刘建伟,吴宇恩,贺玉彬,芮先宏"
+          },
+          "previous": {
+            "id": "019163.01",
+            "courseCode": "019163",
+            "courseName": "化学原理B",
+            "teacher": "刘建伟,吴宇恩",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2406",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "2406",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2406",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "2406",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "019163.01",
+            "courseCode": "019163",
+            "courseName": "化学原理B",
+            "teacher": "刘建伟,吴宇恩,贺玉彬,芮先宏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2406",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "2406",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2406",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "2406",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "刘建伟,吴宇恩",
+              "after": "刘建伟,吴宇恩,贺玉彬,芮先宏"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "020147.01",
+            "courseCode": "020147",
+            "courseName": "高分子生物材料",
+            "teacher": "洪春雁,邓正玉"
+          },
+          "previous": {
+            "id": "020147.01",
+            "courseCode": "020147",
+            "courseName": "高分子生物材料",
+            "teacher": "洪春雁",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5207",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "020147.01",
+            "courseCode": "020147",
+            "courseName": "高分子生物材料",
+            "teacher": "洪春雁,邓正玉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5207",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "洪春雁",
+              "after": "洪春雁,邓正玉"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "022062.01",
+            "courseCode": "022062",
+            "courseName": "热力学与统计物理A",
+            "teacher": "翁明其"
+          },
+          "previous": {
+            "id": "022062.01",
+            "courseCode": "022062",
+            "courseName": "热力学与统计物理A",
+            "teacher": "翁明其",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2106",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2106",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "022062.01",
+            "courseCode": "022062",
+            "courseName": "热力学与统计物理A",
+            "teacher": "翁明其",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2106",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2106",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 85
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "022095.05",
+            "courseCode": "022095",
+            "courseName": "量子力学C",
+            "teacher": "季文韬"
+          },
+          "previous": {
+            "id": "022095.05",
+            "courseCode": "022095",
+            "courseName": "量子力学C",
+            "teacher": "季文韬",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A305",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "022095.05",
+            "courseCode": "022095",
+            "courseName": "量子力学C",
+            "teacher": "季文韬",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A305",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 70,
+              "after": 80
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "022118.01",
+            "courseCode": "022118",
+            "courseName": "固体物理B",
+            "teacher": "郑奇靖"
+          },
+          "previous": {
+            "id": "022118.01",
+            "courseCode": "022118",
+            "courseName": "固体物理B",
+            "teacher": "郑奇靖",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2207",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2207",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "022118.01",
+            "courseCode": "022118",
+            "courseName": "固体物理B",
+            "teacher": "郑奇靖",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2207",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2207",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 34,
+              "after": 60
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "022148.01",
+            "courseCode": "022148",
+            "courseName": "量子力学A",
+            "teacher": "施郁,胡昊昱"
+          },
+          "previous": {
+            "id": "022148.01",
+            "courseCode": "022148",
+            "courseName": "量子力学A",
+            "teacher": "施郁",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "022148.01",
+            "courseCode": "022148",
+            "courseName": "量子力学A",
+            "teacher": "施郁,胡昊昱",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "施郁",
+              "after": "施郁,胡昊昱"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "022166.01",
+            "courseCode": "022166",
+            "courseName": "天文学导论",
+            "teacher": "薛永泉"
+          },
+          "previous": {
+            "id": "022166.01",
+            "courseCode": "022166",
+            "courseName": "天文学导论",
+            "teacher": "薛永泉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16,
+                  18
+                ],
+                "room": "2121",
+                "day": 3,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  5,
+                  7,
+                  9,
+                  11,
+                  13,
+                  15,
+                  17
+                ],
+                "room": "2121",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "022166.01",
+            "courseCode": "022166",
+            "courseName": "天文学导论",
+            "teacher": "薛永泉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16,
+                  18
+                ],
+                "room": "2121",
+                "day": 3,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  5,
+                  7,
+                  9,
+                  11,
+                  13,
+                  15,
+                  17
+                ],
+                "room": "2121",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "undergradShared",
+              "label": "本研同堂",
+              "before": false,
+              "after": true
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "022392.03",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "潘海俊,王义林"
+          },
+          "previous": {
+            "id": "022392.03",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "潘海俊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5103",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5103",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "022392.03",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "潘海俊,王义林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5103",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5103",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "潘海俊",
+              "after": "潘海俊,王义林"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 65,
+              "after": 72
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "022392.05",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "杨睿智"
+          },
+          "previous": {
+            "id": "022392.05",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "杨睿智",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5201",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5201",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "022392.05",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "杨睿智",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5201",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5201",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 65,
+              "after": 72
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "022392.06",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "曹利明"
+          },
+          "previous": {
+            "id": "022392.06",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "曹利明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "022392.06",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "曹利明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 65,
+              "after": 72
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "022392.07",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "李毅"
+          },
+          "previous": {
+            "id": "022392.07",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "李毅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5104",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5104",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "022392.07",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "李毅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5104",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5104",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 65,
+              "after": 72
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "022392.08",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "朱界杰"
+          },
+          "previous": {
+            "id": "022392.08",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "朱界杰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1301",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1301",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "022392.08",
+            "courseCode": "022392",
+            "courseName": "理论力学A",
+            "teacher": "朱界杰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1301",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1301",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 65,
+              "after": 72
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "023181.01",
+            "courseCode": "023181",
+            "courseName": "线性电子线路",
+            "teacher": "郑柘炀"
+          },
+          "previous": {
+            "id": "023181.01",
+            "courseCode": "023181",
+            "courseName": "线性电子线路",
+            "teacher": "郑柘炀",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "023181.01",
+            "courseCode": "023181",
+            "courseName": "线性电子线路",
+            "teacher": "郑柘炀",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 70,
+              "after": 95
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "023181.02",
+            "courseCode": "023181",
+            "courseName": "线性电子线路",
+            "teacher": "陆广华"
+          },
+          "previous": {
+            "id": "023181.02",
+            "courseCode": "023181",
+            "courseName": "线性电子线路",
+            "teacher": "陆广华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A313",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A313",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "023181.02",
+            "courseCode": "023181",
+            "courseName": "线性电子线路",
+            "teacher": "陆广华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A313",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A313",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 72,
+              "after": 79
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "023181.03",
+            "courseCode": "023181",
+            "courseName": "线性电子线路",
+            "teacher": "陆伟"
+          },
+          "previous": {
+            "id": "023181.03",
+            "courseCode": "023181",
+            "courseName": "线性电子线路",
+            "teacher": "陆伟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A111",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A111",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "023181.03",
+            "courseCode": "023181",
+            "courseName": "线性电子线路",
+            "teacher": "陆伟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A111",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A111",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 70,
+              "after": 85
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "023181.04",
+            "courseCode": "023181",
+            "courseName": "线性电子线路",
+            "teacher": "许小东"
+          },
+          "previous": {
+            "id": "023181.04",
+            "courseCode": "023181",
+            "courseName": "线性电子线路",
+            "teacher": "许小东",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "023181.04",
+            "courseCode": "023181",
+            "courseName": "线性电子线路",
+            "teacher": "许小东",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 70,
+              "after": 77
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210036.01",
+            "courseCode": "210036",
+            "courseName": "软件安全与测试",
+            "teacher": "程绍银,方涵"
+          },
+          "previous": {
+            "id": "210036.01",
+            "courseCode": "210036",
+            "courseName": "软件安全与测试",
+            "teacher": "程绍银",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "GT-A401",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "210036.01",
+            "courseCode": "210036",
+            "courseName": "软件安全与测试",
+            "teacher": "程绍银,方涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "GT-A401",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "程绍银",
+              "after": "程绍银,方涵"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210037.01",
+            "courseCode": "210037",
+            "courseName": "数理逻辑与图论",
+            "teacher": "刘斌,马泽华"
+          },
+          "previous": {
+            "id": "210037.01",
+            "courseCode": "210037",
+            "courseName": "数理逻辑与图论",
+            "teacher": "刘斌",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "GT-B110",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "GT-B110",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "210037.01",
+            "courseCode": "210037",
+            "courseName": "数理逻辑与图论",
+            "teacher": "刘斌,马泽华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "GT-B110",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "GT-B110",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "刘斌",
+              "after": "刘斌,马泽华"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210050.01",
+            "courseCode": "210050",
+            "courseName": "数字逻辑电路",
+            "teacher": "胡新伟"
+          },
+          "previous": {
+            "id": "210050.01",
+            "courseCode": "210050",
+            "courseName": "数字逻辑电路",
+            "teacher": "胡新伟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A113",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "210050.01",
+            "courseCode": "210050",
+            "courseName": "数字逻辑电路",
+            "teacher": "胡新伟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A113",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 65,
+              "after": 82
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210050.02",
+            "courseCode": "210050",
+            "courseName": "数字逻辑电路",
+            "teacher": "秦晓卫"
+          },
+          "previous": {
+            "id": "210050.02",
+            "courseCode": "210050",
+            "courseName": "数字逻辑电路",
+            "teacher": "秦晓卫",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A312",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A312",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "210050.02",
+            "courseCode": "210050",
+            "courseName": "数字逻辑电路",
+            "teacher": "秦晓卫",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A312",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A312",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 65,
+              "after": 75
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210050.03",
+            "courseCode": "210050",
+            "courseName": "数字逻辑电路",
+            "teacher": "周烽"
+          },
+          "previous": {
+            "id": "210050.03",
+            "courseCode": "210050",
+            "courseName": "数字逻辑电路",
+            "teacher": "周烽",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A211",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A211",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "210050.03",
+            "courseCode": "210050",
+            "courseName": "数字逻辑电路",
+            "teacher": "周烽",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A211",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A211",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 70,
+              "after": 80
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210050.05",
+            "courseCode": "210050",
+            "courseName": "数字逻辑电路",
+            "teacher": "胡新伟"
+          },
+          "previous": {
+            "id": "210050.05",
+            "courseCode": "210050",
+            "courseName": "数字逻辑电路",
+            "teacher": "胡新伟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A305",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A305",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "210050.05",
+            "courseCode": "210050",
+            "courseName": "数字逻辑电路",
+            "teacher": "胡新伟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A305",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A305",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 75
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210078.04",
+            "courseCode": "210078",
+            "courseName": "电子系统设计",
+            "teacher": "李玉虎"
+          },
+          "previous": {
+            "id": "210078.04",
+            "courseCode": "210078",
+            "courseName": "电子系统设计",
+            "teacher": "李玉虎",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "GT-B211",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "GT-B211",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "210078.04",
+            "courseCode": "210078",
+            "courseName": "电子系统设计",
+            "teacher": "李玉虎",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "GT-B211",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "GT-B211",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 70,
+              "after": 75
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210503.01",
+            "courseCode": "210503",
+            "courseName": "数据结构与数据库",
+            "teacher": "刘勇"
+          },
+          "previous": {
+            "id": "210503.01",
+            "courseCode": "210503",
+            "courseName": "数据结构与数据库",
+            "teacher": "刘勇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "3C102",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "3C102",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "210503.01",
+            "courseCode": "210503",
+            "courseName": "数据结构与数据库",
+            "teacher": "刘勇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "3C102",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "3C102",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "25金融学",
+                "24机器人工程*"
+              ],
+              "after": [
+                "24测控技术与仪器",
+                "25金融学",
+                "24机器人工程*"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210708.01",
+            "courseCode": "210708",
+            "courseName": "数字图像处理B",
+            "teacher": "周文罡,李礼,李厚强,邓家俊"
+          },
+          "previous": {
+            "id": "210708.01",
+            "courseCode": "210708",
+            "courseName": "数字图像处理B",
+            "teacher": "周文罡,李礼,李厚强",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "GT-B105",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "GT-B105",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  12
+                ],
+                "room": "GT-B105",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "210708.01",
+            "courseCode": "210708",
+            "courseName": "数字图像处理B",
+            "teacher": "周文罡,李礼,李厚强,邓家俊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "GT-B105",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  12
+                ],
+                "room": "GT-B105",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "GT-B105",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  12
+                ],
+                "room": "GT-B105",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "周文罡,李礼,李厚强",
+              "after": "周文罡,李礼,李厚强,邓家俊"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "229001.01",
+            "courseCode": "229001",
+            "courseName": "离散数学",
+            "teacher": "邵帅,王超"
+          },
+          "previous": {
+            "id": "229001.01",
+            "courseCode": "229001",
+            "courseName": "离散数学",
+            "teacher": "邵帅,王超",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A313",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A313",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "229001.01",
+            "courseCode": "229001",
+            "courseName": "离散数学",
+            "teacher": "邵帅,王超",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A313",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A313",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 80
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "910008.01",
+            "courseCode": "910008",
+            "courseName": "病原生物学",
+            "teacher": "魏海明,马筱玲,计永胜,周永刚,崔国梁"
+          },
+          "previous": {
+            "id": "910008.01",
+            "courseCode": "910008",
+            "courseName": "病原生物学",
+            "teacher": "魏海明,马筱玲,计永胜,周永刚",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  3
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  8
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  15
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  14
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  15,
+                  18
+                ],
+                "room": "西区生物楼附楼K504",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  3
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  8
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  15
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  14
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "910008.01",
+            "courseCode": "910008",
+            "courseName": "病原生物学",
+            "teacher": "魏海明,马筱玲,计永胜,周永刚,崔国梁",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  3
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  8
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  15
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  14
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区生物楼附楼K504",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  15,
+                  18
+                ],
+                "room": "西区生物楼附楼K504",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  3
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  8
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  15
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  14
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "魏海明,马筱玲,计永胜,周永刚",
+              "after": "魏海明,马筱玲,计永胜,周永刚,崔国梁"
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    3
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    7
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    8
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    14,
+                    15
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    15,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    3
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    7
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    8
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    14,
+                    15
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    14
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    3
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    7
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    8
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    14,
+                    15
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    15,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    3
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    7
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    8
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    14,
+                    15
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    14
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "910011.01",
+            "courseCode": "910011",
+            "courseName": "人体机能学实验",
+            "teacher": "张隆华,汪铭,胡媛萍,胡兵,倪芳,陈聚涛"
+          },
+          "previous": {
+            "id": "910011.01",
+            "courseCode": "910011",
+            "courseName": "人体机能学实验",
+            "teacher": "陈聚涛,张隆华,胡兵,汪铭,倪芳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "西区生物楼附楼K508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  5
+                ],
+                "room": "西区生物楼附楼K508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  4
+                ],
+                "room": "西区生物楼附楼K508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "西区生物楼附楼K508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  12
+                ],
+                "room": "西区生物楼附楼K508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  16
+                ],
+                "room": "西区生物楼附楼K508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "910011.01",
+            "courseCode": "910011",
+            "courseName": "人体机能学实验",
+            "teacher": "张隆华,汪铭,胡媛萍,胡兵,倪芳,陈聚涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "西区生物楼附楼K508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  5
+                ],
+                "room": "西区生物楼附楼K508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  4
+                ],
+                "room": "西区生物楼附楼K508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "西区生物楼附楼K508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  12
+                ],
+                "room": "西区生物楼附楼K508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  16
+                ],
+                "room": "西区生物楼附楼K508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "陈聚涛,张隆华,胡兵,汪铭,倪芳",
+              "after": "张隆华,汪铭,胡媛萍,胡兵,倪芳,陈聚涛"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "AI1001B.03",
+            "courseCode": "AI1001B",
+            "courseName": "人工智能数学原理与算法B",
+            "teacher": "钟志诚,张少锋"
+          },
+          "previous": {
+            "id": "AI1001B.03",
+            "courseCode": "AI1001B",
+            "courseName": "人工智能数学原理与算法B",
+            "teacher": "钟志诚",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  13
+                ],
+                "room": "3C102",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "AI1001B.03",
+            "courseCode": "AI1001B",
+            "courseName": "人工智能数学原理与算法B",
+            "teacher": "钟志诚,张少锋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  13
+                ],
+                "room": "3C102",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "钟志诚",
+              "after": "钟志诚,张少锋"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "AI1501.01",
+            "courseCode": "AI1501",
+            "courseName": "生成式人工智能概述",
+            "teacher": "刘武,杨勋,常晓军"
+          },
+          "previous": {
+            "id": "AI1501.01",
+            "courseCode": "AI1501",
+            "courseName": "生成式人工智能概述",
+            "teacher": "刘武,杨勋,常晓军",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  10
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  14
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "AI1501.01",
+            "courseCode": "AI1501",
+            "courseName": "生成式人工智能概述",
+            "teacher": "刘武,杨勋,常晓军",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  10
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  14
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 80
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "AI2001B.01",
+            "courseCode": "AI2001B",
+            "courseName": "人工智能导论B",
+            "teacher": "於俊,王子磊"
+          },
+          "previous": {
+            "id": "AI2001B.01",
+            "courseCode": "AI2001B",
+            "courseName": "人工智能导论B",
+            "teacher": "於俊,王子磊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "GT-B212",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  8,
+                  14
+                ],
+                "room": "GT-B212",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "AI2001B.01",
+            "courseCode": "AI2001B",
+            "courseName": "人工智能导论B",
+            "teacher": "於俊,王子磊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "GT-B212",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  8,
+                  14
+                ],
+                "room": "GT-B212",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 100,
+              "after": 110
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "AI3002.01",
+            "courseCode": "AI3002",
+            "courseName": "人工智能与机器学习基础",
+            "teacher": "王翔"
+          },
+          "previous": {
+            "id": "AI3002.01",
+            "courseCode": "AI3002",
+            "courseName": "人工智能与机器学习基础",
+            "teacher": "王翔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "GT-B112",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "AI3002.01",
+            "courseCode": "AI3002",
+            "courseName": "人工智能与机器学习基础",
+            "teacher": "王翔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "GT-B112",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 47,
+              "after": 120
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "AI3002.02",
+            "courseCode": "AI3002",
+            "courseName": "人工智能与机器学习基础",
+            "teacher": "张岸"
+          },
+          "previous": {
+            "id": "AI3002.02",
+            "courseCode": "AI3002",
+            "courseName": "人工智能与机器学习基础",
+            "teacher": "张岸",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3C103",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "AI3002.02",
+            "courseCode": "AI3002",
+            "courseName": "人工智能与机器学习基础",
+            "teacher": "张岸",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3C103",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 72,
+              "after": 130
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIO1504G.01",
+            "courseCode": "BIO1504G",
+            "courseName": "人体健康与疾病",
+            "teacher": "陈永艳,江维"
+          },
+          "previous": {
+            "id": "BIO1504G.01",
+            "courseCode": "BIO1504G",
+            "courseName": "人体健康与疾病",
+            "teacher": "陈永艳,江维",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5107",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "5107",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIO1504G.01",
+            "courseCode": "BIO1504G",
+            "courseName": "人体健康与疾病",
+            "teacher": "陈永艳,江维",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5107",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "5107",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 60
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIO1505G.01",
+            "courseCode": "BIO1505G",
+            "courseName": "生物技术与生命科学",
+            "teacher": "郑晓东,余家力"
+          },
+          "previous": {
+            "id": "BIO1505G.01",
+            "courseCode": "BIO1505G",
+            "courseName": "生物技术与生命科学",
+            "teacher": "郑晓东",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "2121",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIO1505G.01",
+            "courseCode": "BIO1505G",
+            "courseName": "生物技术与生命科学",
+            "teacher": "郑晓东,余家力",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "2121",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "郑晓东",
+              "after": "郑晓东,余家力"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIO1506G.01",
+            "courseCode": "BIO1506G",
+            "courseName": "脑科学与认知科学导论",
+            "teacher": "毕国强,杨昱鹏,张智,晋艳,张效初,侯熠文"
+          },
+          "previous": {
+            "id": "BIO1506G.01",
+            "courseCode": "BIO1506G",
+            "courseName": "脑科学与认知科学导论",
+            "teacher": "毕国强,杨昱鹏,张智,晋艳,张效初",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  5
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  8
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  11
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  14
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIO1506G.01",
+            "courseCode": "BIO1506G",
+            "courseName": "脑科学与认知科学导论",
+            "teacher": "毕国强,杨昱鹏,张智,晋艳,张效初,侯熠文",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  5
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  14
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  8
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  11
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  14
+                ],
+                "room": "3A109",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "毕国强,杨昱鹏,张智,晋艳,张效初",
+              "after": "毕国强,杨昱鹏,张智,晋艳,张效初,侯熠文"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIO1511G.01",
+            "courseCode": "BIO1511G",
+            "courseName": "生命的化学基础",
+            "teacher": "龙冬,薛林"
+          },
+          "previous": {
+            "id": "BIO1511G.01",
+            "courseCode": "BIO1511G",
+            "courseName": "生命的化学基础",
+            "teacher": "龙冬,薛林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  10
+                ],
+                "room": "5104",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  13
+                ],
+                "room": "5104",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIO1511G.01",
+            "courseCode": "BIO1511G",
+            "courseName": "生命的化学基础",
+            "teacher": "龙冬,薛林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  10
+                ],
+                "room": "5104",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  13
+                ],
+                "room": "5104",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 80
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIO1514G.01",
+            "courseCode": "BIO1514G",
+            "courseName": "生物进化论的历史由来、基本概念及未来发展",
+            "teacher": "占成,薛天,刘静"
+          },
+          "previous": {
+            "id": "BIO1514G.01",
+            "courseCode": "BIO1514G",
+            "courseName": "生物进化论的历史由来、基本概念及未来发展",
+            "teacher": "占成,薛天",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  9
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIO1514G.01",
+            "courseCode": "BIO1514G",
+            "courseName": "生物进化论的历史由来、基本概念及未来发展",
+            "teacher": "占成,薛天,刘静",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  9
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  14
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "占成,薛天",
+              "after": "占成,薛天,刘静"
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    9
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    10,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    9
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    10,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIO1517.01",
+            "courseCode": "BIO1517",
+            "courseName": "地球生命演化",
+            "teacher": "李旭"
+          },
+          "previous": {
+            "id": "BIO1517.01",
+            "courseCode": "BIO1517",
+            "courseName": "地球生命演化",
+            "teacher": "李旭",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "1101",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIO1517.01",
+            "courseCode": "BIO1517",
+            "courseName": "地球生命演化",
+            "teacher": "李旭",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "1101",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 90
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIO3701.01",
+            "courseCode": "BIO3701",
+            "courseName": "生物医学论文写作",
+            "teacher": "宋晓元"
+          },
+          "previous": {
+            "id": "BIO3701.01",
+            "courseCode": "BIO3701",
+            "courseName": "生物医学论文写作",
+            "teacher": "宋晓元",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A104",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIO3701.01",
+            "courseCode": "BIO3701",
+            "courseName": "生物医学论文写作",
+            "teacher": "宋晓元",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A104",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 22
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL5181P.03",
+            "courseCode": "BIOL5181P",
+            "courseName": "生物信息学",
+            "teacher": "瞿昆,许川,李倩"
+          },
+          "previous": {
+            "id": "BIOL5181P.03",
+            "courseCode": "BIOL5181P",
+            "courseName": "生物信息学",
+            "teacher": "瞿昆",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3B102",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL5181P.03",
+            "courseCode": "BIOL5181P",
+            "courseName": "生物信息学",
+            "teacher": "瞿昆,许川,李倩",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3B102",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "瞿昆",
+              "after": "瞿昆,许川,李倩"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL6425P.01",
+            "courseCode": "BIOL6425P",
+            "courseName": "高级生理学",
+            "teacher": "姜浩武,薛天,汪铭,孟建军,晋艳,曹鹏,曹洋,张济舟"
+          },
+          "previous": {
+            "id": "BIOL6425P.01",
+            "courseCode": "BIOL6425P",
+            "courseName": "高级生理学",
+            "teacher": "晋艳,陈聚涛,薛天,汪铭",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A202",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL6425P.01",
+            "courseCode": "BIOL6425P",
+            "courseName": "高级生理学",
+            "teacher": "姜浩武,薛天,汪铭,孟建军,晋艳,曹鹏,曹洋,张济舟",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A202",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "晋艳,陈聚涛,薛天,汪铭",
+              "after": "姜浩武,薛天,汪铭,孟建军,晋艳,曹鹏,曹洋,张济舟"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BMED6226P.01",
+            "courseCode": "BMED6226P",
+            "courseName": "神经与康复工程",
+            "teacher": "崔锦江"
+          },
+          "previous": {
+            "id": "BMED6226P.01",
+            "courseCode": "BMED6226P",
+            "courseName": "神经与康复工程",
+            "teacher": "崔锦江",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "若水路D105",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "BMED6226P.01",
+            "courseCode": "BMED6226P",
+            "courseName": "神经与康复工程",
+            "teacher": "崔锦江",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "若水路D204",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "若水路D105",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "若水路D204",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BMED6230P.01",
+            "courseCode": "BMED6230P",
+            "courseName": "生物芯片技术与应用",
+            "teacher": "秦建华"
+          },
+          "previous": {
+            "id": "BMED6230P.01",
+            "courseCode": "BMED6230P",
+            "courseName": "生物芯片技术与应用",
+            "teacher": "秦建华",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "若水路D105",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "BMED6230P.01",
+            "courseCode": "BMED6230P",
+            "courseName": "生物芯片技术与应用",
+            "teacher": "秦建华",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "若水路D204",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "若水路D105",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "若水路D204",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BMED7401P.02",
+            "courseCode": "BMED7401P",
+            "courseName": "生物医学工程前沿专题",
+            "teacher": "孙明斋"
+          },
+          "previous": {
+            "id": "BMED7401P.02",
+            "courseCode": "BMED7401P",
+            "courseName": "生物医学工程前沿专题",
+            "teacher": "孙明斋",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "若水路D201",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "BMED7401P.02",
+            "courseCode": "BMED7401P",
+            "courseName": "生物医学工程前沿专题",
+            "teacher": "孙明斋",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "若水路D201",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "其他",
+              "after": ""
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEM3001.01",
+            "courseCode": "CHEM3001",
+            "courseName": "催化化学",
+            "teacher": "严欢,黄伟新,千坤"
+          },
+          "previous": {
+            "id": "CHEM3001.01",
+            "courseCode": "CHEM3001",
+            "courseName": "催化化学",
+            "teacher": "严欢,黄伟新,千坤",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "2305",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "2305",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  18
+                ],
+                "room": "2305",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "2305",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "2305",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  18
+                ],
+                "room": "2305",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEM3001.01",
+            "courseCode": "CHEM3001",
+            "courseName": "催化化学",
+            "teacher": "严欢,黄伟新,千坤",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "2305",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "2305",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  18
+                ],
+                "room": "2305",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "2305",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "2305",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  18
+                ],
+                "room": "2305",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 32
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEM6424P.04",
+            "courseCode": "CHEM6424P",
+            "courseName": "综合仪器分析实验",
+            "teacher": "胡万群,邵伟,周强,刘斯,张清伟"
+          },
+          "previous": {
+            "id": "CHEM6424P.04",
+            "courseCode": "CHEM6424P",
+            "courseName": "综合仪器分析实验",
+            "teacher": "胡万群,邵伟,周强,刘斯,张清伟",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "环资楼106;环资楼115 ;环资楼310;环资楼312;环资楼313;环资楼316;环资楼101B",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEM6424P.04",
+            "courseCode": "CHEM6424P",
+            "courseName": "综合仪器分析实验",
+            "teacher": "胡万群,邵伟,周强,刘斯,张清伟",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "环资楼106;环资楼115 ;环资楼310;环资楼312;环资楼313;环资楼316;环资楼101B",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 24
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6001P.01",
+            "courseCode": "COMP6001P",
+            "courseName": "算法设计与分析",
+            "teacher": "汪炀,徐殷"
+          },
+          "previous": {
+            "id": "COMP6001P.01",
+            "courseCode": "COMP6001P",
+            "courseName": "算法设计与分析",
+            "teacher": "汪炀,徐殷",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "G3-108",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "G3-108",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6001P.01",
+            "courseCode": "COMP6001P",
+            "courseName": "算法设计与分析",
+            "teacher": "汪炀,徐殷",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "G3-108",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "G3-108",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 170,
+              "after": 178
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6001P.02",
+            "courseCode": "COMP6001P",
+            "courseName": "算法设计与分析",
+            "teacher": "汪炀,徐殷"
+          },
+          "previous": {
+            "id": "COMP6001P.02",
+            "courseCode": "COMP6001P",
+            "courseName": "算法设计与分析",
+            "teacher": "汪炀,徐殷",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "G3-108",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "G3-108",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6001P.02",
+            "courseCode": "COMP6001P",
+            "courseName": "算法设计与分析",
+            "teacher": "汪炀,徐殷",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "G3-108",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "G3-108",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 170,
+              "after": 178
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6002P.01",
+            "courseCode": "COMP6002P",
+            "courseName": "组合数学",
+            "teacher": "许胤龙,吕敏"
+          },
+          "previous": {
+            "id": "COMP6002P.01",
+            "courseCode": "COMP6002P",
+            "courseName": "组合数学",
+            "teacher": "许胤龙,吕敏",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B212",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B212",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6002P.01",
+            "courseCode": "COMP6002P",
+            "courseName": "组合数学",
+            "teacher": "许胤龙,吕敏",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B212",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B212",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 170,
+              "after": 178
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6002P.02",
+            "courseCode": "COMP6002P",
+            "courseName": "组合数学",
+            "teacher": "邵帅"
+          },
+          "previous": {
+            "id": "COMP6002P.02",
+            "courseCode": "COMP6002P",
+            "courseName": "组合数学",
+            "teacher": "邵帅",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "G3-108",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6002P.02",
+            "courseCode": "COMP6002P",
+            "courseName": "组合数学",
+            "teacher": "邵帅",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "G3-108",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 170,
+              "after": 17
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6003P.01",
+            "courseCode": "COMP6003P",
+            "courseName": "计算机应用数学",
+            "teacher": "宋骐"
+          },
+          "previous": {
+            "id": "COMP6003P.01",
+            "courseCode": "COMP6003P",
+            "courseName": "计算机应用数学",
+            "teacher": "宋骐",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-108",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6003P.01",
+            "courseCode": "COMP6003P",
+            "courseName": "计算机应用数学",
+            "teacher": "宋骐",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-108",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 170,
+              "after": 178
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6004P.01",
+            "courseCode": "COMP6004P",
+            "courseName": "计算机系统",
+            "teacher": "周学海"
+          },
+          "previous": {
+            "id": "COMP6004P.01",
+            "courseCode": "COMP6004P",
+            "courseName": "计算机系统",
+            "teacher": "周学海",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-108",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6004P.01",
+            "courseCode": "COMP6004P",
+            "courseName": "计算机系统",
+            "teacher": "周学海",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-108",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 170,
+              "after": 178
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6103P.01",
+            "courseCode": "COMP6103P",
+            "courseName": "高级计算机网络",
+            "teacher": "赵功名"
+          },
+          "previous": {
+            "id": "COMP6103P.01",
+            "courseCode": "COMP6103P",
+            "courseName": "高级计算机网络",
+            "teacher": "赵功名",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GT-B112",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6103P.01",
+            "courseCode": "COMP6103P",
+            "courseName": "高级计算机网络",
+            "teacher": "赵功名",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GT-B112",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 170,
+              "after": 178
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6110P.01",
+            "courseCode": "COMP6110P",
+            "courseName": "机器学习与知识发现",
+            "teacher": "陈恩红,徐林莉"
+          },
+          "previous": {
+            "id": "COMP6110P.01",
+            "courseCode": "COMP6110P",
+            "courseName": "机器学习与知识发现",
+            "teacher": "陈恩红,徐林莉",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-108",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6110P.01",
+            "courseCode": "COMP6110P",
+            "courseName": "机器学习与知识发现",
+            "teacher": "陈恩红,徐林莉",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-108",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 170,
+              "after": 178
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6207P.01",
+            "courseCode": "COMP6207P",
+            "courseName": "图像处理",
+            "teacher": "董兰芳"
+          },
+          "previous": {
+            "id": "COMP6207P.01",
+            "courseCode": "COMP6207P",
+            "courseName": "图像处理",
+            "teacher": "董兰芳",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GT-B212",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6207P.01",
+            "courseCode": "COMP6207P",
+            "courseName": "图像处理",
+            "teacher": "董兰芳",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GT-B212",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "其他",
+              "after": ""
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6211P.01",
+            "courseCode": "COMP6211P",
+            "courseName": "高级计算机图形学",
+            "teacher": "董兰芳"
+          },
+          "previous": {
+            "id": "COMP6211P.01",
+            "courseCode": "COMP6211P",
+            "courseName": "高级计算机图形学",
+            "teacher": "董兰芳",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G2-B303",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6211P.01",
+            "courseCode": "COMP6211P",
+            "courseName": "高级计算机图形学",
+            "teacher": "董兰芳",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G2-B303",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "其他",
+              "after": ""
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6212P.01",
+            "courseCode": "COMP6212P",
+            "courseName": "计算机视觉",
+            "teacher": "王上飞"
+          },
+          "previous": {
+            "id": "COMP6212P.01",
+            "courseCode": "COMP6212P",
+            "courseName": "计算机视觉",
+            "teacher": "王上飞",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-109",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6212P.01",
+            "courseCode": "COMP6212P",
+            "courseName": "计算机视觉",
+            "teacher": "王上飞",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-109",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "其他",
+              "after": ""
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6213P.01",
+            "courseCode": "COMP6213P",
+            "courseName": "生物信息学",
+            "teacher": "郑浩然"
+          },
+          "previous": {
+            "id": "COMP6213P.01",
+            "courseCode": "COMP6213P",
+            "courseName": "生物信息学",
+            "teacher": "郑浩然",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-A401",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6213P.01",
+            "courseCode": "COMP6213P",
+            "courseName": "生物信息学",
+            "teacher": "郑浩然",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-A401",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "其他",
+              "after": ""
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "COMP6217P.01",
+            "courseCode": "COMP6217P",
+            "courseName": "智能物联网",
+            "teacher": "张信明"
+          },
+          "previous": {
+            "id": "COMP6217P.01",
+            "courseCode": "COMP6217P",
+            "courseName": "智能物联网",
+            "teacher": "张信明",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-108",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "COMP6217P.01",
+            "courseCode": "COMP6217P",
+            "courseName": "智能物联网",
+            "teacher": "张信明",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-108",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "其他",
+              "after": ""
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "DSCI6002P.01",
+            "courseCode": "DSCI6002P",
+            "courseName": "深度学习",
+            "teacher": "王超,康奇宇"
+          },
+          "previous": {
+            "id": "DSCI6002P.01",
+            "courseCode": "DSCI6002P",
+            "courseName": "深度学习",
+            "teacher": "王超,康奇宇",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-110",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "DSCI6002P.01",
+            "courseCode": "DSCI6002P",
+            "courseName": "深度学习",
+            "teacher": "王超,康奇宇",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-110",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 120,
+              "after": 180
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "DSCI6003P.01",
+            "courseCode": "DSCI6003P",
+            "courseName": "强化学习",
+            "teacher": "张少锋,苏骏炜"
+          },
+          "previous": {
+            "id": "DSCI6003P.01",
+            "courseCode": "DSCI6003P",
+            "courseName": "强化学习",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G2-B303",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "DSCI6003P.01",
+            "courseCode": "DSCI6003P",
+            "courseName": "强化学习",
+            "teacher": "张少锋,苏骏炜",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "G3-109",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "张少锋,苏骏炜"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 120,
+              "after": 180
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "G2-B303",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "G3-109",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.03",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.03",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.03",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 125,
+              "after": 127
+            },
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "24材料物理",
+                "24材料化学",
+                "24分析化学",
+                "24化学物理仪器",
+                "24应用化学",
+                "24化学物理",
+                "24化学生物学",
+                "24物理化学",
+                "24无机化学",
+                "24有机化学",
+                "24高分子材料"
+              ],
+              "after": [
+                "24材料物理",
+                "24材料化学",
+                "24分析化学",
+                "24化学物理仪器",
+                "24应用化学",
+                "24化学物理",
+                "24化学生物学",
+                "24物理化学",
+                "24无机化学",
+                "24有机化学",
+                "24高分子材料",
+                "24高分子化学与物理"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EE2003.03",
+            "courseCode": "EE2003",
+            "courseName": "计算机原理与嵌入式系统",
+            "teacher": "何力,周燚"
+          },
+          "previous": {
+            "id": "EE2003.03",
+            "courseCode": "EE2003",
+            "courseName": "计算机原理与嵌入式系统",
+            "teacher": "何力,周燚",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3C302",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3C302",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "EE2003.03",
+            "courseCode": "EE2003",
+            "courseName": "计算机原理与嵌入式系统",
+            "teacher": "何力,周燚",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3C302",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3C302",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 72,
+              "after": 77
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EE2003.05",
+            "courseCode": "EE2003",
+            "courseName": "计算机原理与嵌入式系统",
+            "teacher": "王嵩,张旭,何力,周燚"
+          },
+          "previous": {
+            "id": "EE2003.05",
+            "courseCode": "EE2003",
+            "courseName": "计算机原理与嵌入式系统",
+            "teacher": "王嵩,张旭,何力,周燚",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "3C103",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  15
+                ],
+                "room": "3C103",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "3C103",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  15
+                ],
+                "room": "3C103",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "EE2003.05",
+            "courseCode": "EE2003",
+            "courseName": "计算机原理与嵌入式系统",
+            "teacher": "王嵩,张旭,何力,周燚",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "3C103",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  15
+                ],
+                "room": "3C103",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "3C103",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  15
+                ],
+                "room": "3C103",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 70,
+              "after": 79
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EE2007.01",
+            "courseCode": "EE2007",
+            "courseName": "运筹学A",
+            "teacher": "熊军林"
+          },
+          "previous": {
+            "id": "EE2007.01",
+            "courseCode": "EE2007",
+            "courseName": "运筹学A",
+            "teacher": "熊军林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "GT-B210",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "GT-B210",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "EE2007.01",
+            "courseCode": "EE2007",
+            "courseName": "运筹学A",
+            "teacher": "熊军林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "GT-B210",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "GT-B210",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 100,
+              "after": 105
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EE2501.02",
+            "courseCode": "EE2501",
+            "courseName": "电子技术基础",
+            "teacher": "曹平"
+          },
+          "previous": {
+            "id": "EE2501.02",
+            "courseCode": "EE2501",
+            "courseName": "电子技术基础",
+            "teacher": "曹平",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A213",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "EE2501.02",
+            "courseCode": "EE2501",
+            "courseName": "电子技术基础",
+            "teacher": "曹平",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3C202",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 90,
+              "after": 102
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A213",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "3C202",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EE2502.05",
+            "courseCode": "EE2502",
+            "courseName": "数字电路",
+            "teacher": "赵雷"
+          },
+          "previous": {
+            "id": "EE2502.05",
+            "courseCode": "EE2502",
+            "courseName": "数字电路",
+            "teacher": "赵雷",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1101",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "EE2502.05",
+            "courseCode": "EE2502",
+            "courseName": "数字电路",
+            "teacher": "赵雷",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1101",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 80,
+              "after": 90
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EE2502.06",
+            "courseCode": "EE2502",
+            "courseName": "数字电路",
+            "teacher": "李锋,曹平"
+          },
+          "previous": {
+            "id": "EE2502.06",
+            "courseCode": "EE2502",
+            "courseName": "数字电路",
+            "teacher": "曹平,李锋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "3C204",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "3C204",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "EE2502.06",
+            "courseCode": "EE2502",
+            "courseName": "数字电路",
+            "teacher": "李锋,曹平",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "3C204",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "3C204",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 65,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EE3005.02",
+            "courseCode": "EE3005",
+            "courseName": "现代通信原理",
+            "teacher": "周武旸,赵明"
+          },
+          "previous": {
+            "id": "EE3005.02",
+            "courseCode": "EE3005",
+            "courseName": "现代通信原理",
+            "teacher": "周武旸,赵明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  3
+                ],
+                "room": "GT-B210",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  11,
+                  15
+                ],
+                "room": "GT-B210",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  3,
+                  10
+                ],
+                "room": "GT-B210",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  10
+                ],
+                "room": "高新区先进电子系统实验室实验安排:周一下午、晚上,周二晚上,周三下午、晚上,周四晚上",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  11,
+                  15
+                ],
+                "room": "高新区先进电子系统实验室实验安排:周一下午、晚上,周二晚上,周三下午、晚上,周四晚上",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  3
+                ],
+                "room": "GT-B210",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  11,
+                  15
+                ],
+                "room": "GT-B210",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  3,
+                  10
+                ],
+                "room": "GT-B210",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "EE3005.02",
+            "courseCode": "EE3005",
+            "courseName": "现代通信原理",
+            "teacher": "周武旸,赵明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  3
+                ],
+                "room": "GT-B210",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  11,
+                  15
+                ],
+                "room": "GT-B210",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  3,
+                  10
+                ],
+                "room": "GT-B210",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  10
+                ],
+                "room": "高新区先进电子系统实验室实验安排:周一下午、晚上,周二晚上,周三下午、晚上,周四晚上",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  11,
+                  15
+                ],
+                "room": "高新区先进电子系统实验室实验安排:周一下午、晚上,周二晚上,周三下午、晚上,周四晚上",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  3
+                ],
+                "room": "GT-B210",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  11,
+                  15
+                ],
+                "room": "GT-B210",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  3,
+                  10
+                ],
+                "room": "GT-B210",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 70,
+              "after": 74
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EE4501.01",
+            "courseCode": "EE4501",
+            "courseName": "脑机接口",
+            "teacher": "陈勋,刘爱萍,李煜"
+          },
+          "previous": {
+            "id": "EE4501.01",
+            "courseCode": "EE4501",
+            "courseName": "脑机接口",
+            "teacher": "陈勋,刘爱萍",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  8
+                ],
+                "room": "GT-B110",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  15
+                ],
+                "room": "GT-B110",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "EE4501.01",
+            "courseCode": "EE4501",
+            "courseName": "脑机接口",
+            "teacher": "陈勋,刘爱萍,李煜",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  8
+                ],
+                "room": "GT-B110",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "GT-B110",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  15
+                ],
+                "room": "GT-B110",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "陈勋,刘爱萍",
+              "after": "陈勋,刘爱萍,李煜"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 80,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EIEN7401P.05",
+            "courseCode": "EIEN7401P",
+            "courseName": "电子信息类开放实践课",
+            "teacher": "胡心亭"
+          },
+          "previous": {
+            "id": "EIEN7401P.05",
+            "courseCode": "EIEN7401P",
+            "courseName": "电子信息类开放实践课",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  18
+                ],
+                "room": "G2-B302",
+                "day": 1,
+                "periods": [
+                  10,
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "EIEN7401P.05",
+            "courseCode": "EIEN7401P",
+            "courseName": "电子信息类开放实践课",
+            "teacher": "胡心亭",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  18
+                ],
+                "room": "G2-B302",
+                "day": 1,
+                "periods": [
+                  10,
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "胡心亭"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ELEC5303P.01",
+            "courseCode": "ELEC5303P",
+            "courseName": "超大规模集成电路工艺学",
+            "teacher": "金西"
+          },
+          "previous": {
+            "id": "ELEC5303P.01",
+            "courseCode": "ELEC5303P",
+            "courseName": "超大规模集成电路工艺学",
+            "teacher": "金西",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5201",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ELEC5303P.01",
+            "courseCode": "ELEC5303P",
+            "courseName": "超大规模集成电路工艺学",
+            "teacher": "金西",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5201",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 150,
+              "after": 170
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ELEC5304P.03",
+            "courseCode": "ELEC5304P",
+            "courseName": "半导体器件原理",
+            "teacher": "徐军,郭国平"
+          },
+          "previous": {
+            "id": "ELEC5304P.03",
+            "courseCode": "ELEC5304P",
+            "courseName": "半导体器件原理",
+            "teacher": "徐军,郭国平",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3B102",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ELEC5304P.03",
+            "courseCode": "ELEC5304P",
+            "courseName": "半导体器件原理",
+            "teacher": "徐军,郭国平",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3B102",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 150,
+              "after": 170
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ENVS1501.01",
+            "courseCode": "ENVS1501",
+            "courseName": "漫谈双碳科技",
+            "teacher": "刘江涛"
+          },
+          "previous": {
+            "id": "ENVS1501.01",
+            "courseCode": "ENVS1501",
+            "courseName": "漫谈双碳科技",
+            "teacher": "刘江涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2621",
+                "day": 4,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ENVS1501.01",
+            "courseCode": "ENVS1501",
+            "courseName": "漫谈双碳科技",
+            "teacher": "刘江涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2621",
+                "day": 4,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 90,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ENVS4003.01",
+            "courseCode": "ENVS4003",
+            "courseName": "环境遥感",
+            "teacher": "刘诚"
+          },
+          "previous": {
+            "id": "ENVS4003.01",
+            "courseCode": "ENVS4003",
+            "courseName": "环境遥感",
+            "teacher": "刘诚",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2505",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ENVS4003.01",
+            "courseCode": "ENVS4003",
+            "courseName": "环境遥感",
+            "teacher": "刘诚",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2505",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 22,
+              "after": 32
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FIN1502.01",
+            "courseCode": "FIN1502",
+            "courseName": "诺贝尔经济学经典选读",
+            "teacher": "李林子"
+          },
+          "previous": {
+            "id": "FIN1502.01",
+            "courseCode": "FIN1502",
+            "courseName": "诺贝尔经济学经典选读",
+            "teacher": "李林子",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  12
+                ],
+                "room": "2211",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FIN1502.01",
+            "courseCode": "FIN1502",
+            "courseName": "诺贝尔经济学经典选读",
+            "teacher": "李林子",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  12
+                ],
+                "room": "2211",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 80
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FINA6408P.01",
+            "courseCode": "FINA6408P",
+            "courseName": "大数据分析技术",
+            "teacher": "庞引明"
+          },
+          "previous": {
+            "id": "FINA6408P.01",
+            "courseCode": "FINA6408P",
+            "courseName": "大数据分析技术",
+            "teacher": "庞引明",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  6,
+                  10
+                ],
+                "room": "囯金院",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  10
+                ],
+                "room": "囯金院",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "FINA6408P.01",
+            "courseCode": "FINA6408P",
+            "courseName": "大数据分析技术",
+            "teacher": "庞引明",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  6,
+                  10
+                ],
+                "room": "合上",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  10
+                ],
+                "room": "囯金院",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "囯金院",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "合上",
+                  "campus": "其他"
+                },
+                {
+                  "room": "囯金院",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1009.01",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao"
+          },
+          "previous": {
+            "id": "FL1009.01",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "3A203",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1009.01",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "3A203",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1009.02",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao"
+          },
+          "previous": {
+            "id": "FL1009.02",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "3A203",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1009.02",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "3A203",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1009.03",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao"
+          },
+          "previous": {
+            "id": "FL1009.03",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "3A203",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1009.03",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "3A203",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 45
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1009.04",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao"
+          },
+          "previous": {
+            "id": "FL1009.04",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "3A203",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1009.04",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "3A203",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 0
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1009.05",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Matthew Bell"
+          },
+          "previous": {
+            "id": "FL1009.05",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Matthew Bell",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "3A203",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1009.05",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Matthew Bell",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "3A203",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 45
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1009.06",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "FL1009.06",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Matthew Bell",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "3A203",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1009.06",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Matthew Bell",
+              "after": ""
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 0
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    10,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": []
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A203",
+                  "campus": "本部"
+                }
+              ],
+              "after": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1009.07",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao"
+          },
+          "previous": {
+            "id": "FL1009.07",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "2204",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1009.07",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "2204",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1009.08",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao"
+          },
+          "previous": {
+            "id": "FL1009.08",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "2204",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1009.08",
+            "courseCode": "FL1009",
+            "courseName": "英语交流进阶III",
+            "teacher": "Thomas Yifang Xiao",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "2204",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 0
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1017.05",
+            "courseCode": "FL1017",
+            "courseName": "科普英语交流",
+            "teacher": "陈静"
+          },
+          "previous": {
+            "id": "FL1017.05",
+            "courseCode": "FL1017",
+            "courseName": "科普英语交流",
+            "teacher": "陈静",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "3A209",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1017.05",
+            "courseCode": "FL1017",
+            "courseName": "科普英语交流",
+            "teacher": "陈静",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "3A209",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 43
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1017.06",
+            "courseCode": "FL1017",
+            "courseName": "科普英语交流",
+            "teacher": "陈静"
+          },
+          "previous": {
+            "id": "FL1017.06",
+            "courseCode": "FL1017",
+            "courseName": "科普英语交流",
+            "teacher": "陈静",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  14
+                ],
+                "room": "3A209",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1017.06",
+            "courseCode": "FL1017",
+            "courseName": "科普英语交流",
+            "teacher": "陈静",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  14
+                ],
+                "room": "3A209",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 43
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1017.10",
+            "courseCode": "FL1017",
+            "courseName": "科普英语交流",
+            "teacher": "陈静"
+          },
+          "previous": {
+            "id": "FL1017.10",
+            "courseCode": "FL1017",
+            "courseName": "科普英语交流",
+            "teacher": "陈静",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  14
+                ],
+                "room": "3A209",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1017.10",
+            "courseCode": "FL1017",
+            "courseName": "科普英语交流",
+            "teacher": "陈静",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  14
+                ],
+                "room": "2204",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    8,
+                    14
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    8,
+                    14
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A209",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2204",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1102B.01",
+            "courseCode": "FL1102B",
+            "courseName": "科普英语交流B",
+            "teacher": "张曼君"
+          },
+          "previous": {
+            "id": "FL1102B.01",
+            "courseCode": "FL1102B",
+            "courseName": "科普英语交流B",
+            "teacher": "张曼君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2504",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1102B.01",
+            "courseCode": "FL1102B",
+            "courseName": "科普英语交流B",
+            "teacher": "张曼君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2504",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1102B.04",
+            "courseCode": "FL1102B",
+            "courseName": "科普英语交流B",
+            "teacher": "张曼君"
+          },
+          "previous": {
+            "id": "FL1102B.04",
+            "courseCode": "FL1102B",
+            "courseName": "科普英语交流B",
+            "teacher": "张曼君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2206",
+                "day": 3,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1102B.04",
+            "courseCode": "FL1102B",
+            "courseName": "科普英语交流B",
+            "teacher": "张曼君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2206",
+                "day": 3,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1117.04",
+            "courseCode": "FL1117",
+            "courseName": "科普英语交流进阶",
+            "teacher": "龚伟峰"
+          },
+          "previous": {
+            "id": "FL1117.04",
+            "courseCode": "FL1117",
+            "courseName": "科普英语交流进阶",
+            "teacher": "龚伟峰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "2507",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1117.04",
+            "courseCode": "FL1117",
+            "courseName": "科普英语交流进阶",
+            "teacher": "龚伟峰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "2507",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1508.01",
+            "courseCode": "FL1508",
+            "courseName": "现代日本语言与文化(初级)",
+            "teacher": "霍沁宇"
+          },
+          "previous": {
+            "id": "FL1508.01",
+            "courseCode": "FL1508",
+            "courseName": "现代日本语言与文化(初级)",
+            "teacher": "霍沁宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2205",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2205",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1508.01",
+            "courseCode": "FL1508",
+            "courseName": "现代日本语言与文化(初级)",
+            "teacher": "霍沁宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2421",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2421",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 25,
+              "after": 70
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2205",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2421",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6103U.01",
+            "courseCode": "FORL6103U",
+            "courseName": "学术交流英语",
+            "teacher": "John Gandy"
+          },
+          "previous": {
+            "id": "FORL6103U.01",
+            "courseCode": "FORL6103U",
+            "courseName": "学术交流英语",
+            "teacher": "John Gandy",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5503",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6103U.01",
+            "courseCode": "FORL6103U",
+            "courseName": "学术交流英语",
+            "teacher": "John Gandy",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5503",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 60
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6202U.01",
+            "courseCode": "FORL6202U",
+            "courseName": "汉语听说",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "FORL6202U.01",
+            "courseCode": "FORL6202U",
+            "courseName": "汉语听说",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2302",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2302",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2302",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6202U.01",
+            "courseCode": "FORL6202U",
+            "courseName": "汉语听说",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2302",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2302",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2306",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2302",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2302",
+                  "campus": "本部"
+                },
+                {
+                  "room": "2306",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6202U.02",
+            "courseCode": "FORL6202U",
+            "courseName": "汉语听说",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "FORL6202U.02",
+            "courseCode": "FORL6202U",
+            "courseName": "汉语听说",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "3A207",
+                "day": 1,
+                "periods": [
+                  2,
+                  3
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "3A207",
+                "day": 2,
+                "periods": [
+                  2,
+                  3
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "3A403",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6202U.02",
+            "courseCode": "FORL6202U",
+            "courseName": "汉语听说",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "3A207",
+                "day": 2,
+                "periods": [
+                  2,
+                  3
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "3A403",
+                "day": 3,
+                "periods": [
+                  2,
+                  3
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "3A403",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 1,
+                  "periods": [
+                    2,
+                    3
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 2,
+                  "periods": [
+                    2,
+                    3
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 2,
+                  "periods": [
+                    2,
+                    3
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 3,
+                  "periods": [
+                    2,
+                    3
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6202U.04",
+            "courseCode": "FORL6202U",
+            "courseName": "汉语听说",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "FORL6202U.04",
+            "courseCode": "FORL6202U",
+            "courseName": "汉语听说",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2508",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2508",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6202U.04",
+            "courseCode": "FORL6202U",
+            "courseName": "汉语听说",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2508",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2508",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2508",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 3,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6202U.05",
+            "courseCode": "FORL6202U",
+            "courseName": "汉语听说",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "FORL6202U.05",
+            "courseCode": "FORL6202U",
+            "courseName": "汉语听说",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2508",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2508",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2508",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6202U.05",
+            "courseCode": "FORL6202U",
+            "courseName": "汉语听说",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2508",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2508",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  19
+                ],
+                "room": "2508",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    19
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "GEOL3003.01",
+            "courseCode": "GEOL3003",
+            "courseName": "岩石学",
+            "teacher": "洪吉安,夏琼霞,纪敏"
+          },
+          "previous": {
+            "id": "GEOL3003.01",
+            "courseCode": "GEOL3003",
+            "courseName": "岩石学",
+            "teacher": "洪吉安,夏琼霞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "东区新地空楼708",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  16
+                ],
+                "room": "东区新地空楼708",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "东区新地空楼708",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  16
+                ],
+                "room": "东区新地空楼708",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "GEOL3003.01",
+            "courseCode": "GEOL3003",
+            "courseName": "岩石学",
+            "teacher": "洪吉安,夏琼霞,纪敏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "东区新地空楼708",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "东区新地空楼708",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  16
+                ],
+                "room": "东区新地空楼708",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "东区新地空楼708",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "东区新地空楼708",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  16
+                ],
+                "room": "东区新地空楼708",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "洪吉安,夏琼霞",
+              "after": "洪吉安,夏琼霞,纪敏"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "GEOP4004.01",
+            "courseCode": "GEOP4004",
+            "courseName": "人工智能与地球物理",
+            "teacher": "伍新明,李泽峰,刘影"
+          },
+          "previous": {
+            "id": "GEOP4004.01",
+            "courseCode": "GEOP4004",
+            "courseName": "人工智能与地球物理",
+            "teacher": "伍新明,李泽峰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2406",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "GEOP4004.01",
+            "courseCode": "GEOP4004",
+            "courseName": "人工智能与地球物理",
+            "teacher": "伍新明,李泽峰,刘影",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2406",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "伍新明,李泽峰",
+              "after": "伍新明,李泽峰,刘影"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.03",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.03",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.03",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 125,
+              "after": 127
+            },
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "24材料物理",
+                "24材料化学",
+                "24分析化学",
+                "24化学物理仪器",
+                "24应用化学",
+                "24化学物理",
+                "24化学生物学",
+                "24物理化学",
+                "24无机化学",
+                "24有机化学",
+                "24高分子材料"
+              ],
+              "after": [
+                "24材料物理",
+                "24材料化学",
+                "24分析化学",
+                "24化学物理仪器",
+                "24应用化学",
+                "24化学物理",
+                "24化学生物学",
+                "24物理化学",
+                "24无机化学",
+                "24有机化学",
+                "24高分子材料",
+                "24高分子化学与物理"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1540M.01",
+            "courseCode": "HS1540M",
+            "courseName": "城市与文化遗产",
+            "teacher": "慕课教师"
+          },
+          "previous": {
+            "id": "HS1540M.01",
+            "courseCode": "HS1540M",
+            "courseName": "城市与文化遗产",
+            "teacher": "慕课教师",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1540M.01",
+            "courseCode": "HS1540M",
+            "courseName": "城市与文化遗产",
+            "teacher": "慕课教师",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  14,
+                  15
+                ],
+                "room": "5104",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  18,
+                  18
+                ],
+                "room": "5104",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    14,
+                    15
+                  ],
+                  "day": 5,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    18,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "5104",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "IC4003.01",
+            "courseCode": "IC4003",
+            "courseName": "集成电路制造设备导论",
+            "teacher": "郑柘炀,李志鹏,计旭东"
+          },
+          "previous": {
+            "id": "IC4003.01",
+            "courseCode": "IC4003",
+            "courseName": "集成电路制造设备导论",
+            "teacher": "郑柘炀,李志鹏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "GT-B111",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  8,
+                  14
+                ],
+                "room": "GT-B111",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "IC4003.01",
+            "courseCode": "IC4003",
+            "courseName": "集成电路制造设备导论",
+            "teacher": "郑柘炀,李志鹏,计旭东",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "GT-B111",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "GT-B111",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  8,
+                  14
+                ],
+                "room": "GT-B111",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "郑柘炀,李志鹏",
+              "after": "郑柘炀,李志鹏,计旭东"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "INFO6101P.01",
+            "courseCode": "INFO6101P",
+            "courseName": "矩阵分析与应用",
+            "teacher": "龚晨,刘伟杰"
+          },
+          "previous": {
+            "id": "INFO6101P.01",
+            "courseCode": "INFO6101P",
+            "courseName": "矩阵分析与应用",
+            "teacher": "龚晨,刘伟杰",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G3-107",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G3-107",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "INFO6101P.01",
+            "courseCode": "INFO6101P",
+            "courseName": "矩阵分析与应用",
+            "teacher": "龚晨,刘伟杰",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G3-107",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G3-107",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "INFO6101P.02",
+            "courseCode": "INFO6101P",
+            "courseName": "矩阵分析与应用",
+            "teacher": "徐正元,黄诺"
+          },
+          "previous": {
+            "id": "INFO6101P.02",
+            "courseCode": "INFO6101P",
+            "courseName": "矩阵分析与应用",
+            "teacher": "徐正元,黄诺",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G3-113",
+                "day": 1,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "INFO6101P.02",
+            "courseCode": "INFO6101P",
+            "courseName": "矩阵分析与应用",
+            "teacher": "徐正元,黄诺",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G3-113",
+                "day": 1,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "INFO6207P.01",
+            "courseCode": "INFO6207P",
+            "courseName": "信号检测与估计",
+            "teacher": "徐旭"
+          },
+          "previous": {
+            "id": "INFO6207P.01",
+            "courseCode": "INFO6207P",
+            "courseName": "信号检测与估计",
+            "teacher": "徐旭",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G3-115",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "INFO6207P.01",
+            "courseCode": "INFO6207P",
+            "courseName": "信号检测与估计",
+            "teacher": "徐旭",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G3-115",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "INFO6402P.01",
+            "courseCode": "INFO6402P",
+            "courseName": "多媒体通信",
+            "teacher": "陈晓辉,俞能海"
+          },
+          "previous": {
+            "id": "INFO6402P.01",
+            "courseCode": "INFO6402P",
+            "courseName": "多媒体通信",
+            "teacher": "陈晓辉,俞能海",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "G3-107",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "INFO6402P.01",
+            "courseCode": "INFO6402P",
+            "courseName": "多媒体通信",
+            "teacher": "陈晓辉,俞能海",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "G3-107",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "INFO7404P.01",
+            "courseCode": "INFO7404P",
+            "courseName": "图像理解",
+            "teacher": "陈雪锦"
+          },
+          "previous": {
+            "id": "INFO7404P.01",
+            "courseCode": "INFO7404P",
+            "courseName": "图像理解",
+            "teacher": "陈雪锦",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "G3-114",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "G3-113",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "INFO7404P.01",
+            "courseCode": "INFO7404P",
+            "courseName": "图像理解",
+            "teacher": "陈雪锦",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "G3-114",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "G3-113",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "INST6101P.01",
+            "courseCode": "INST6101P",
+            "courseName": "高等工程数学",
+            "teacher": "郑津津"
+          },
+          "previous": {
+            "id": "INST6101P.01",
+            "courseCode": "INST6101P",
+            "courseName": "高等工程数学",
+            "teacher": "郑津津",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "3C101",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "3C101",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "INST6101P.01",
+            "courseCode": "INST6101P",
+            "courseName": "高等工程数学",
+            "teacher": "郑津津",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "3C101",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "3C101",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 193,
+              "after": 200
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ISTE6401Q.01",
+            "courseCode": "ISTE6401Q",
+            "courseName": "人工智能原理与应用",
+            "teacher": "吴剑灿,夏彦,王江涛,徐金辉,康奇宇"
+          },
+          "previous": {
+            "id": "ISTE6401Q.01",
+            "courseCode": "ISTE6401Q",
+            "courseName": "人工智能原理与应用",
+            "teacher": "吴剑灿,夏彦,王江涛,徐金辉,康奇宇",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "3A306",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ISTE6401Q.01",
+            "courseCode": "ISTE6401Q",
+            "courseName": "人工智能原理与应用",
+            "teacher": "吴剑灿,夏彦,王江涛,徐金辉,康奇宇",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "3A306",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ISTE7001P.01",
+            "courseCode": "ISTE7001P",
+            "courseName": "人工智能的数理科学基础",
+            "teacher": "钟志诚,陈景润"
+          },
+          "previous": {
+            "id": "ISTE7001P.01",
+            "courseCode": "ISTE7001P",
+            "courseName": "人工智能的数理科学基础",
+            "teacher": "陈景润,钟志诚",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  14
+                ],
+                "room": "GH-206",
+                "day": 2,
+                "periods": [
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "ISTE7001P.01",
+            "courseCode": "ISTE7001P",
+            "courseName": "人工智能的数理科学基础",
+            "teacher": "钟志诚,陈景润",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  16
+                ],
+                "room": "GT-A401",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 120,
+              "after": 80
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    3,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    3,
+                    16
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "GH-206",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "GT-A401",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1006.06",
+            "courseCode": "MARX1006",
+            "courseName": "形势与政策(讲座)",
+            "teacher": "虎旭昕"
+          },
+          "previous": {
+            "id": "MARX1006.06",
+            "courseCode": "MARX1006",
+            "courseName": "形势与政策(讲座)",
+            "teacher": "虎旭昕",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "MARX1006.06",
+            "courseCode": "MARX1006",
+            "courseName": "形势与政策(讲座)",
+            "teacher": "虎旭昕",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 136,
+              "after": 138
+            },
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "24材料物理",
+                "24材料化学",
+                "24环境科学与工程",
+                "24分析化学",
+                "24化学物理仪器",
+                "24应用化学",
+                "24化学物理",
+                "24化学生物学",
+                "24物理化学",
+                "24无机化学",
+                "24有机化学",
+                "24高分子材料"
+              ],
+              "after": [
+                "24材料物理",
+                "24材料化学",
+                "24环境科学与工程",
+                "24分析化学",
+                "24化学物理仪器",
+                "24应用化学",
+                "24化学物理",
+                "24化学生物学",
+                "24物理化学",
+                "24无机化学",
+                "24有机化学",
+                "24高分子材料",
+                "24高分子化学与物理"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1011.11",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "卢江,潘鑫"
+          },
+          "previous": {
+            "id": "MARX1011.11",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "卢江",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "5302",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1011.11",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "卢江,潘鑫",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "5302",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "卢江",
+              "after": "卢江,潘鑫"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.10",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松,徐灿"
+          },
+          "previous": {
+            "id": "MARX1014.10",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1301",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.10",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松,徐灿",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1301",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "郭育松",
+              "after": "郭育松,徐灿"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX6102U.10",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "江可可"
+          },
+          "previous": {
+            "id": "MARX6102U.10",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "江可可",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "G3-110",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "G3-110",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX6102U.10",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "江可可",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "G3-107",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "G3-107",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "G3-110",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "G3-107",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX6102U.11",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "郭育松"
+          },
+          "previous": {
+            "id": "MARX6102U.11",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "郭育松",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "GT-B211",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "GT-B211",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX6102U.11",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "郭育松",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "G3-113",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "G3-113",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "GT-B211",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "G3-113",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX6102U.12",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "叶政"
+          },
+          "previous": {
+            "id": "MARX6102U.12",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "叶政",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "G3-109",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "G3-109",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX6102U.12",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "叶政",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "G3-110",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "G3-110",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "G3-109",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "G3-110",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX6102U.13",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "陈小林"
+          },
+          "previous": {
+            "id": "MARX6102U.13",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "陈小林",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "G3-108",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "G3-108",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX6102U.13",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "陈小林",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "G3-109",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  8,
+                  13
+                ],
+                "room": "G3-109",
+                "day": 7,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 7,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    13
+                  ],
+                  "day": 7,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 7,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    8,
+                    13
+                  ],
+                  "day": 7,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "G3-108",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "G3-109",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH1003.01",
+            "courseCode": "MATH1003",
+            "courseName": "数学分析(A3)",
+            "teacher": "李思敏"
+          },
+          "previous": {
+            "id": "MATH1003.01",
+            "courseCode": "MATH1003",
+            "courseName": "数学分析(A3)",
+            "teacher": "李思敏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2105",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2105",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH1003.01",
+            "courseCode": "MATH1003",
+            "courseName": "数学分析(A3)",
+            "teacher": "李思敏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2105",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2105",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 80,
+              "after": 85
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH1003.02",
+            "courseCode": "MATH1003",
+            "courseName": "数学分析(A3)",
+            "teacher": "左达峰,吴冶默"
+          },
+          "previous": {
+            "id": "MATH1003.02",
+            "courseCode": "MATH1003",
+            "courseName": "数学分析(A3)",
+            "teacher": "左达峰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2210",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2210",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH1003.02",
+            "courseCode": "MATH1003",
+            "courseName": "数学分析(A3)",
+            "teacher": "左达峰,吴冶默",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2210",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2210",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "左达峰",
+              "after": "左达峰,吴冶默"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH2001.01",
+            "courseCode": "MATH2001",
+            "courseName": "计算方法",
+            "teacher": "熊涛,黄振广"
+          },
+          "previous": {
+            "id": "MATH2001.01",
+            "courseCode": "MATH2001",
+            "courseName": "计算方法",
+            "teacher": "熊涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "5201",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "5201",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH2001.01",
+            "courseCode": "MATH2001",
+            "courseName": "计算方法",
+            "teacher": "熊涛,黄振广",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "5201",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "5201",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "熊涛",
+              "after": "熊涛,黄振广"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 120,
+              "after": 150
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH5001P.01",
+            "courseCode": "MATH5001P",
+            "courseName": "高等实分析",
+            "teacher": "王谢平"
+          },
+          "previous": {
+            "id": "MATH5001P.01",
+            "courseCode": "MATH5001P",
+            "courseName": "高等实分析",
+            "teacher": "王谢平",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5504",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5504",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH5001P.01",
+            "courseCode": "MATH5001P",
+            "courseName": "高等实分析",
+            "teacher": "王谢平",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5504",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5504",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6202P.01",
+            "courseCode": "MCEN6202P",
+            "courseName": "工程数学",
+            "teacher": "张明波,杨赛赛,蒋嘉敏"
+          },
+          "previous": {
+            "id": "MCEN6202P.01",
+            "courseCode": "MCEN6202P",
+            "courseName": "工程数学",
+            "teacher": "张明波,杨赛赛,陈景润,蒋嘉敏",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "苏高院公共教学楼301教室",
+                "day": 2,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6202P.01",
+            "courseCode": "MCEN6202P",
+            "courseName": "工程数学",
+            "teacher": "张明波,杨赛赛,蒋嘉敏",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "苏高院公共教学楼301教室",
+                "day": 2,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张明波,杨赛赛,陈景润,蒋嘉敏",
+              "after": "张明波,杨赛赛,蒋嘉敏"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MCEN6202P.02",
+            "courseCode": "MCEN6202P",
+            "courseName": "工程数学",
+            "teacher": "张明波,杨赛赛,蒋嘉敏,陈景润"
+          },
+          "previous": {
+            "id": "MCEN6202P.02",
+            "courseCode": "MCEN6202P",
+            "courseName": "工程数学",
+            "teacher": "张明波,杨赛赛,蒋嘉敏",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "苏高院公共教学楼301教室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MCEN6202P.02",
+            "courseCode": "MCEN6202P",
+            "courseName": "工程数学",
+            "teacher": "张明波,杨赛赛,蒋嘉敏,陈景润",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "苏高院公共教学楼301教室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张明波,杨赛赛,蒋嘉敏",
+              "after": "张明波,杨赛赛,蒋嘉敏,陈景润"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ME2005.05",
+            "courseCode": "ME2005",
+            "courseName": "机械设计基础I",
+            "teacher": "李家文,汪超炜"
+          },
+          "previous": {
+            "id": "ME2005.05",
+            "courseCode": "ME2005",
+            "courseName": "机械设计基础I",
+            "teacher": "李家文",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A317",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A317",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ME2005.05",
+            "courseCode": "ME2005",
+            "courseName": "机械设计基础I",
+            "teacher": "李家文,汪超炜",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A317",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A317",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "李家文",
+              "after": "李家文,汪超炜"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ME2005.08",
+            "courseCode": "ME2005",
+            "courseName": "机械设计基础I",
+            "teacher": "张世武,胡奇强"
+          },
+          "previous": {
+            "id": "ME2005.08",
+            "courseCode": "ME2005",
+            "courseName": "机械设计基础I",
+            "teacher": "张世武",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A317",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A317",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ME2005.08",
+            "courseCode": "ME2005",
+            "courseName": "机械设计基础I",
+            "teacher": "张世武,胡奇强",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A317",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A317",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张世武",
+              "after": "张世武,胡奇强"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ME2015.01",
+            "courseCode": "ME2015",
+            "courseName": "工程材料及成型技术基础",
+            "teacher": "王硕桂"
+          },
+          "previous": {
+            "id": "ME2015.01",
+            "courseCode": "ME2015",
+            "courseName": "工程材料及成型技术基础",
+            "teacher": "王硕桂",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A110",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ME2015.01",
+            "courseCode": "ME2015",
+            "courseName": "工程材料及成型技术基础",
+            "teacher": "王硕桂",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A106",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A110",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "3A106",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ME2017.01",
+            "courseCode": "ME2017",
+            "courseName": "机器人学基础",
+            "teacher": "董二宝,高纬"
+          },
+          "previous": {
+            "id": "ME2017.01",
+            "courseCode": "ME2017",
+            "courseName": "机器人学基础",
+            "teacher": "董二宝",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3C302",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ME2017.01",
+            "courseCode": "ME2017",
+            "courseName": "机器人学基础",
+            "teacher": "董二宝,高纬",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3C302",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "董二宝",
+              "after": "董二宝,高纬"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ME3001.01",
+            "courseCode": "ME3001",
+            "courseName": "传热学A",
+            "teacher": "陈海翔,雷佼,居晓宇,胡艺馨"
+          },
+          "previous": {
+            "id": "ME3001.01",
+            "courseCode": "ME3001",
+            "courseName": "传热学A",
+            "teacher": "陈海翔,雷佼,居晓宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "3A210",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  13
+                ],
+                "room": "3A210",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  18
+                ],
+                "room": "3A210",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "3A210",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  13
+                ],
+                "room": "3A210",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  18
+                ],
+                "room": "3A210",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ME3001.01",
+            "courseCode": "ME3001",
+            "courseName": "传热学A",
+            "teacher": "陈海翔,雷佼,居晓宇,胡艺馨",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "3A210",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A210",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  13
+                ],
+                "room": "3A210",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  18
+                ],
+                "room": "3A210",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "3A210",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A210",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  13
+                ],
+                "room": "3A210",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  18
+                ],
+                "room": "3A210",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "陈海翔,雷佼,居晓宇",
+              "after": "陈海翔,雷佼,居晓宇,胡艺馨"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ME4007.01",
+            "courseCode": "ME4007",
+            "courseName": "热灾害实验诊断方法",
+            "teacher": "王喜世,张启兴,王强"
+          },
+          "previous": {
+            "id": "ME4007.01",
+            "courseCode": "ME4007",
+            "courseName": "热灾害实验诊断方法",
+            "teacher": "王喜世,张启兴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "3A210",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "3A210",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ME4007.01",
+            "courseCode": "ME4007",
+            "courseName": "热灾害实验诊断方法",
+            "teacher": "王喜世,张启兴,王强",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "3A210",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A210",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "3A210",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "王喜世,张启兴",
+              "after": "王喜世,张启兴,王强"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MECH6101P.03",
+            "courseCode": "MECH6101P",
+            "courseName": "高等应用数学",
+            "teacher": "刘罗勤"
+          },
+          "previous": {
+            "id": "MECH6101P.03",
+            "courseCode": "MECH6101P",
+            "courseName": "高等应用数学",
+            "teacher": "刘罗勤",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3B101",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3B101",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MECH6101P.03",
+            "courseCode": "MECH6101P",
+            "courseName": "高等应用数学",
+            "teacher": "刘罗勤",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3B101",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3B101",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 110,
+              "after": 120
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MECH6102P.02",
+            "courseCode": "MECH6102P",
+            "courseName": "高等流体力学",
+            "teacher": "穆恺"
+          },
+          "previous": {
+            "id": "MECH6102P.02",
+            "courseCode": "MECH6102P",
+            "courseName": "高等流体力学",
+            "teacher": "穆恺",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A404",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A404",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MECH6102P.02",
+            "courseCode": "MECH6102P",
+            "courseName": "高等流体力学",
+            "teacher": "穆恺",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A404",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A404",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 120
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MECH6401P.01",
+            "courseCode": "MECH6401P",
+            "courseName": "高等连续介质力学",
+            "teacher": "骆天治"
+          },
+          "previous": {
+            "id": "MECH6401P.01",
+            "courseCode": "MECH6401P",
+            "courseName": "高等连续介质力学",
+            "teacher": "骆天治",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A306",
+                "day": 2,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A306",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MECH6401P.01",
+            "courseCode": "MECH6401P",
+            "courseName": "高等连续介质力学",
+            "teacher": "骆天治",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A306",
+                "day": 2,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A306",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 70
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MECH6401P.02",
+            "courseCode": "MECH6401P",
+            "courseName": "高等连续介质力学",
+            "teacher": "张永亮"
+          },
+          "previous": {
+            "id": "MECH6401P.02",
+            "courseCode": "MECH6401P",
+            "courseName": "高等连续介质力学",
+            "teacher": "张永亮",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A207",
+                "day": 2,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A207",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MECH6401P.02",
+            "courseCode": "MECH6401P",
+            "courseName": "高等连续介质力学",
+            "teacher": "张永亮",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A207",
+                "day": 2,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A207",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 70
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MECH6416P.01",
+            "courseCode": "MECH6416P",
+            "courseName": "软材料力学与软体机器人",
+            "teacher": "王柳"
+          },
+          "previous": {
+            "id": "MECH6416P.01",
+            "courseCode": "MECH6416P",
+            "courseName": "软材料力学与软体机器人",
+            "teacher": "王柳",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "3A405",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MECH6416P.01",
+            "courseCode": "MECH6416P",
+            "courseName": "软材料力学与软体机器人",
+            "teacher": "王柳",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "3A405",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 65
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MIPR6400P.01",
+            "courseCode": "MIPR6400P",
+            "courseName": "AI与知识产权",
+            "teacher": "刘洋"
+          },
+          "previous": {
+            "id": "MIPR6400P.01",
+            "courseCode": "MIPR6400P",
+            "courseName": "AI与知识产权",
+            "teacher": "刘洋",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "2403",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MIPR6400P.01",
+            "courseCode": "MIPR6400P",
+            "courseName": "AI与知识产权",
+            "teacher": "刘洋",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "2206",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    12
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    12
+                  ],
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2403",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2206",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MNSC3014.01",
+            "courseCode": "MNSC3014",
+            "courseName": "数字经济",
+            "teacher": "姬翔,吴杰,李明珺"
+          },
+          "previous": {
+            "id": "MNSC3014.01",
+            "courseCode": "MNSC3014",
+            "courseName": "数字经济",
+            "teacher": "姬翔,吴杰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "5205",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  14
+                ],
+                "room": "5205",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MNSC3014.01",
+            "courseCode": "MNSC3014",
+            "courseName": "数字经济",
+            "teacher": "姬翔,吴杰,李明珺",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  4
+                ],
+                "room": "5205",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "5205",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  14
+                ],
+                "room": "5205",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "姬翔,吴杰",
+              "after": "姬翔,吴杰,李明珺"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE5003P.01",
+            "courseCode": "MSAE5003P",
+            "courseName": "博弈论",
+            "teacher": "彭雪丰,杜少甫"
+          },
+          "previous": {
+            "id": "MSAE5003P.01",
+            "courseCode": "MSAE5003P",
+            "courseName": "博弈论",
+            "teacher": "杜少甫",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5102",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE5003P.01",
+            "courseCode": "MSAE5003P",
+            "courseName": "博弈论",
+            "teacher": "彭雪丰,杜少甫",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5102",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "杜少甫",
+              "after": "彭雪丰,杜少甫"
+            },
+            {
+              "field": "undergradShared",
+              "label": "本研同堂",
+              "before": false,
+              "after": true
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 80,
+              "after": 70
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSEN7001P.01",
+            "courseCode": "MSEN7001P",
+            "courseName": "新能源材料与技术",
+            "teacher": "张宁"
+          },
+          "previous": {
+            "id": "MSEN7001P.01",
+            "courseCode": "MSEN7001P",
+            "courseName": "新能源材料与技术",
+            "teacher": "张宁",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "苏高院公共教学楼305教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSEN7001P.01",
+            "courseCode": "MSEN7001P",
+            "courseName": "新能源材料与技术",
+            "teacher": "张宁",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "苏高院公共教学楼305教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 55
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NNM2012.01",
+            "courseCode": "NNM2012",
+            "courseName": "新媒体大数据分析",
+            "teacher": "朱孟潇,黄振亚,张凯,唐秀秀"
+          },
+          "previous": {
+            "id": "NNM2012.01",
+            "courseCode": "NNM2012",
+            "courseName": "新媒体大数据分析",
+            "teacher": "朱孟潇,黄振亚,张凯",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  17,
+                  18
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  6
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  16
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "NNM2012.01",
+            "courseCode": "NNM2012",
+            "courseName": "新媒体大数据分析",
+            "teacher": "朱孟潇,黄振亚,张凯,唐秀秀",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  17,
+                  18
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  6
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  16
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "朱孟潇,黄振亚,张凯",
+              "after": "朱孟潇,黄振亚,张凯,唐秀秀"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NSE4010.01",
+            "courseCode": "NSE4010",
+            "courseName": "纳米科学与技术",
+            "teacher": "宋礼,龙冉,陈双明"
+          },
+          "previous": {
+            "id": "NSE4010.01",
+            "courseCode": "NSE4010",
+            "courseName": "纳米科学与技术",
+            "teacher": "宋礼,龙冉,陈双明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  6
+                ],
+                "room": "3A209",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  17,
+                  18
+                ],
+                "room": "3A209",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  11
+                ],
+                "room": "3A209",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  16
+                ],
+                "room": "3A209",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "NSE4010.01",
+            "courseCode": "NSE4010",
+            "courseName": "纳米科学与技术",
+            "teacher": "宋礼,龙冉,陈双明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  6
+                ],
+                "room": "3A209",
+                "day": 5,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  17,
+                  18
+                ],
+                "room": "3A209",
+                "day": 5,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  11
+                ],
+                "room": "3A209",
+                "day": 5,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  16
+                ],
+                "room": "3A209",
+                "day": 5,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    6
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    17,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    11
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    12,
+                    16
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    6
+                  ],
+                  "day": 5,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    17,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    11
+                  ],
+                  "day": 5,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    12,
+                    16
+                  ],
+                  "day": 5,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PADM6121P.01",
+            "courseCode": "PADM6121P",
+            "courseName": "模型与数据分析方法",
+            "teacher": "刘洋"
+          },
+          "previous": {
+            "id": "PADM6121P.01",
+            "courseCode": "PADM6121P",
+            "courseName": "模型与数据分析方法",
+            "teacher": "杜少甫,陈鹏展",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "2206",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PADM6121P.01",
+            "courseCode": "PADM6121P",
+            "courseName": "模型与数据分析方法",
+            "teacher": "刘洋",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2503",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "杜少甫,陈鹏展",
+              "after": "刘洋"
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    15
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2206",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2503",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PADM6421P.01",
+            "courseCode": "PADM6421P",
+            "courseName": "科技创新管理",
+            "teacher": "刘洋"
+          },
+          "previous": {
+            "id": "PADM6421P.01",
+            "courseCode": "PADM6421P",
+            "courseName": "科技创新管理",
+            "teacher": "刘洋",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2402",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PADM6421P.01",
+            "courseCode": "PADM6421P",
+            "courseName": "科技创新管理",
+            "teacher": "刘洋",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2206",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2402",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2206",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHIL6301U.11",
+            "courseCode": "PHIL6301U",
+            "courseName": "工程伦理",
+            "teacher": "李文忠"
+          },
+          "previous": {
+            "id": "PHIL6301U.11",
+            "courseCode": "PHIL6301U",
+            "courseName": "工程伦理",
+            "teacher": "李文忠",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  13
+                ],
+                "room": "3B202",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHIL6301U.11",
+            "courseCode": "PHIL6301U",
+            "courseName": "工程伦理",
+            "teacher": "李文忠",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  13
+                ],
+                "room": "TH-B101",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 180,
+              "after": 150
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    13
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    13
+                  ],
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3B202",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "TH-B101",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1003A.01",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "周宗权"
+          },
+          "previous": {
+            "id": "PHYS1003A.01",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "周宗权",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2103",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2103",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1003A.01",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "周宗权",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2103",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2103",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 48
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1003A.04",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "王安廷"
+          },
+          "previous": {
+            "id": "PHYS1003A.04",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "王安廷",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5106",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5106",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1003A.04",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "王安廷",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5106",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5106",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 48
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1003A.05",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "项国勇,吴康达,孙泽亮"
+          },
+          "previous": {
+            "id": "PHYS1003A.05",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "项国勇,吴康达",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  11
+                ],
+                "room": "2103",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  18
+                ],
+                "room": "2103",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  11
+                ],
+                "room": "2103",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  18
+                ],
+                "room": "2103",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1003A.05",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "项国勇,吴康达,孙泽亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  11
+                ],
+                "room": "2103",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2103",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  18
+                ],
+                "room": "2103",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  11
+                ],
+                "room": "2103",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2103",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  18
+                ],
+                "room": "2103",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "项国勇,吴康达",
+              "after": "项国勇,吴康达,孙泽亮"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 48
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1003A.06",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "董春华,柳必恒"
+          },
+          "previous": {
+            "id": "PHYS1003A.06",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "董春华,柳必恒",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5307",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5307",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1003A.06",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "董春华,柳必恒",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5307",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5307",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 48
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1003A.07",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "王沛"
+          },
+          "previous": {
+            "id": "PHYS1003A.07",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "王沛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5206",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5206",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1003A.07",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "王沛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5206",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5206",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 48
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1003A.08",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "鲁拥华"
+          },
+          "previous": {
+            "id": "PHYS1003A.08",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "鲁拥华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5206",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5206",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1003A.08",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "鲁拥华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5206",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5206",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 48
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1003A.09",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "陈巍,王纺翔,徐新标"
+          },
+          "previous": {
+            "id": "PHYS1003A.09",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "陈巍,王纺翔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "5107",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "5107",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "5107",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "5107",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1003A.09",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "陈巍,王纺翔,徐新标",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "5107",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5107",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "5107",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "5107",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5107",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "5107",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "陈巍,王纺翔",
+              "after": "陈巍,王纺翔,徐新标"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 48
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1003A.10",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "陈耕,郭钰"
+          },
+          "previous": {
+            "id": "PHYS1003A.10",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "陈耕",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1003A.10",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "陈耕,郭钰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "陈耕",
+              "after": "陈耕,郭钰"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 48
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1003A.11",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "许金时"
+          },
+          "previous": {
+            "id": "PHYS1003A.11",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "许金时",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1101",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1101",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1003A.11",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "许金时",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1101",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1101",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 48
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1004A.01",
+            "courseCode": "PHYS1004A",
+            "courseName": "电磁学A",
+            "teacher": "秦敢,许泽华"
+          },
+          "previous": {
+            "id": "PHYS1004A.01",
+            "courseCode": "PHYS1004A",
+            "courseName": "电磁学A",
+            "teacher": "秦敢",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2621",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2621",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1004A.01",
+            "courseCode": "PHYS1004A",
+            "courseName": "电磁学A",
+            "teacher": "秦敢,许泽华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2621",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2621",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "秦敢",
+              "after": "秦敢,许泽华"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1004A.02",
+            "courseCode": "PHYS1004A",
+            "courseName": "电磁学A",
+            "teacher": "潘海俊,章金凤"
+          },
+          "previous": {
+            "id": "PHYS1004A.02",
+            "courseCode": "PHYS1004A",
+            "courseName": "电磁学A",
+            "teacher": "潘海俊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A113",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1004A.02",
+            "courseCode": "PHYS1004A",
+            "courseName": "电磁学A",
+            "teacher": "潘海俊,章金凤",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A113",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "潘海俊",
+              "after": "潘海俊,章金凤"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 55
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1004B.04",
+            "courseCode": "PHYS1004B",
+            "courseName": "电磁学B",
+            "teacher": "唐泽波"
+          },
+          "previous": {
+            "id": "PHYS1004B.04",
+            "courseCode": "PHYS1004B",
+            "courseName": "电磁学B",
+            "teacher": "唐泽波",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A312",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A312",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1004B.04",
+            "courseCode": "PHYS1004B",
+            "courseName": "电磁学B",
+            "teacher": "唐泽波",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A312",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A312",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 94,
+              "after": 99
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1004B.06",
+            "courseCode": "PHYS1004B",
+            "courseName": "电磁学B",
+            "teacher": "孙霞"
+          },
+          "previous": {
+            "id": "PHYS1004B.06",
+            "courseCode": "PHYS1004B",
+            "courseName": "电磁学B",
+            "teacher": "孙霞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A112",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A112",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1004B.06",
+            "courseCode": "PHYS1004B",
+            "courseName": "电磁学B",
+            "teacher": "孙霞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A112",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A112",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 90,
+              "after": 99
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1004C.01",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "张永生"
+          },
+          "previous": {
+            "id": "PHYS1004C.01",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "张永生",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A211",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A211",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1004C.01",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "张永生",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A211",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A211",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 55,
+              "after": 60
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1004C.03",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "陈永虎"
+          },
+          "previous": {
+            "id": "PHYS1004C.03",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "陈永虎",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A312",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A312",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1004C.03",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "陈永虎",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A312",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A312",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 55,
+              "after": 60
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1004C.04",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "卢荣德"
+          },
+          "previous": {
+            "id": "PHYS1004C.04",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "卢荣德",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1004C.04",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "卢荣德",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 55,
+              "after": 60
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1004C.05",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "李剑"
+          },
+          "previous": {
+            "id": "PHYS1004C.05",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "李剑",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A311",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A311",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1004C.05",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "李剑",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A311",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A311",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 55,
+              "after": 60
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1004C.06",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "应剑俊"
+          },
+          "previous": {
+            "id": "PHYS1004C.06",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "应剑俊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A312",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A312",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1004C.06",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "应剑俊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A312",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A312",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 55,
+              "after": 60
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1004C.07",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "张一飞"
+          },
+          "previous": {
+            "id": "PHYS1004C.07",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "张一飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A313",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A313",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1004C.07",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "张一飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A313",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A313",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 55,
+              "after": 60
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1004C.08",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "丁桂军"
+          },
+          "previous": {
+            "id": "PHYS1004C.08",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "丁桂军",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A112",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A112",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1004C.08",
+            "courseCode": "PHYS1004C",
+            "courseName": "电磁学C",
+            "teacher": "丁桂军",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A112",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A112",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 55,
+              "after": 60
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1005B.01",
+            "courseCode": "PHYS1005B",
+            "courseName": "原子物理B",
+            "teacher": "何海燕,王臻"
+          },
+          "previous": {
+            "id": "PHYS1005B.01",
+            "courseCode": "PHYS1005B",
+            "courseName": "原子物理B",
+            "teacher": "何海燕",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5104",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1005B.01",
+            "courseCode": "PHYS1005B",
+            "courseName": "原子物理B",
+            "teacher": "何海燕,王臻",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5104",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "何海燕",
+              "after": "何海燕,王臻"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009A.04",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华"
+          },
+          "previous": {
+            "id": "PHYS1009A.04",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009A.04",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009A.05",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华"
+          },
+          "previous": {
+            "id": "PHYS1009A.05",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009A.05",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 78,
+              "after": 65
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009B.04",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋"
+          },
+          "previous": {
+            "id": "PHYS1009B.04",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009B.04",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 260,
+              "after": 280
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009B.05",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋"
+          },
+          "previous": {
+            "id": "PHYS1009B.05",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009B.05",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 225,
+              "after": 245
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS5202P.01",
+            "courseCode": "PHYS5202P",
+            "courseName": "凝聚态物理前沿",
+            "teacher": "项子霁,秦维"
+          },
+          "previous": {
+            "id": "PHYS5202P.01",
+            "courseCode": "PHYS5202P",
+            "courseName": "凝聚态物理前沿",
+            "teacher": "项子霁,秦维",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5504",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5504",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS5202P.01",
+            "courseCode": "PHYS5202P",
+            "courseName": "凝聚态物理前沿",
+            "teacher": "项子霁,秦维",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5504",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5504",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 150,
+              "after": 180
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS6004P.01",
+            "courseCode": "PHYS6004P",
+            "courseName": "粒子物理",
+            "teacher": "杨为民"
+          },
+          "previous": {
+            "id": "PHYS6004P.01",
+            "courseCode": "PHYS6004P",
+            "courseName": "粒子物理",
+            "teacher": "杨为民",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1302",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1302",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS6004P.01",
+            "courseCode": "PHYS6004P",
+            "courseName": "粒子物理",
+            "teacher": "杨为民",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1302",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1302",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "undergradShared",
+              "label": "本研同堂",
+              "before": false,
+              "after": true
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS6151P.01",
+            "courseCode": "PHYS6151P",
+            "courseName": "高等电动力学",
+            "teacher": "张鹏飞"
+          },
+          "previous": {
+            "id": "PHYS6151P.01",
+            "courseCode": "PHYS6151P",
+            "courseName": "高等电动力学",
+            "teacher": "张鹏飞",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "2106",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "1202",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS6151P.01",
+            "courseCode": "PHYS6151P",
+            "courseName": "高等电动力学",
+            "teacher": "张鹏飞",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "2106",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "1202",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "",
+              "after": "其他"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS6255P.01",
+            "courseCode": "PHYS6255P",
+            "courseName": "生命系统中的统计物理",
+            "teacher": "袁军华"
+          },
+          "previous": {
+            "id": "PHYS6255P.01",
+            "courseCode": "PHYS6255P",
+            "courseName": "生命系统中的统计物理",
+            "teacher": "袁军华",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2306",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS6255P.01",
+            "courseCode": "PHYS6255P",
+            "courseName": "生命系统中的统计物理",
+            "teacher": "袁军华",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2306",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "language",
+              "label": "授课语言",
+              "before": "中文",
+              "after": "英语"
+            },
+            {
+              "field": "undergradShared",
+              "label": "本研同堂",
+              "before": false,
+              "after": true
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS6403P.01",
+            "courseCode": "PHYS6403P",
+            "courseName": "量子多体理论(I)",
+            "teacher": "刘国柱"
+          },
+          "previous": {
+            "id": "PHYS6403P.01",
+            "courseCode": "PHYS6403P",
+            "courseName": "量子多体理论(I)",
+            "teacher": "刘国柱",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5502",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5502",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS6403P.01",
+            "courseCode": "PHYS6403P",
+            "courseName": "量子多体理论(I)",
+            "teacher": "刘国柱",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5502",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5502",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 120,
+              "after": 130
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS6601P.01",
+            "courseCode": "PHYS6601P",
+            "courseName": "超导物理",
+            "teacher": "阮可青,高尚"
+          },
+          "previous": {
+            "id": "PHYS6601P.01",
+            "courseCode": "PHYS6601P",
+            "courseName": "超导物理",
+            "teacher": "阮可青,高尚",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5307",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5307",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS6601P.01",
+            "courseCode": "PHYS6601P",
+            "courseName": "超导物理",
+            "teacher": "阮可青,高尚",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5307",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5307",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "其他",
+              "after": ""
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 80,
+              "after": 90
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS7555P.01",
+            "courseCode": "PHYS7555P",
+            "courseName": "前沿等离子体物理与技术",
+            "teacher": "孙玄,祝曹祥,贾青,张彦增"
+          },
+          "previous": {
+            "id": "PHYS7555P.01",
+            "courseCode": "PHYS7555P",
+            "courseName": "前沿等离子体物理与技术",
+            "teacher": "孙玄,祝曹祥,贾青,张彦增",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "3A310",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "3A310",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS7555P.01",
+            "courseCode": "PHYS7555P",
+            "courseName": "前沿等离子体物理与技术",
+            "teacher": "孙玄,祝曹祥,贾青,张彦增",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "3A310",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "3A310",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 80,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT3001.01",
+            "courseCode": "STAT3001",
+            "courseName": "机器学习方法",
+            "teacher": "崔文泉"
+          },
+          "previous": {
+            "id": "STAT3001.01",
+            "courseCode": "STAT3001",
+            "courseName": "机器学习方法",
+            "teacher": "崔文泉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5306",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT3001.01",
+            "courseCode": "STAT3001",
+            "courseName": "机器学习方法",
+            "teacher": "崔文泉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5306",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 59,
+              "after": 68
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT3003.01",
+            "courseCode": "STAT3003",
+            "courseName": "统计算法基础",
+            "teacher": "曾靖,温灿红"
+          },
+          "previous": {
+            "id": "STAT3003.01",
+            "courseCode": "STAT3003",
+            "courseName": "统计算法基础",
+            "teacher": "曾靖,温灿红",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT3003.01",
+            "courseCode": "STAT3003",
+            "courseName": "统计算法基础",
+            "teacher": "曾靖,温灿红",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 57,
+              "after": 75
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT5103P.01",
+            "courseCode": "STAT5103P",
+            "courseName": "线性统计模型",
+            "teacher": "李阳,郑泽敏"
+          },
+          "previous": {
+            "id": "STAT5103P.01",
+            "courseCode": "STAT5103P",
+            "courseName": "线性统计模型",
+            "teacher": "李阳,郑泽敏",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5504",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "startTime": "14:00",
+                "endTime": "16:25",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT5103P.01",
+            "courseCode": "STAT5103P",
+            "courseName": "线性统计模型",
+            "teacher": "李阳,郑泽敏",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "5504",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "startTime": "14:00",
+                "endTime": "16:25",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "undergradShared",
+              "label": "本研同堂",
+              "before": false,
+              "after": true
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT5104P.01",
+            "courseCode": "STAT5104P",
+            "courseName": "高等概率论",
+            "teacher": "胡太忠,庄玮玮"
+          },
+          "previous": {
+            "id": "STAT5104P.01",
+            "courseCode": "STAT5104P",
+            "courseName": "高等概率论",
+            "teacher": "胡太忠,庄玮玮",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "5104",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ],
+                "room": "5104",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT5104P.01",
+            "courseCode": "STAT5104P",
+            "courseName": "高等概率论",
+            "teacher": "胡太忠,庄玮玮",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "5104",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16
+                ],
+                "room": "5104",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "undergradShared",
+              "label": "本研同堂",
+              "before": false,
+              "after": true
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT5127P.01",
+            "courseCode": "STAT5127P",
+            "courseName": "贝叶斯分析",
+            "teacher": "陈昱,张伟平"
+          },
+          "previous": {
+            "id": "STAT5127P.01",
+            "courseCode": "STAT5127P",
+            "courseName": "贝叶斯分析",
+            "teacher": "张伟平,陈昱",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "2406",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT5127P.01",
+            "courseCode": "STAT5127P",
+            "courseName": "贝叶斯分析",
+            "teacher": "陈昱,张伟平",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  20
+                ],
+                "room": "2406",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "undergradShared",
+              "label": "本研同堂",
+              "before": false,
+              "after": true
             }
           ]
         }

--- a/public/data/semesters/2026-summer/courses.json
+++ b/public/data/semesters/2026-summer/courses.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-07-28T05:06:12Z",
+  "generatedAt": "2026-07-30T12:17:38Z",
   "source": {
     "url": "https://catalog.ustc.edu.cn/query/lesson",
     "semesterId": 441
@@ -780,7 +780,7 @@
       "examType": "笔试（闭卷）",
       "grading": "百分制",
       "undergradShared": false,
-      "enrolled": 97,
+      "enrolled": 96,
       "capacity": 100,
       "classes": [],
       "rawSchedule": "3A112: 1(6,7,8,9);3A112: 2(6,7,8,9);3A112: 4(6,7,8,9);3A112: 5(6,7,8,9);3A112: 6(6,7,8,9)",
@@ -880,7 +880,7 @@
       "examType": "笔试（闭卷）",
       "grading": "百分制",
       "undergradShared": false,
-      "enrolled": 83,
+      "enrolled": 82,
       "capacity": 100,
       "classes": [],
       "rawSchedule": "3A112: 1(2,3,4,5);3A112: 2(2,3,4,5);西区电一楼机房1厅: 3(1,2,3,4,5);西区电一楼机房1厅: 3(6,7,8,9,10);3A112: 4(2,3,4,5);3A112: 5(2,3,4,5);3A112: 6(2,3,4,5)",
@@ -4299,7 +4299,7 @@
         "code": "108",
         "name": "外语教学中心"
       },
-      "teacher": "",
+      "teacher": "Matthew Bell,Steve Masashi Musha",
       "credits": 2,
       "hours": 40,
       "level": "研究生",
@@ -4454,7 +4454,7 @@
         "code": "108",
         "name": "外语教学中心"
       },
-      "teacher": "",
+      "teacher": "Matthew Bell,Patrick Mackie,陈静",
       "credits": 2,
       "hours": 40,
       "level": "研究生",
@@ -4609,7 +4609,7 @@
         "code": "108",
         "name": "外语教学中心"
       },
-      "teacher": "",
+      "teacher": "Lewis Roberts,Matthew Bell,李献伟",
       "credits": 2,
       "hours": 40,
       "level": "研究生",
@@ -4764,7 +4764,7 @@
         "code": "108",
         "name": "外语教学中心"
       },
-      "teacher": "",
+      "teacher": "Samuel GIBSON,Thomas Yifang Xiao",
       "credits": 2,
       "hours": 40,
       "level": "研究生",
@@ -4919,7 +4919,7 @@
         "code": "108",
         "name": "外语教学中心"
       },
-      "teacher": "",
+      "teacher": "Thomas Yifang Xiao,Andres Melo",
       "credits": 2,
       "hours": 40,
       "level": "研究生",
@@ -5074,7 +5074,7 @@
         "code": "108",
         "name": "外语教学中心"
       },
-      "teacher": "",
+      "teacher": "John Gandy,Thomas Yifang Xiao",
       "credits": 2,
       "hours": 40,
       "level": "研究生",
@@ -5229,7 +5229,7 @@
         "code": "108",
         "name": "外语教学中心"
       },
-      "teacher": "",
+      "teacher": "Thomas Yifang Xiao,Bradley Johnson",
       "credits": 2,
       "hours": 40,
       "level": "研究生",
@@ -5240,7 +5240,7 @@
       "examType": "口试",
       "grading": "二分制",
       "undergradShared": false,
-      "enrolled": 24,
+      "enrolled": 19,
       "capacity": 35,
       "classes": [],
       "rawSchedule": "2305: 1(6,7);东区二教2-621教室: 1(8,9);2305: 2(6,7);东区二教2-621教室: 2(8,9);2305: 3(6,7);东区二教2-621教室: 3(8,9);2305: 4(6,7);东区二教2-621教室: 4(8,9);2305: 5(6,7);东区二教2-621教室: 5(8,9)",
@@ -5384,7 +5384,7 @@
         "code": "108",
         "name": "外语教学中心"
       },
-      "teacher": "",
+      "teacher": "Thomas Yifang Xiao,David Garcia",
       "credits": 2,
       "hours": 40,
       "level": "研究生",
@@ -5395,7 +5395,7 @@
       "examType": "口试",
       "grading": "二分制",
       "undergradShared": false,
-      "enrolled": 24,
+      "enrolled": 18,
       "capacity": 23,
       "classes": [],
       "rawSchedule": "2306: 1(6,7);东区二教2-621教室: 1(8,9);2306: 2(6,7);东区二教2-621教室: 2(8,9);2306: 3(6,7);东区二教2-621教室: 3(8,9);2306: 4(6,7);东区二教2-621教室: 4(8,9);2306: 5(6,7);东区二教2-621教室: 5(8,9)",
@@ -5539,7 +5539,7 @@
         "code": "108",
         "name": "外语教学中心"
       },
-      "teacher": "",
+      "teacher": "Thomas Yifang Xiao,John Gandy",
       "credits": 2,
       "hours": 40,
       "level": "研究生",
@@ -5550,7 +5550,7 @@
       "examType": "口试",
       "grading": "二分制",
       "undergradShared": false,
-      "enrolled": 0,
+      "enrolled": 5,
       "capacity": 0,
       "classes": [],
       "rawSchedule": "2421: 1(6,7,8,9);2421: 2(6,7,8,9);2421: 3(6,7,8,9);2421: 4(6,7,8,9);2421: 5(6,7,8,9)",
@@ -5639,7 +5639,7 @@
         "code": "108",
         "name": "外语教学中心"
       },
-      "teacher": "",
+      "teacher": "David Garcia,Matthew Bell",
       "credits": 2,
       "hours": 40,
       "level": "研究生",
@@ -5650,7 +5650,7 @@
       "examType": "口试",
       "grading": "二分制",
       "undergradShared": false,
-      "enrolled": 0,
+      "enrolled": 6,
       "capacity": 0,
       "classes": [],
       "rawSchedule": "2621: 1(6,7,8,9);2621: 2(6,7,8,9);2621: 3(6,7,8,9);2621: 4(6,7,8,9);2621: 5(6,7,8,9)",
@@ -11487,5 +11487,5 @@
       }
     }
   },
-  "revision": "7c85994e639da8f9c83bdd39d2c482ee8c02f36960bd3e5d549b347432f6c9c9"
+  "revision": "545a0522aa4f3f117169d11d89b3ee96055be807d989a71aa2afbb13b152efca"
 }

--- a/public/data/semesters/2026-summer/updates.json
+++ b/public/data/semesters/2026-summer/updates.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "semesterKey": "2026-summer",
-  "currentRevision": "7c85994e639da8f9c83bdd39d2c482ee8c02f36960bd3e5d549b347432f6c9c9",
+  "currentRevision": "545a0522aa4f3f117169d11d89b3ee96055be807d989a71aa2afbb13b152efca",
   "entries": [
     {
       "id": "2026-summer:193249c0acc6eee0",
@@ -3869,6 +3869,2741 @@
               "label": "授课教师",
               "before": "",
               "after": "Thomas Yifang Xiao,David Garcia"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2026-summer:545a0522aa4f3f11",
+      "revision": "545a0522aa4f3f117169d11d89b3ee96055be807d989a71aa2afbb13b152efca",
+      "previousRevision": "7c85994e639da8f9c83bdd39d2c482ee8c02f36960bd3e5d549b347432f6c9c9",
+      "publishedAt": "2026-07-30T12:17:38Z",
+      "summary": {
+        "added": 0,
+        "removed": 0,
+        "modified": 10
+      },
+      "added": [],
+      "removed": [],
+      "modified": [
+        {
+          "course": {
+            "id": "FORL7201U.09",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Matthew Bell,Steve Masashi Musha"
+          },
+          "previous": {
+            "id": "FORL7201U.09",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2204",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2204",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2204",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2204",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2204",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL7201U.09",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Matthew Bell,Steve Masashi Musha",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2204",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2204",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2204",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2204",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2204",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "Matthew Bell,Steve Masashi Musha"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL7201U.10",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Matthew Bell,Patrick Mackie,陈静"
+          },
+          "previous": {
+            "id": "FORL7201U.10",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2205",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2205",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2205",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2205",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2205",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL7201U.10",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Matthew Bell,Patrick Mackie,陈静",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2205",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2205",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2205",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2205",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2205",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "Matthew Bell,Patrick Mackie,陈静"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL7201U.11",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Lewis Roberts,Matthew Bell,李献伟"
+          },
+          "previous": {
+            "id": "FORL7201U.11",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2206",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2206",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2206",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2206",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2206",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL7201U.11",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Lewis Roberts,Matthew Bell,李献伟",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2206",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2206",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2206",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2206",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2206",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-421教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "Lewis Roberts,Matthew Bell,李献伟"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL7201U.12",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Samuel GIBSON,Thomas Yifang Xiao"
+          },
+          "previous": {
+            "id": "FORL7201U.12",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2207",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2207",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2207",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2207",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2207",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL7201U.12",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Samuel GIBSON,Thomas Yifang Xiao",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2207",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2207",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2207",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2207",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2207",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "Samuel GIBSON,Thomas Yifang Xiao"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL7201U.13",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Thomas Yifang Xiao,Andres Melo"
+          },
+          "previous": {
+            "id": "FORL7201U.13",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2303",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2303",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2303",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2303",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL7201U.13",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Thomas Yifang Xiao,Andres Melo",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2303",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2303",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2303",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2303",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "Thomas Yifang Xiao,Andres Melo"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL7201U.14",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "John Gandy,Thomas Yifang Xiao"
+          },
+          "previous": {
+            "id": "FORL7201U.14",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2304",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2304",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2304",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2304",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2304",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL7201U.14",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "John Gandy,Thomas Yifang Xiao",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2304",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2304",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2304",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2304",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2304",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "John Gandy,Thomas Yifang Xiao"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL7201U.15",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Thomas Yifang Xiao,Bradley Johnson"
+          },
+          "previous": {
+            "id": "FORL7201U.15",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2305",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2305",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2305",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2305",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2305",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL7201U.15",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Thomas Yifang Xiao,Bradley Johnson",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2305",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2305",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2305",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2305",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2305",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "Thomas Yifang Xiao,Bradley Johnson"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL7201U.16",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Thomas Yifang Xiao,David Garcia"
+          },
+          "previous": {
+            "id": "FORL7201U.16",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2306",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2306",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2306",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2306",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2306",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL7201U.16",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Thomas Yifang Xiao,David Garcia",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2306",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2306",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2306",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2306",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2306",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "东区二教2-621教室",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "Thomas Yifang Xiao,David Garcia"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL7201U.17",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Thomas Yifang Xiao,John Gandy"
+          },
+          "previous": {
+            "id": "FORL7201U.17",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2421",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2421",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2421",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2421",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2421",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL7201U.17",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "Thomas Yifang Xiao,John Gandy",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2421",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2421",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2421",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2421",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2421",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "Thomas Yifang Xiao,John Gandy"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL7201U.18",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "David Garcia,Matthew Bell"
+          },
+          "previous": {
+            "id": "FORL7201U.18",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2621",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2621",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2621",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2621",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2621",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL7201U.18",
+            "courseCode": "FORL7201U",
+            "courseName": "工程博士英语",
+            "teacher": "David Garcia,Matthew Bell",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2621",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2621",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2621",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2621",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2621",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "David Garcia,Matthew Bell"
             }
           ]
         }

--- a/public/data/semesters/index.json
+++ b/public/data/semesters/index.json
@@ -6,14 +6,14 @@
       "key": "2026-fall",
       "name": "2026年秋季学期",
       "file": "2026-fall/courses.json",
-      "revision": "6a10a9e3813591e40361a5b578c9ad699a9bc371fb7bbc058628923c2289cbb6",
+      "revision": "a72799997bae83bf18693e16bff922cbe1cdc7c261fa614ebe95529246e238d3",
       "updatesFile": "2026-fall/updates.json"
     },
     {
       "key": "2026-summer",
       "name": "2026年夏季学期",
       "file": "2026-summer/courses.json",
-      "revision": "7c85994e639da8f9c83bdd39d2c482ee8c02f36960bd3e5d549b347432f6c9c9",
+      "revision": "545a0522aa4f3f117169d11d89b3ee96055be807d989a71aa2afbb13b152efca",
       "updatesFile": "2026-summer/updates.json"
     }
   ]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,7 @@ import UpdateNoticeModal from '@/components/UpdateNoticeModal';
 import UpdateHistoryModal from '@/components/UpdateHistoryModal';
 import { useOverlayStackSnapshot } from '@/components/overlayStack';
 import SharedPlanImportModal from '@/components/SharedPlanImportModal';
+import CourseFinderModal from '@/components/CourseFinderModal';
 import { loadPlansPayload, savePlansPayload } from '@/utils/planSeed';
 import { FavoritesProvider, useFavorites } from '@/favorites/FavoritesContext';
 import { MemosProvider, useMemos } from '@/memos/MemosContext';
@@ -203,6 +204,7 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
   const [selectedCoursesTab, setSelectedCoursesTab] = useState<'current' | 'curriculum'>('current');
   const [favoritesOpen, setFavoritesOpen] = useState(false);
   const [memoOpen, setMemoOpen] = useState(false);
+  const [courseFinderOpen, setCourseFinderOpen] = useState(false);
   const [memoTargetId, setMemoTargetId] = useState<string | null>(null);
   const [pendingFavoriteArrangement, setPendingFavoriteArrangement] = useState<{
     planId: string;
@@ -769,6 +771,7 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
   const handleRestartOnboarding = () => {
     setDetailGroupKey(null);
     setFavoritesOpen(false);
+    setCourseFinderOpen(false);
     setCustomizationOpen(false);
     window.setTimeout(() => onboarding.startTour(), 220);
   };
@@ -827,6 +830,7 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
   const handleTourStepAction = useCallback((action: NonNullable<TourStep['action']>) => {
     setDetailGroupKey(null);
     setFavoritesOpen(false);
+    setCourseFinderOpen(false);
     if (action === 'openSelectedCoursesCurriculum') {
       setCustomizationOpen(false);
       openSelectedCourses('curriculum');
@@ -852,6 +856,7 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
     setDetailGroupKey(null);
     setSelectedCoursesOpen(false);
     setFavoritesOpen(false);
+    setCourseFinderOpen(false);
     setCustomizationOpen(false);
     onboarding.finishTour();
   };
@@ -860,6 +865,7 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
     setDetailGroupKey(null);
     setSelectedCoursesOpen(false);
     setFavoritesOpen(false);
+    setCourseFinderOpen(false);
     setCustomizationOpen(false);
     onboarding.skipTour();
   };
@@ -905,6 +911,7 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
               filter={filter}
               setFilter={setFilter}
               options={filterOptions}
+              onOpenFinder={() => setCourseFinderOpen(true)}
               onOpenMemo={() => {
                 setMemoTargetId(null);
                 setMemoOpen(true);
@@ -983,6 +990,17 @@ function MainArea({ themeMode, onToggleTheme }: { themeMode: Theme; onToggleThem
           setMemoOpen(false);
           setMemoTargetId(null);
         }}
+      />
+      <CourseFinderModal
+        open={courseFinderOpen}
+        onClose={() => setCourseFinderOpen(false)}
+        groups={groups}
+        selectedIds={selectedIds}
+        conflictGroupKeys={conflictGroupKeys}
+        themeMode={themeMode}
+        onOpenDetail={setDetailGroupKey}
+        courseMap={courseMap}
+        groupsByCode={groupsByCode}
       />
       <CustomizationModal
         open={customizationOpen}

--- a/src/components/CourseFinderModal.test.ts
+++ b/src/components/CourseFinderModal.test.ts
@@ -1,0 +1,340 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { act, createElement, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CourseGroup, CourseSection } from '@/types';
+
+const coursePoolCalls = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+
+vi.mock('./BottomModal', () => ({
+  default: ({
+    open,
+    children,
+    footer,
+  }: {
+    open: boolean;
+    children: ReactNode;
+    footer?: ReactNode;
+  }) => open ? createElement('div', { 'data-testid': 'bottom-modal' }, children, footer) : null,
+}));
+
+vi.mock('./CoursePool', () => ({
+  default: (props: Record<string, unknown>) => {
+    coursePoolCalls.push(props);
+    return createElement('div', { 'data-testid': 'course-pool' }, '课程结果');
+  },
+}));
+
+import CourseFinderModal from './CourseFinderModal';
+
+const cssSource = readFileSync(resolve('src/index.css'), 'utf8');
+
+interface MountedRoot {
+  host: HTMLDivElement;
+  root: Root;
+}
+
+const mountedRoots: MountedRoot[] = [];
+const originalRequestAnimationFrame = window.requestAnimationFrame;
+
+async function mount(node: ReactNode): Promise<MountedRoot> {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const root = createRoot(host);
+  const mounted = { host, root };
+  mountedRoots.push(mounted);
+  await act(async () => {
+    root.render(node);
+  });
+  return mounted;
+}
+
+function section(): CourseSection {
+  return {
+    id: 'TEST100.01',
+    courseName: '测试课程',
+    department: { code: '01', name: '测试学院' },
+    teacher: '测试教师',
+    credits: 2,
+    hours: 32,
+    level: '本科',
+    sectionType: '',
+    category: '',
+    courseType: '',
+    language: '',
+    examType: '',
+    grading: '',
+    undergradShared: false,
+    enrolled: 0,
+    capacity: 100,
+    classes: [],
+    rawSchedule: '',
+    schedule: [
+      { weeks: [1, 16], room: '101', campus: '本部', day: 1, periods: [1] },
+      { weeks: [1, 16], room: '102', campus: '本部', day: 3, periods: [5] },
+    ],
+  };
+}
+
+const testSection = section();
+const testGroup: CourseGroup = {
+  courseCode: 'TEST100',
+  courseName: testSection.courseName,
+  schedule: testSection.schedule,
+  fingerprint: 'test',
+  sectionIds: [testSection.id],
+  teachers: [testSection.teacher],
+  sections: [testSection],
+  key: 'TEST100::test',
+};
+
+const courseMap = new Map([[testSection.id, testSection]]);
+const groupsByCode = new Map([[testGroup.courseCode, [testGroup]]]);
+const onOpenDetail = vi.fn();
+
+function finder(open: boolean): ReactNode {
+  return createElement(CourseFinderModal, {
+    open,
+    onClose: vi.fn(),
+    groups: [testGroup],
+    selectedIds: new Set<string>(),
+    conflictGroupKeys: new Set<string>(),
+    themeMode: 'light',
+    onOpenDetail,
+    courseMap,
+    groupsByCode,
+  });
+}
+
+function findSearchButton(): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+    .find((candidate) => candidate.textContent?.replace(/\s/g, '') === '寻找');
+  if (!button) throw new Error('Missing finder search button');
+  return button;
+}
+
+function findWithinCheckbox(): HTMLInputElement {
+  const checkbox = document.querySelector<HTMLInputElement>(
+    'input[type="checkbox"]',
+  );
+  if (!checkbox) throw new Error('Missing within-selection checkbox');
+  return checkbox;
+}
+
+function findGridCell(day: number, period: number): HTMLButtonElement {
+  const cell = document.querySelector<HTMLButtonElement>(
+    `.course-finder__picker-pane [data-slot-key="${day}-${period}"]`,
+  );
+  if (!cell) throw new Error(`Missing finder grid cell ${day}-${period}`);
+  return cell;
+}
+
+function mousePointerEvent(
+  type: 'pointerdown' | 'pointermove' | 'pointerup',
+  button = 0,
+): MouseEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    button,
+    buttons: type === 'pointerup' ? 0 : 1,
+  });
+  Object.defineProperty(event, 'pointerType', { value: 'mouse' });
+  Object.defineProperty(event, 'pointerId', { value: 1 });
+  return event;
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  coursePoolCalls.length = 0;
+  onOpenDetail.mockClear();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const { root } of mountedRoots.splice(0).reverse()) root.unmount();
+    await Promise.resolve();
+  });
+  document.body.replaceChildren();
+  if (originalRequestAnimationFrame) window.requestAnimationFrame = originalRequestAnimationFrame;
+  else delete (window as Partial<Window>).requestAnimationFrame;
+});
+
+describe('CourseFinderModal interactions', () => {
+  it('searches a selected cell and reuses CoursePool with all normal actions wired', async () => {
+    window.requestAnimationFrame = (callback) => window.setTimeout(
+      () => callback(window.performance.now()),
+      0,
+    );
+    await mount(finder(true));
+
+    const firstCell = findGridCell(1, 1);
+    const secondCell = findGridCell(3, 5);
+    expect(findSearchButton().disabled).toBe(true);
+
+    act(() => {
+      firstCell.click();
+      secondCell.click();
+    });
+    expect(firstCell.getAttribute('aria-pressed')).toBe('true');
+    expect(secondCell.getAttribute('aria-pressed')).toBe('true');
+    expect(findSearchButton().disabled).toBe(false);
+
+    await act(async () => {
+      findSearchButton().click();
+      await new Promise((resolve) => window.setTimeout(resolve, 10));
+    });
+
+    expect(document.body.textContent).toContain('1 门课程 · 1 个时间组');
+    expect(document.body.textContent).toContain(
+      '实验性功能，请仔细核对搜索结果中课程信息，搜索结果也有可能展示不全。',
+    );
+    expect(coursePoolCalls.at(-1)).toMatchObject({
+      groups: [testGroup],
+      dataTour: null,
+      onOpenDetail,
+      emptyDescription: '没有符合所选时间条件的课程',
+    });
+  });
+
+  it('defaults to within mode and excludes a group with time outside the selection', async () => {
+    window.requestAnimationFrame = (callback) => window.setTimeout(
+      () => callback(window.performance.now()),
+      0,
+    );
+    await mount(finder(true));
+
+    const checkbox = findWithinCheckbox();
+    expect(checkbox.checked).toBe(true);
+
+    const cell = findGridCell(1, 1);
+    act(() => cell.click());
+
+    await act(async () => {
+      findSearchButton().click();
+      await new Promise((resolve) => window.setTimeout(resolve, 10));
+    });
+
+    expect(coursePoolCalls.at(-1)).toMatchObject({ groups: [] });
+  });
+
+  it('matches a group when any selected slot intersects after within mode is cleared', async () => {
+    window.requestAnimationFrame = (callback) => window.setTimeout(
+      () => callback(window.performance.now()),
+      0,
+    );
+    await mount(finder(true));
+
+    const checkbox = findWithinCheckbox();
+    expect(checkbox.checked).toBe(true);
+    act(() => checkbox.click());
+    expect(checkbox.checked).toBe(false);
+
+    const matchingCell = findGridCell(1, 1);
+    const unrelatedCell = findGridCell(2, 2);
+    act(() => {
+      matchingCell.click();
+      unrelatedCell.click();
+    });
+
+    await act(async () => {
+      findSearchButton().click();
+      await new Promise((resolve) => window.setTimeout(resolve, 10));
+    });
+
+    expect(coursePoolCalls.at(-1)).toMatchObject({ groups: [testGroup] });
+  });
+
+  it('uses the blocked-time grid empty and blocked states without a hard state', async () => {
+    await mount(finder(true));
+
+    const cells = document.querySelectorAll<HTMLButtonElement>(
+      '.course-finder__picker-pane [data-slot-key]',
+    );
+    expect(cells).toHaveLength(91);
+
+    const cell = findGridCell(1, 1);
+    expect(cell.classList.contains('availability-grid__cell--empty')).toBe(true);
+    expect(cell.textContent).toBe('');
+
+    act(() => cell.click());
+    expect(cell.classList.contains('availability-grid__cell--blocked')).toBe(true);
+    expect(cell.getAttribute('aria-pressed')).toBe('true');
+    expect(cell.textContent).toBe('');
+
+    act(() => cell.click());
+    expect(cell.classList.contains('availability-grid__cell--empty')).toBe(true);
+    expect(cell.getAttribute('aria-pressed')).toBe('false');
+    expect(document.querySelector('.course-finder__picker-pane .availability-grid__cell--hard'))
+      .toBeNull();
+  });
+
+  it('mouse drag paints and erases finder cells until pointerup', async () => {
+    await mount(finder(true));
+
+    const first = findGridCell(1, 1);
+    const second = findGridCell(2, 1);
+    const third = findGridCell(3, 1);
+
+    act(() => {
+      first.dispatchEvent(mousePointerEvent('pointerdown'));
+      second.dispatchEvent(mousePointerEvent('pointermove'));
+      window.dispatchEvent(mousePointerEvent('pointerup'));
+    });
+    expect(first.classList.contains('availability-grid__cell--blocked')).toBe(true);
+    expect(second.classList.contains('availability-grid__cell--blocked')).toBe(true);
+
+    act(() => {
+      third.dispatchEvent(mousePointerEvent('pointermove'));
+    });
+    expect(third.classList.contains('availability-grid__cell--empty')).toBe(true);
+
+    act(() => {
+      first.dispatchEvent(mousePointerEvent('pointerdown'));
+      second.dispatchEvent(mousePointerEvent('pointermove'));
+      window.dispatchEvent(mousePointerEvent('pointerup'));
+    });
+    expect(first.classList.contains('availability-grid__cell--empty')).toBe(true);
+    expect(second.classList.contains('availability-grid__cell--empty')).toBe(true);
+  });
+
+  it('uses the shared clear-button treatment and centers the experimental disclaimer', async () => {
+    await mount(finder(true));
+
+    const clearButton = document.querySelector<HTMLButtonElement>(
+      '.course-finder__picker-pane .availability-grid-clear-button',
+    );
+    expect(clearButton).not.toBeNull();
+    expect(clearButton?.textContent?.replace(/\s/g, '')).toBe('清空');
+    expect(clearButton?.classList.contains('ant-btn-sm')).toBe(false);
+    expect(cssSource).toMatch(
+      /\.course-finder-modal \.bottom-modal__footer\s*\{[^}]*justify-content:\s*center;/s,
+    );
+    expect(cssSource).toMatch(
+      /\.course-finder__disclaimer\s*\{[^}]*text-align:\s*center;/s,
+    );
+  });
+
+  it('returns to the unsearched state when an in-flight search is closed', async () => {
+    window.requestAnimationFrame = vi.fn(() => 1);
+    const mounted = await mount(finder(true));
+    const cell = findGridCell(1, 1);
+    act(() => cell.click());
+
+    act(() => findSearchButton().click());
+    expect(document.body.textContent).toContain('正在寻找匹配课程…');
+
+    await act(async () => {
+      mounted.root.render(finder(false));
+    });
+    await act(async () => {
+      mounted.root.render(finder(true));
+    });
+
+    expect(document.body.textContent).toContain('尚未寻找');
+    expect(document.body.textContent).not.toContain('0 门课程 · 0 个时间组');
+    expect(coursePoolCalls).toHaveLength(0);
+  });
+});

--- a/src/components/CourseFinderModal.tsx
+++ b/src/components/CourseFinderModal.tsx
@@ -1,0 +1,248 @@
+import { Button, Checkbox, Empty, Spin } from 'antd';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { CourseGroup, CourseSection } from '@/types';
+import {
+  filterCourseGroupsByTime,
+  type CourseTimeSearchMode,
+} from '@/utils/courseTimeSearch';
+import BottomModal from './BottomModal';
+import CoursePool from './CoursePool';
+import TimeSlotGrid, {
+  type TimeSlotPaintChange,
+} from './TimeSlotGrid';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  groups: CourseGroup[];
+  selectedIds: Set<string>;
+  conflictGroupKeys: Set<string>;
+  themeMode: 'light' | 'dark';
+  onOpenDetail: (groupKey: string) => void;
+  courseMap: ReadonlyMap<string, CourseSection>;
+  groupsByCode: ReadonlyMap<string, CourseGroup[]>;
+}
+
+const SEARCH_CHUNK_SIZE = 240;
+
+function waitForPaint(): Promise<void> {
+  if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => window.requestAnimationFrame(() => resolve()));
+}
+
+function yieldToBrowser(): Promise<void> {
+  if (typeof window === 'undefined') return Promise.resolve();
+  return new Promise((resolve) => window.setTimeout(resolve, 0));
+}
+
+export default function CourseFinderModal({
+  open,
+  onClose,
+  groups,
+  selectedIds,
+  conflictGroupKeys,
+  themeMode,
+  onOpenDetail,
+  courseMap,
+  groupsByCode,
+}: Props) {
+  const [selectedSlots, setSelectedSlots] = useState<Set<string>>(() => new Set());
+  const [mode, setMode] = useState<CourseTimeSearchMode>('within');
+  const [searching, setSearching] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [resultGroups, setResultGroups] = useState<CourseGroup[]>([]);
+  const searchGenerationRef = useRef(0);
+
+  const resultCourseCount = useMemo(
+    () => new Set(resultGroups.map((group) => group.courseCode)).size,
+    [resultGroups],
+  );
+
+  const invalidateResults = () => {
+    searchGenerationRef.current += 1;
+    setSearching(false);
+    setHasSearched(false);
+    setResultGroups([]);
+  };
+
+  useEffect(() => {
+    searchGenerationRef.current += 1;
+    setSearching(false);
+    setHasSearched(false);
+    setResultGroups([]);
+  }, [groups]);
+
+  useEffect(() => {
+    if (open) return;
+    searchGenerationRef.current += 1;
+    setSearching(false);
+  }, [open]);
+
+  useEffect(() => () => {
+    searchGenerationRef.current += 1;
+  }, []);
+
+  const paintSlots = (changes: readonly TimeSlotPaintChange[]) => {
+    setSelectedSlots((current) => {
+      const next = new Set(current);
+      for (const { key, state } of changes) {
+        if (state === 'blocked') next.add(key);
+        else next.delete(key);
+      }
+      return next;
+    });
+    invalidateResults();
+  };
+
+  const clearSlots = () => {
+    setSelectedSlots(new Set());
+    invalidateResults();
+  };
+
+  const runSearch = async () => {
+    if (searching || selectedSlots.size === 0) return;
+
+    const generation = searchGenerationRef.current + 1;
+    searchGenerationRef.current = generation;
+    const selection = new Set(selectedSlots);
+    const searchMode = mode;
+    setSearching(true);
+
+    // 先让出一次绘制，再分块扫描，数据量较大时加载动画仍能持续更新。
+    await waitForPaint();
+    const matches: CourseGroup[] = [];
+    for (let index = 0; index < groups.length; index += SEARCH_CHUNK_SIZE) {
+      if (searchGenerationRef.current !== generation) return;
+      matches.push(...filterCourseGroupsByTime(
+        groups.slice(index, index + SEARCH_CHUNK_SIZE),
+        selection,
+        searchMode,
+      ));
+      if (index + SEARCH_CHUNK_SIZE < groups.length) await yieldToBrowser();
+    }
+
+    if (searchGenerationRef.current !== generation) return;
+    setResultGroups(matches);
+    setHasSearched(true);
+    setSearching(false);
+  };
+
+  const resultStatus = searching
+    ? '正在寻找…'
+    : hasSearched
+      ? `${resultCourseCount} 门课程 · ${resultGroups.length} 个时间组`
+      : '尚未寻找';
+
+  return (
+    <BottomModal
+      open={open}
+      title="寻找课程"
+      onClose={onClose}
+      width={1120}
+      className="course-finder-modal"
+      footer={(
+        <p className="course-finder__disclaimer">
+          实验性功能，请仔细核对搜索结果中课程信息，搜索结果也有可能展示不全。
+        </p>
+      )}
+    >
+      <div className="course-finder__layout">
+        <section className="course-finder__picker-pane" aria-labelledby="course-finder-picker-title">
+          <div className="availability-grid-section-header">
+            <div className="availability-grid-section-copy">
+              <h3 id="course-finder-picker-title">选择时间块</h3>
+              <p>
+                点击切换未选择与已选择；按住鼠标拖动可连续选择或取消。
+                默认仅寻找全部上课节次均在所选范围内的课程时间组。
+              </p>
+            </div>
+            <Button
+              className="availability-grid-clear-button"
+              disabled={selectedSlots.size === 0}
+              onClick={clearSlots}
+            >
+              清空
+            </Button>
+          </div>
+
+          <TimeSlotGrid
+            ariaLabel="寻找课程时间选择"
+            getState={(key) => selectedSlots.has(key) ? 'blocked' : 'empty'}
+            nextState={(state) => state === 'empty' ? 'blocked' : 'empty'}
+            onPaint={paintSlots}
+            stateLabels={{
+              empty: '未选择',
+              blocked: '已选择',
+              hard: '强冲突',
+            }}
+          />
+
+          <div className="course-finder__criteria">
+            <Checkbox
+              checked={mode === 'within'}
+              onChange={(event) => {
+                setMode(event.target.checked ? 'within' : 'contains');
+                invalidateResults();
+              }}
+            >
+              只在这些时间块中
+            </Checkbox>
+            <span className="course-finder__selection-count">
+              已选 {selectedSlots.size} 个时间块
+            </span>
+            <Button
+              type="primary"
+              loading={searching}
+              disabled={selectedSlots.size === 0}
+              onClick={() => void runSearch()}
+            >
+              寻找
+            </Button>
+          </div>
+          <p className="course-finder__mode-help">
+            {mode === 'within'
+              ? '仅返回全部上课节次均落在所选范围内的时间组。'
+              : '课程只要有上课节次落在所选范围内即可，也可以包含其他上课时间。'}
+          </p>
+        </section>
+
+        <section className="course-finder__results-pane" aria-labelledby="course-finder-results-title">
+          <div className="course-finder__results-header">
+            <h3 id="course-finder-results-title">搜索结果</h3>
+            <span aria-live="polite">{resultStatus}</span>
+          </div>
+          <div className="course-finder__results-content" aria-busy={searching}>
+            {searching ? (
+              <div className="course-finder__loading" role="status">
+                <Spin size="large" />
+                <span>正在寻找匹配课程…</span>
+              </div>
+            ) : hasSearched ? (
+              <CoursePool
+                groups={resultGroups}
+                selectedIds={selectedIds}
+                conflictGroupKeys={conflictGroupKeys}
+                themeMode={themeMode}
+                onOpenDetail={onOpenDetail}
+                courseMap={courseMap}
+                groupsByCode={groupsByCode}
+                className="course-finder__course-pool"
+                dataTour={null}
+                emptyDescription="没有符合所选时间条件的课程"
+              />
+            ) : (
+              <div className="course-finder__empty">
+                <Empty
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  description="勾选时间块后点击“寻找”"
+                />
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </BottomModal>
+  );
+}

--- a/src/components/CoursePool.tsx
+++ b/src/components/CoursePool.tsx
@@ -21,6 +21,9 @@ interface Props {
   onOpenDetail: (groupKey: string) => void;
   courseMap: ReadonlyMap<string, CourseSection>;
   groupsByCode: ReadonlyMap<string, CourseGroup[]>;
+  className?: string;
+  dataTour?: string | null;
+  emptyDescription?: string;
 }
 
 /** react-window 2.x: List <RowProps> 的"单元格 props"。
@@ -108,6 +111,9 @@ export default function CoursePool({
   onOpenDetail,
   courseMap,
   groupsByCode,
+  className,
+  dataTour = 'search-results',
+  emptyDescription = '无匹配课程',
 }: Props) {
   const { activePlan, dispatch } = usePlans();
   const { timeGroupKeys, toggle: toggleFavorite } = useFavorites();
@@ -203,9 +209,12 @@ export default function CoursePool({
 
   // rowProps 一旦变化需要被 List 自动观察到（react-window 2.x 自动）
   return (
-    <div className="panel-inner course-pool no-print" data-tour="search-results">
+    <div
+      className={`panel-inner course-pool no-print${className ? ` ${className}` : ''}`}
+      data-tour={dataTour ?? undefined}
+    >
       {groups.length === 0 ? (
-        <Empty description="无匹配课程" style={{ marginTop: 40 }} />
+        <Empty description={emptyDescription} style={{ marginTop: 40 }} />
       ) : (
         <div className="course-pool__list">
           <List<RowExtraProps>

--- a/src/components/CustomizationModal.test.ts
+++ b/src/components/CustomizationModal.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const source = readFileSync(new URL('./CustomizationModal.tsx', import.meta.url), 'utf8');
+const timeSlotGridSource = readFileSync(new URL('./TimeSlotGrid.tsx', import.meta.url), 'utf8');
 const onboarding = readFileSync(
   new URL('./onboarding/OnboardingWizard.tsx', import.meta.url),
   'utf8',
@@ -82,13 +83,15 @@ describe('CustomizationModal hard conflict three-state grid', () => {
   it('renders a three-state availability grid cycling empty -> blocked -> hard', () => {
     expect(source).toContain('draftHardConflictSlots');
     expect(source).toContain('hardConflictSlotSet');
-    expect(source).toContain('availability-grid__cell--${state}');
+    expect(source).toContain('<TimeSlotGrid');
+    expect(timeSlotGridSource).toContain('availability-grid__cell--${state}');
     expect(styles).toContain('availability-grid__cell--hard');
     expect(source).toMatch(/空闲.*有事.*强冲突|强冲突.*有事.*空闲/);
   });
 
   it('applies hard conflict slots back to settings and keeps them exclusive with blocked', () => {
-    expect(source).toContain('hardConflictSlots: draftHardConflictSlots');
+    expect(source).toContain('timeSlotGridRef.current?.flushPendingPaint()');
+    expect(source).toContain('hardConflictSlots: nextHardConflictSlots');
     expect(source).toContain('清空占位');
   });
 });

--- a/src/components/CustomizationModal.tsx
+++ b/src/components/CustomizationModal.tsx
@@ -1,9 +1,7 @@
 import { App, Button } from 'antd';
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { DAYS, PERIODS, DAY_LABELS } from '@/constants/grid';
 import {
   ARRANGEMENT_DISPLAY_COUNT_OPTIONS,
-  blockedSlotKey,
   CALCULATION_MODE_OPTIONS,
   RESIDENT_CAMPUS_OPTIONS,
   type ArrangementDisplayCount,
@@ -16,6 +14,10 @@ import {
   PreferenceToggleButton as PreferenceToggle,
 } from './onboarding/PreferenceSwitch';
 import SelectWithChevron from './SelectWithChevron';
+import TimeSlotGrid, {
+  type TimeSlotGridHandle,
+  type TimeSlotPaintChange,
+} from './TimeSlotGrid';
 
 export type CustomizationPage = 'main' | 'blockedSlots' | 'calculationMode';
 
@@ -70,21 +72,22 @@ export default function CustomizationModal({
   const { message } = App.useApp();
   const [page, setPage] = useState<CustomizationPage>(initialPage);
   const [draftBlockedSlots, setDraftBlockedSlots] = useState(settings.blockedSlots);
+  const draftBlockedSlotsRef = useRef(settings.blockedSlots);
   const blockedSlotSet = useMemo(() => new Set(draftBlockedSlots), [draftBlockedSlots]);
   const [draftHardConflictSlots, setDraftHardConflictSlots] = useState(settings.hardConflictSlots);
+  const draftHardConflictSlotsRef = useRef(settings.hardConflictSlots);
   const hardConflictSlotSet = useMemo(() => new Set(draftHardConflictSlots), [draftHardConflictSlots]);
   const modalBodyRef = useRef<HTMLDivElement>(null);
-  const dragStateRef = useRef<{ active: boolean; targetState: 'blocked' | 'hard' | 'empty'; lastKey: string }>({
-    active: false,
-    targetState: 'blocked',
-    lastKey: '',
-  });
-  const lastGridPointerTypeRef = useRef('');
+  const timeSlotGridRef = useRef<TimeSlotGridHandle>(null);
 
   useEffect(() => {
     if (!open) return;
-    setDraftBlockedSlots(settings.blockedSlots);
-    setDraftHardConflictSlots(settings.hardConflictSlots);
+    const nextBlockedSlots = [...settings.blockedSlots];
+    const nextHardConflictSlots = [...settings.hardConflictSlots];
+    draftBlockedSlotsRef.current = nextBlockedSlots;
+    draftHardConflictSlotsRef.current = nextHardConflictSlots;
+    setDraftBlockedSlots(nextBlockedSlots);
+    setDraftHardConflictSlots(nextHardConflictSlots);
     setPage(initialPage);
   }, [initialPage, open, settings.blockedSlots, settings.hardConflictSlots]);
 
@@ -92,19 +95,6 @@ export default function CustomizationModal({
     if (!open) return;
     modalBodyRef.current?.scrollTo({ top: 0 });
   }, [open, page]);
-
-  useEffect(() => {
-    const stopDragging = () => {
-      dragStateRef.current.active = false;
-      dragStateRef.current.lastKey = '';
-    };
-    window.addEventListener('pointerup', stopDragging);
-    window.addEventListener('blur', stopDragging);
-    return () => {
-      window.removeEventListener('pointerup', stopDragging);
-      window.removeEventListener('blur', stopDragging);
-    };
-  }, []);
 
   const setPreferHalfDay = (preferHalfDay: boolean) => {
     onChange({ ...settings, preferHalfDay });
@@ -144,42 +134,35 @@ export default function CustomizationModal({
     message.success('排课方案展示数量已更新');
   };
 
-  const toggleSlot = (day: number, period: number) => {
-    const key = blockedSlotKey(day, period);
-    const current = hardConflictSlotSet.has(key) ? 'hard'
-      : blockedSlotSet.has(key) ? 'blocked' : 'empty';
-    const target = current === 'empty' ? 'blocked'
-      : current === 'blocked' ? 'hard' : 'empty';
-    setDraftBlockedSlots((cur) => {
-      const next = new Set(cur);
-      if (target === 'blocked') next.add(key); else next.delete(key);
-      return [...next].sort();
-    });
-    setDraftHardConflictSlots((cur) => {
-      const next = new Set(cur);
-      if (target === 'hard') next.add(key); else next.delete(key);
-      return [...next].sort();
-    });
-  };
-
-  const paintSlot = (key: string, targetState: 'blocked' | 'hard' | 'empty') => {
-    setDraftBlockedSlots((cur) => {
-      const next = new Set(cur);
-      if (targetState === 'blocked') next.add(key); else next.delete(key);
-      return [...next].sort();
-    });
-    setDraftHardConflictSlots((cur) => {
-      const next = new Set(cur);
-      if (targetState === 'hard') next.add(key); else next.delete(key);
-      return [...next].sort();
-    });
+  const paintSlots = (changes: readonly TimeSlotPaintChange[]) => {
+    const nextBlockedSlotSet = new Set(draftBlockedSlotsRef.current);
+    const nextHardConflictSlotSet = new Set(draftHardConflictSlotsRef.current);
+    for (const { key, state } of changes) {
+      if (state === 'blocked') nextBlockedSlotSet.add(key);
+      else nextBlockedSlotSet.delete(key);
+      if (state === 'hard') nextHardConflictSlotSet.add(key);
+      else nextHardConflictSlotSet.delete(key);
+    }
+    const nextBlockedSlots = [...nextBlockedSlotSet].sort();
+    const nextHardConflictSlots = [...nextHardConflictSlotSet].sort();
+    draftBlockedSlotsRef.current = nextBlockedSlots;
+    draftHardConflictSlotsRef.current = nextHardConflictSlots;
+    setDraftBlockedSlots(nextBlockedSlots);
+    setDraftHardConflictSlots(nextHardConflictSlots);
   };
 
   const applySlots = () => {
-    const blockedChanged = draftBlockedSlots.join('|') !== settings.blockedSlots.join('|');
-    const hardChanged = draftHardConflictSlots.join('|') !== settings.hardConflictSlots.join('|');
+    timeSlotGridRef.current?.flushPendingPaint();
+    const nextBlockedSlots = draftBlockedSlotsRef.current;
+    const nextHardConflictSlots = draftHardConflictSlotsRef.current;
+    const blockedChanged = nextBlockedSlots.join('|') !== settings.blockedSlots.join('|');
+    const hardChanged = nextHardConflictSlots.join('|') !== settings.hardConflictSlots.join('|');
     if (!blockedChanged && !hardChanged) return;
-    onChange({ ...settings, blockedSlots: draftBlockedSlots, hardConflictSlots: draftHardConflictSlots });
+    onChange({
+      ...settings,
+      blockedSlots: nextBlockedSlots,
+      hardConflictSlots: nextHardConflictSlots,
+    });
   };
 
   const returnToMain = () => {
@@ -330,14 +313,17 @@ export default function CustomizationModal({
 
         {page === 'blockedSlots' ? (
           <div className="customization__subpage" data-tour="customization-blocked-slots">
-            <div className="customization__subpage-header">
-              <div className="customization__subpage-copy">
+            <div className="customization__subpage-header availability-grid-section-header">
+              <div className="customization__subpage-copy availability-grid-section-copy">
                 <h3>占位时间</h3>
                 <p>点击循环切换 空闲 → 有事 → 强冲突 → 空闲；按住鼠标拖动可连续标注为按下时的目标状态。</p>
               </div>
               <Button
+                className="availability-grid-clear-button"
                 disabled={draftBlockedSlots.length === 0 && draftHardConflictSlots.length === 0}
                 onClick={() => {
+                  draftBlockedSlotsRef.current = [];
+                  draftHardConflictSlotsRef.current = [];
                   setDraftBlockedSlots([]);
                   setDraftHardConflictSlots([]);
                 }}
@@ -345,77 +331,22 @@ export default function CustomizationModal({
                 清空占位
               </Button>
             </div>
-            <div className="customization__subpage-card">
-              <div className="availability-grid-wrap">
-                <table
-                  className="availability-grid"
-                  onPointerMove={(event) => {
-                    const drag = dragStateRef.current;
-                    if (!drag.active) return;
-                    const target = (event.target as HTMLElement).closest<HTMLButtonElement>('[data-slot-key]');
-                    const key = target?.dataset.slotKey;
-                    if (!key || drag.lastKey === key) return;
-                    drag.lastKey = key;
-                    paintSlot(key, drag.targetState);
-                  }}
-                >
-                  <thead>
-                    <tr>
-                      <th scope="col">节次</th>
-                      {DAYS.map((day) => <th scope="col" key={day}>{DAY_LABELS[day]}</th>)}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {PERIODS.map((period) => (
-                      <tr key={period}>
-                        <th scope="row">{period}</th>
-                        {DAYS.map((day) => {
-                          const key = blockedSlotKey(day, period);
-                          const state = hardConflictSlotSet.has(key)
-                            ? 'hard'
-                            : blockedSlotSet.has(key) ? 'blocked' : 'empty';
-                          return (
-                            <td key={day}>
-                              <button
-                                type="button"
-                                data-slot-key={blockedSlotKey(day, period)}
-                                className={`availability-grid__cell availability-grid__cell--${state}`}
-                                aria-label={`${DAY_LABELS[day]}第 ${period} 节${state === 'empty' ? '空闲' : state === 'blocked' ? '有事' : '强冲突'}`}
-                                aria-pressed={state !== 'empty'}
-                                onPointerDown={(event) => {
-                                  lastGridPointerTypeRef.current = event.pointerType;
-                                  if (event.pointerType !== 'mouse' || event.button !== 0) return;
-                                  event.preventDefault();
-                                  const key = blockedSlotKey(day, period);
-                                  const current = hardConflictSlotSet.has(key)
-                                    ? 'hard'
-                                    : blockedSlotSet.has(key) ? 'blocked' : 'empty';
-                                  const targetState = current === 'empty' ? 'blocked'
-                                    : current === 'blocked' ? 'hard' : 'empty';
-                                  dragStateRef.current = {
-                                    active: true,
-                                    targetState,
-                                    lastKey: key,
-                                  };
-                                  paintSlot(key, targetState);
-                                }}
-                                onClick={(event) => {
-                                  if (event.detail === 0 || lastGridPointerTypeRef.current !== 'mouse') {
-                                    toggleSlot(day, period);
-                                  }
-                                  lastGridPointerTypeRef.current = '';
-                                }}
-                                onDragStart={(event) => event.preventDefault()}
-                              />
-                            </td>
-                          );
-                        })}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
+            <TimeSlotGrid
+              ref={timeSlotGridRef}
+              ariaLabel="占位时间设置"
+              getState={(key) => hardConflictSlotSet.has(key)
+                ? 'hard'
+                : blockedSlotSet.has(key) ? 'blocked' : 'empty'}
+              nextState={(state) => state === 'empty'
+                ? 'blocked'
+                : state === 'blocked' ? 'hard' : 'empty'}
+              onPaint={paintSlots}
+              stateLabels={{
+                empty: '空闲',
+                blocked: '有事',
+                hard: '强冲突',
+              }}
+            />
           </div>
         ) : null}
 

--- a/src/components/CustomizationModalBehavior.test.ts
+++ b/src/components/CustomizationModalBehavior.test.ts
@@ -34,6 +34,19 @@ function getGridCell(day: number, period: number): HTMLButtonElement {
 }
 
 const originalScrollTo = HTMLElement.prototype.scrollTo;
+const originalRequestAnimationFrame = window.requestAnimationFrame;
+const originalCancelAnimationFrame = window.cancelAnimationFrame;
+
+function mousePointerEvent(type: 'pointerdown' | 'pointermove'): MouseEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    button: 0,
+    buttons: 1,
+  });
+  Object.defineProperty(event, 'pointerType', { value: 'mouse' });
+  Object.defineProperty(event, 'pointerId', { value: 1 });
+  return event;
+}
 
 beforeEach(() => {
   (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -48,6 +61,10 @@ afterEach(async () => {
   });
   document.body.replaceChildren();
   HTMLElement.prototype.scrollTo = originalScrollTo;
+  if (originalRequestAnimationFrame) window.requestAnimationFrame = originalRequestAnimationFrame;
+  else delete (window as Partial<Window>).requestAnimationFrame;
+  if (originalCancelAnimationFrame) window.cancelAnimationFrame = originalCancelAnimationFrame;
+  else delete (window as Partial<Window>).cancelAnimationFrame;
   vi.useRealTimers();
 });
 
@@ -68,6 +85,9 @@ describe('CustomizationModal blocked-slots grid behavior', () => {
     );
 
     const cell = getGridCell(1, 1);
+    const clearButton = Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent?.trim() === '清空占位');
+    expect(clearButton?.classList.contains('availability-grid-clear-button')).toBe(true);
     expect(cell.getAttribute('aria-label')).toContain('空闲');
 
     act(() => {
@@ -116,5 +136,43 @@ describe('CustomizationModal blocked-slots grid behavior', () => {
     });
     expect(second.getAttribute('aria-label')).toContain('有事');
     expect(first.getAttribute('aria-label')).toContain('有事');
+  });
+
+  test('returning before the next frame preserves every pending drag cell', async () => {
+    window.requestAnimationFrame = vi.fn(() => 1);
+    window.cancelAnimationFrame = vi.fn();
+    const onChange = vi.fn();
+    await mount(
+      createElement(CustomizationModal, {
+        open: true,
+        settings: DEFAULT_CUSTOM_SETTINGS,
+        onChange,
+        onClose: vi.fn(),
+        onRestartOnboarding: vi.fn(),
+        showUpdatePopup: true,
+        onShowUpdatePopupChange: vi.fn(),
+        onOpenUpdateHistory: vi.fn(),
+        initialPage: 'blockedSlots',
+      }),
+    );
+
+    const first = getGridCell(1, 1);
+    const second = getGridCell(2, 1);
+    const backButton = Array.from(document.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent?.includes('返回'));
+    if (!backButton) throw new Error('Missing customization back button');
+
+    act(() => {
+      first.dispatchEvent(mousePointerEvent('pointerdown'));
+      second.dispatchEvent(mousePointerEvent('pointermove'));
+      backButton.click();
+    });
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_CUSTOM_SETTINGS,
+      blockedSlots: ['1-1', '2-1'],
+      hardConflictSlots: [],
+    });
   });
 });

--- a/src/components/FilterBar.test.ts
+++ b/src/components/FilterBar.test.ts
@@ -1,13 +1,18 @@
+// @vitest-environment jsdom
+
 import { readFileSync } from 'node:fs';
-import { createElement } from 'react';
+import { resolve } from 'node:path';
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 import FilterBar from './FilterBar';
+import { FindCoursesIcon } from './icons';
 import { MemosProvider } from '@/memos/MemosContext';
 
-const filterBarSource = readFileSync(new URL('./FilterBar.tsx', import.meta.url), 'utf8');
-const appSource = readFileSync(new URL('../App.tsx', import.meta.url), 'utf8');
-const cssSource = readFileSync(new URL('../index.css', import.meta.url), 'utf8');
+const filterBarSource = readFileSync(resolve('src/components/FilterBar.tsx'), 'utf8');
+const appSource = readFileSync(resolve('src/App.tsx'), 'utf8');
+const cssSource = readFileSync(resolve('src/index.css'), 'utf8');
 
 const filter = {
   keyword: '',
@@ -40,6 +45,7 @@ describe('FilterBar search row', () => {
       setFilter: vi.fn(),
       options,
       onOpenMemo: vi.fn(),
+      onOpenFinder: vi.fn(),
     } as Parameters<typeof FilterBar>[0])));
 
     expect(html).toMatch(
@@ -71,6 +77,7 @@ describe('FilterBar search row', () => {
       setFilter: vi.fn(),
       options,
       onOpenMemo: vi.fn(),
+      onOpenFinder: vi.fn(),
     } as Parameters<typeof FilterBar>[0])));
 
     const teacherToggleIndex = html.indexOf('filter-bar__teacher-toggle');
@@ -84,9 +91,102 @@ describe('FilterBar search row', () => {
     expect(appSource).not.toContain('resultCount={filteredGroups.length}');
   });
 
-  it('reserves only the checkbox width and lets the input take the remainder', () => {
+  it('places the time finder between the search input and teacher checkbox', () => {
+    const html = renderToStaticMarkup(createElement(MemosProvider, null, createElement(FilterBar, {
+      filter,
+      setFilter: vi.fn(),
+      options,
+      onOpenMemo: vi.fn(),
+      onOpenFinder: vi.fn(),
+    } as Parameters<typeof FilterBar>[0])));
+
+    const inputIndex = html.indexOf('<input');
+    const finderIndex = html.indexOf('aria-label="按时间寻找课程"');
+    const teacherToggleIndex = html.indexOf('filter-bar__teacher-toggle');
+
+    expect(inputIndex).toBeGreaterThan(0);
+    expect(finderIndex).toBeGreaterThan(inputIndex);
+    expect(teacherToggleIndex).toBeGreaterThan(finderIndex);
+  });
+
+  it('renders the time finder as a neutral control with the same height as the search input', () => {
+    const html = renderToStaticMarkup(createElement(MemosProvider, null, createElement(FilterBar, {
+      filter,
+      setFilter: vi.fn(),
+      options,
+      onOpenMemo: vi.fn(),
+      onOpenFinder: vi.fn(),
+    } as Parameters<typeof FilterBar>[0])));
+    const finderMarkup = html.match(
+      /<button[^>]*aria-label="按时间寻找课程"[^>]*>/,
+    )?.[0] ?? '';
+
+    expect(finderMarkup).not.toContain('ant-btn-primary');
     expect(cssSource).toMatch(
-      /\.filter-bar__search\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\) max-content;/s,
+      /\.filter-bar__search\s*\{[^}]*--filter-search-control-height:\s*32px;/s,
+    );
+    expect(cssSource).toMatch(
+      /\.filter-bar__search \.ant-input-affix-wrapper\s*\{[^}]*height:\s*var\(--filter-search-control-height\);/s,
+    );
+    expect(cssSource).toMatch(
+      /#root \.filter-bar__search \.filter-bar__find-button\.ant-btn\.ant-btn-default\s*\{[^}]*height:\s*var\(--filter-search-control-height\);/s,
+    );
+    expect(cssSource).toMatch(
+      /#root \.filter-bar__search \.filter-bar__find-button\.ant-btn\.ant-btn-default\s*\{[^}]*background:\s*#fff;[^}]*color:\s*var\(--text\);/s,
+    );
+  });
+
+  it('renders the reference magnifier with one large and one small four-point sparkle', () => {
+    const icon = renderToStaticMarkup(createElement(FindCoursesIcon));
+
+    expect(icon).toContain(
+      '<circle cx="9.25" cy="12.25" r="5.45" stroke="currentColor" stroke-width="1.55"></circle>',
+    );
+    expect(icon).toContain(
+      '<path d="M13.2 16.2 18.25 21.25" stroke="currentColor" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"></path>',
+    );
+    expect(icon).toContain(
+      '<path d="M17.1 1.9C17.35 4.2 18.9 5.75 21.2 6c-2.3.25-3.85 1.8-4.1 4.15-.25-2.35-1.8-3.9-4.1-4.15 2.3-.25 3.85-1.8 4.1-4.1Z" fill="currentColor"></path>',
+    );
+    expect(icon).toContain(
+      '<path d="M20.25 7.8c.1.9.8 1.6 1.7 1.7-.9.1-1.6.8-1.7 1.7-.1-.9-.8-1.6-1.7-1.7.9-.1 1.6-.8 1.7-1.7Z" fill="currentColor"></path>',
+    );
+  });
+
+  it('opens the time finder from its dedicated entry', async () => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    const host = document.createElement('div');
+    const root = createRoot(host);
+    const onOpenFinder = vi.fn();
+
+    await act(async () => {
+      root.render(createElement(FilterBar, {
+        filter,
+        setFilter: vi.fn(),
+        options,
+        onOpenMemo: vi.fn(),
+        onOpenFinder,
+      } as Parameters<typeof FilterBar>[0]));
+    });
+
+    const finder = host.querySelector<HTMLButtonElement>(
+      'button[aria-label="按时间寻找课程"]',
+    );
+    expect(finder).not.toBeNull();
+
+    act(() => {
+      finder?.click();
+    });
+    expect(onOpenFinder).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it('reserves a fixed finder column while the input takes the remainder', () => {
+    expect(cssSource).toMatch(
+      /\.filter-bar__search\s*\{[^}]*grid-template-columns:\s*minmax\(0, 1fr\) var\(--filter-search-control-height\) max-content;/s,
     );
     expect(cssSource).not.toContain('.filter-bar__count');
   });
@@ -108,6 +208,7 @@ describe('FilterBar search row', () => {
       setFilter: vi.fn(),
       options,
       onOpenMemo: vi.fn(),
+      onOpenFinder: vi.fn(),
     } as Parameters<typeof FilterBar>[0])));
 
     expect(filterBarSource).toContain('placeholder="课程范畴"');

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -2,11 +2,13 @@ import { Button, Checkbox, Input } from 'antd';
 import type { FilterState } from '@/types';
 import type { CourseFilterOptions } from '@/constants/filterOptions';
 import SelectWithChevron from './SelectWithChevron';
+import { FindCoursesIcon } from './icons';
 
 interface Props {
   filter: FilterState;
   setFilter: (f: FilterState) => void;
   options: CourseFilterOptions;
+  onOpenFinder: () => void;
   onOpenMemo: () => void;
 }
 
@@ -14,6 +16,7 @@ export default function FilterBar({
   filter,
   setFilter,
   options,
+  onOpenFinder,
   onOpenMemo,
 }: Props) {
   const update = (patch: Partial<FilterState>) => setFilter({ ...filter, ...patch });
@@ -26,6 +29,13 @@ export default function FilterBar({
           value={filter.keyword}
           onChange={(e) => update({ keyword: e.target.value })}
           allowClear
+        />
+        <Button
+          className="filter-bar__find-button"
+          icon={<FindCoursesIcon />}
+          onClick={onOpenFinder}
+          aria-label="按时间寻找课程"
+          title="按时间寻找课程"
         />
         <Checkbox
           className="filter-bar__teacher-toggle"

--- a/src/components/TimeSlotGrid.test.ts
+++ b/src/components/TimeSlotGrid.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import TimeSlotGrid, { type TimeSlotCellState } from './TimeSlotGrid';
+
+interface MountedRoot {
+  host: HTMLDivElement;
+  root: Root;
+}
+
+const mountedRoots: MountedRoot[] = [];
+const originalRequestAnimationFrame = window.requestAnimationFrame;
+const originalCancelAnimationFrame = window.cancelAnimationFrame;
+let frameCallbacks: FrameRequestCallback[] = [];
+
+async function mountGrid(onPaint: ReturnType<typeof vi.fn>): Promise<void> {
+  const host = document.createElement('div');
+  document.body.append(host);
+  const root = createRoot(host);
+  mountedRoots.push({ host, root });
+  await act(async () => {
+    root.render(createElement(TimeSlotGrid, {
+      ariaLabel: '测试时间表格',
+      getState: (): TimeSlotCellState => 'empty',
+      nextState: (): TimeSlotCellState => 'blocked',
+      onPaint,
+      stateLabels: {
+        empty: '未选择',
+        blocked: '已选择',
+        hard: '强冲突',
+      },
+    }));
+  });
+}
+
+function cell(key: string): HTMLButtonElement {
+  const target = document.querySelector<HTMLButtonElement>(`[data-slot-key="${key}"]`);
+  if (!target) throw new Error(`Missing grid cell ${key}`);
+  return target;
+}
+
+function mousePointerEvent(
+  type: 'pointerdown' | 'pointermove' | 'pointercancel',
+  pointerId = 1,
+  buttons = type === 'pointercancel' ? 0 : 1,
+): MouseEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    button: 0,
+    buttons,
+  });
+  Object.defineProperty(event, 'pointerType', { value: 'mouse' });
+  Object.defineProperty(event, 'pointerId', { value: pointerId });
+  return event;
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  frameCallbacks = [];
+  window.requestAnimationFrame = (callback) => {
+    frameCallbacks.push(callback);
+    return frameCallbacks.length;
+  };
+  window.cancelAnimationFrame = vi.fn();
+});
+
+afterEach(async () => {
+  await act(async () => {
+    for (const { root } of mountedRoots.splice(0).reverse()) root.unmount();
+    await Promise.resolve();
+  });
+  document.body.replaceChildren();
+  if (originalRequestAnimationFrame) window.requestAnimationFrame = originalRequestAnimationFrame;
+  else delete (window as Partial<Window>).requestAnimationFrame;
+  if (originalCancelAnimationFrame) window.cancelAnimationFrame = originalCancelAnimationFrame;
+  else delete (window as Partial<Window>).cancelAnimationFrame;
+});
+
+describe('TimeSlotGrid paint batching', () => {
+  it('commits all mouse-painted cells once per animation frame', async () => {
+    const onPaint = vi.fn();
+    await mountGrid(onPaint);
+
+    act(() => {
+      cell('1-1').dispatchEvent(mousePointerEvent('pointerdown'));
+      cell('2-1').dispatchEvent(mousePointerEvent('pointermove'));
+      cell('3-1').dispatchEvent(mousePointerEvent('pointermove'));
+    });
+
+    expect(onPaint).not.toHaveBeenCalled();
+    expect(frameCallbacks).toHaveLength(1);
+
+    act(() => {
+      frameCallbacks.shift()?.(window.performance.now());
+    });
+
+    expect(onPaint).toHaveBeenCalledOnce();
+    expect(onPaint).toHaveBeenCalledWith([
+      { key: '1-1', state: 'blocked' },
+      { key: '2-1', state: 'blocked' },
+      { key: '3-1', state: 'blocked' },
+    ]);
+  });
+
+  it('ignores unrelated pointers and flushes the initiating pointer on cancellation', async () => {
+    const onPaint = vi.fn();
+    await mountGrid(onPaint);
+
+    act(() => {
+      cell('1-1').dispatchEvent(mousePointerEvent('pointerdown', 7));
+      cell('2-1').dispatchEvent(mousePointerEvent('pointermove', 8));
+      window.dispatchEvent(mousePointerEvent('pointercancel', 8));
+      cell('2-1').dispatchEvent(mousePointerEvent('pointermove', 7));
+      window.dispatchEvent(mousePointerEvent('pointercancel', 7));
+      cell('3-1').dispatchEvent(mousePointerEvent('pointermove', 7));
+    });
+
+    expect(onPaint).toHaveBeenCalledOnce();
+    expect(onPaint).toHaveBeenCalledWith([
+      { key: '1-1', state: 'blocked' },
+      { key: '2-1', state: 'blocked' },
+    ]);
+  });
+
+  it('stops and flushes when pointer movement reports no pressed primary button', async () => {
+    const onPaint = vi.fn();
+    await mountGrid(onPaint);
+
+    act(() => {
+      cell('1-1').dispatchEvent(mousePointerEvent('pointerdown', 4));
+      cell('2-1').dispatchEvent(mousePointerEvent('pointermove', 4, 0));
+      cell('3-1').dispatchEvent(mousePointerEvent('pointermove', 4, 1));
+    });
+
+    expect(onPaint).toHaveBeenCalledOnce();
+    expect(onPaint).toHaveBeenCalledWith([
+      { key: '1-1', state: 'blocked' },
+    ]);
+  });
+});

--- a/src/components/TimeSlotGrid.tsx
+++ b/src/components/TimeSlotGrid.tsx
@@ -1,0 +1,228 @@
+import {
+  forwardRef,
+  memo,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from 'react';
+import { DAY_LABELS, DAYS, PERIODS } from '@/constants/grid';
+import { blockedSlotKey } from '@/utils/customization';
+
+export type TimeSlotCellState = 'empty' | 'blocked' | 'hard';
+
+export interface TimeSlotPaintChange {
+  key: string;
+  state: TimeSlotCellState;
+}
+
+export interface TimeSlotGridHandle {
+  flushPendingPaint: () => void;
+}
+
+interface Props {
+  ariaLabel: string;
+  getState: (key: string) => TimeSlotCellState;
+  nextState: (state: TimeSlotCellState) => TimeSlotCellState;
+  onPaint: (changes: readonly TimeSlotPaintChange[]) => void;
+  stateLabels: Record<TimeSlotCellState, string>;
+}
+
+interface CellProps {
+  cellKey: string;
+  day: number;
+  period: number;
+  state: TimeSlotCellState;
+  stateLabel: string;
+}
+
+const TimeSlotCell = memo(function TimeSlotCell({
+  cellKey,
+  day,
+  period,
+  state,
+  stateLabel,
+}: CellProps) {
+  return (
+    <td>
+      <button
+        type="button"
+        data-slot-key={cellKey}
+        data-slot-state={state}
+        className={`availability-grid__cell availability-grid__cell--${state}`}
+        aria-label={`${DAY_LABELS[day]}第 ${period} 节${stateLabel}`}
+        aria-pressed={state !== 'empty'}
+      />
+    </td>
+  );
+});
+
+const TimeSlotGrid = forwardRef<TimeSlotGridHandle, Props>(function TimeSlotGrid({
+  ariaLabel,
+  getState,
+  nextState,
+  onPaint,
+  stateLabels,
+}, ref) {
+  const dragStateRef = useRef<{
+    active: boolean;
+    pointerId: number | null;
+    targetState: TimeSlotCellState;
+    lastKey: string;
+  }>({
+    active: false,
+    pointerId: null,
+    targetState: 'blocked',
+    lastKey: '',
+  });
+  const lastPointerTypeRef = useRef('');
+  const pendingPaintRef = useRef(new Map<string, TimeSlotCellState>());
+  const paintFrameRef = useRef<number | null>(null);
+  const onPaintRef = useRef(onPaint);
+  const nextStateRef = useRef(nextState);
+  onPaintRef.current = onPaint;
+  nextStateRef.current = nextState;
+
+  const commitPendingPaint = useCallback(() => {
+    if (pendingPaintRef.current.size === 0) return;
+    const changes = [...pendingPaintRef.current].map(([key, state]) => ({ key, state }));
+    pendingPaintRef.current.clear();
+    onPaintRef.current(changes);
+  }, []);
+
+  const flushPendingPaint = useCallback(() => {
+    if (paintFrameRef.current !== null) {
+      window.cancelAnimationFrame(paintFrameRef.current);
+      paintFrameRef.current = null;
+    }
+    commitPendingPaint();
+  }, [commitPendingPaint]);
+
+  useImperativeHandle(ref, () => ({
+    flushPendingPaint,
+  }), [flushPendingPaint]);
+
+  const queuePaint = useCallback((key: string, state: TimeSlotCellState) => {
+    pendingPaintRef.current.set(key, state);
+    if (paintFrameRef.current !== null) return;
+    paintFrameRef.current = window.requestAnimationFrame(() => {
+      paintFrameRef.current = null;
+      commitPendingPaint();
+    });
+  }, [commitPendingPaint]);
+
+  const stopDragging = useCallback((pointerId?: number) => {
+    const drag = dragStateRef.current;
+    if (!drag.active) return;
+    if (pointerId !== undefined && drag.pointerId !== pointerId) return;
+    flushPendingPaint();
+    dragStateRef.current.active = false;
+    dragStateRef.current.pointerId = null;
+    dragStateRef.current.lastKey = '';
+  }, [flushPendingPaint]);
+
+  useEffect(() => {
+    const stopPointerDragging = (event: PointerEvent) => {
+      stopDragging(event.pointerId);
+    };
+    const stopAllDragging = () => stopDragging();
+    window.addEventListener('pointerup', stopPointerDragging);
+    window.addEventListener('pointercancel', stopPointerDragging);
+    window.addEventListener('blur', stopAllDragging);
+    return () => {
+      window.removeEventListener('pointerup', stopPointerDragging);
+      window.removeEventListener('pointercancel', stopPointerDragging);
+      window.removeEventListener('blur', stopAllDragging);
+      if (paintFrameRef.current !== null) {
+        window.cancelAnimationFrame(paintFrameRef.current);
+        paintFrameRef.current = null;
+      }
+      commitPendingPaint();
+    };
+  }, [commitPendingPaint, stopDragging]);
+
+  return (
+    <div className="availability-grid-card">
+      <div className="availability-grid-wrap">
+        <table
+          className="availability-grid"
+          aria-label={ariaLabel}
+          onPointerMove={(event) => {
+            const drag = dragStateRef.current;
+            if (!drag.active || event.pointerId !== drag.pointerId) return;
+            if ((event.buttons & 1) === 0) {
+              stopDragging(event.pointerId);
+              return;
+            }
+            const target = (event.target as HTMLElement)
+              .closest<HTMLButtonElement>('[data-slot-key]');
+            const key = target?.dataset.slotKey;
+            if (!key || drag.lastKey === key) return;
+            drag.lastKey = key;
+            queuePaint(key, drag.targetState);
+          }}
+          onPointerDown={(event) => {
+            const target = (event.target as HTMLElement)
+              .closest<HTMLButtonElement>('[data-slot-key]');
+            const key = target?.dataset.slotKey;
+            const state = target?.dataset.slotState as TimeSlotCellState | undefined;
+            if (!key || !state) return;
+            lastPointerTypeRef.current = event.pointerType;
+            if (event.pointerType !== 'mouse' || event.button !== 0) return;
+            event.preventDefault();
+            const targetState = nextStateRef.current(state);
+            dragStateRef.current = {
+              active: true,
+              pointerId: event.pointerId,
+              targetState,
+              lastKey: key,
+            };
+            queuePaint(key, targetState);
+          }}
+          onClick={(event) => {
+            const target = (event.target as HTMLElement)
+              .closest<HTMLButtonElement>('[data-slot-key]');
+            const key = target?.dataset.slotKey;
+            const state = target?.dataset.slotState as TimeSlotCellState | undefined;
+            if (!key || !state) return;
+            if (event.detail === 0 || lastPointerTypeRef.current !== 'mouse') {
+              onPaintRef.current([{ key, state: nextStateRef.current(state) }]);
+            }
+            lastPointerTypeRef.current = '';
+          }}
+          onDragStart={(event) => event.preventDefault()}
+        >
+          <thead>
+            <tr>
+              <th scope="col">节次</th>
+              {DAYS.map((day) => <th scope="col" key={day}>{DAY_LABELS[day]}</th>)}
+            </tr>
+          </thead>
+          <tbody>
+            {PERIODS.map((period) => (
+              <tr key={period}>
+                <th scope="row">{period}</th>
+                {DAYS.map((day) => {
+                  const key = blockedSlotKey(day, period);
+                  const state = getState(key);
+                  return (
+                    <TimeSlotCell
+                      key={day}
+                      cellKey={key}
+                      day={day}
+                      period={period}
+                      state={state}
+                      stateLabel={stateLabels[state]}
+                    />
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+});
+
+export default TimeSlotGrid;

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -211,3 +211,33 @@ export function GearIcon(props: IconProps) {
     </svg>
   );
 }
+
+/** 放大镜叠加双星闪光，强调“按时间发现课程”而非普通关键词搜索。 */
+export function FindCoursesIcon(props: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" {...props}>
+      <path
+        d="M13.2 16.2 18.25 21.25"
+        stroke="currentColor"
+        strokeWidth="1.55"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <circle
+        cx="9.25"
+        cy="12.25"
+        r="5.45"
+        stroke="currentColor"
+        strokeWidth="1.55"
+      />
+      <path
+        d="M17.1 1.9C17.35 4.2 18.9 5.75 21.2 6c-2.3.25-3.85 1.8-4.1 4.15-.25-2.35-1.8-3.9-4.1-4.15 2.3-.25 3.85-1.8 4.1-4.1Z"
+        fill="currentColor"
+      />
+      <path
+        d="M20.25 7.8c.1.9.8 1.6 1.7 1.7-.9.1-1.6.8-1.7 1.7-.1-.9-.8-1.6-1.7-1.7.9-.1 1.6-.8 1.7-1.7Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -677,8 +677,9 @@ html {
 }
 
 .filter-bar__search {
+  --filter-search-control-height: 32px;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) max-content;
+  grid-template-columns: minmax(0, 1fr) var(--filter-search-control-height) max-content;
   align-items: center;
   gap: 8px;
 }
@@ -690,6 +691,52 @@ html {
 
 .filter-bar__search .ant-input-affix-wrapper {
   min-width: 0;
+  height: var(--filter-search-control-height);
+}
+
+#root .filter-bar__search .filter-bar__find-button.ant-btn.ant-btn-default {
+  width: var(--filter-search-control-height);
+  min-width: var(--filter-search-control-height);
+  height: var(--filter-search-control-height);
+  min-height: var(--filter-search-control-height);
+  padding: 0;
+  border-radius: var(--radius-md);
+  border-color: var(--border);
+  background: #fff;
+  color: var(--text);
+  box-shadow: none;
+}
+
+#root .filter-bar__search .filter-bar__find-button.ant-btn.ant-btn-default:not(:disabled):hover {
+  border-color: var(--border-strong);
+  background: #fff;
+  color: var(--text);
+}
+
+#root .filter-bar__search .filter-bar__find-button.ant-btn.ant-btn-default:not(:disabled):focus-visible {
+  border-color: var(--accent);
+  background: #fff;
+  color: var(--text);
+  outline-color: var(--accent);
+}
+
+#root .filter-bar__find-button.ant-btn .ant-btn-icon {
+  display: inline-flex;
+  margin: 0;
+}
+
+.filter-bar__find-button svg {
+  display: block;
+  width: 22px;
+  height: 22px;
+}
+
+:root[data-theme='dark'] #root .filter-bar__search .filter-bar__find-button.ant-btn.ant-btn-default,
+:root[data-theme='dark'] #root .filter-bar__search .filter-bar__find-button.ant-btn.ant-btn-default:not(:disabled):hover,
+:root[data-theme='dark'] #root .filter-bar__search .filter-bar__find-button.ant-btn.ant-btn-default:not(:disabled):focus-visible {
+  border-color: var(--border-strong);
+  background: var(--dark-surface-raised);
+  color: var(--text);
 }
 
 .filter-bar__controls {
@@ -725,6 +772,178 @@ html {
 #root .filter-bar__memo-toggle.ant-btn:focus-visible {
   outline: 0;
   box-shadow: none !important;
+}
+
+/* ============================================================
+ * CourseFinderModal
+ * ============================================================ */
+.course-finder-modal .bottom-modal__panel {
+  height: min(92dvh, 840px);
+  max-height: min(92dvh, 840px);
+}
+
+.course-finder-modal .bottom-modal__body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  overflow: hidden;
+}
+
+.course-finder-modal .bottom-modal__footer {
+  justify-content: center;
+}
+
+.course-finder__layout {
+  width: 100%;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(560px, 1.16fr) minmax(340px, 0.84fr);
+  gap: 16px;
+}
+
+.course-finder__picker-pane,
+.course-finder__results-pane {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.course-finder__picker-pane {
+  gap: 10px;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.course-finder__results-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.course-finder__results-header h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 15px;
+  line-height: 1.4;
+}
+
+.course-finder__results-header {
+  min-height: 32px;
+  align-items: center;
+}
+
+.course-finder__results-header > span {
+  color: var(--text-sub);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.course-finder__criteria {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr) max-content;
+  align-items: center;
+  gap: 10px;
+}
+
+.course-finder__selection-count {
+  color: var(--text-sub);
+  font-size: 12px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.course-finder__mode-help {
+  margin: -4px 0 0;
+  color: var(--text-sub);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.course-finder__results-pane {
+  gap: 8px;
+}
+
+.course-finder__results-content {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--text) 2%, var(--panel-bg));
+}
+
+.course-finder__loading,
+.course-finder__empty {
+  width: 100%;
+  height: 100%;
+  min-height: 260px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.course-finder__loading {
+  flex-direction: column;
+  gap: 12px;
+  color: var(--text-sub);
+  font-size: 13px;
+}
+
+.course-finder__results-content .course-finder__course-pool {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.course-finder__results-content .course-pool__list {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto;
+}
+
+.course-finder__disclaimer {
+  width: 100%;
+  margin: 0;
+  color: var(--text-sub);
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: center;
+}
+
+@media (max-width: 1050px) {
+  .course-finder-modal .bottom-modal__body {
+    display: block;
+    overflow: auto;
+  }
+
+  .course-finder__layout {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  .course-finder__picker-pane {
+    overflow: visible;
+    padding-right: 0;
+  }
+
+  .course-finder__results-content {
+    flex: 0 0 auto;
+    height: clamp(380px, 56dvh, 560px);
+  }
+}
+
+@media (forced-colors: active) {
+  .availability-grid__cell--blocked {
+    outline: 2px solid Highlight;
+    outline-offset: -3px;
+  }
 }
 
 /* ============================================================
@@ -4071,8 +4290,35 @@ html.theme-transitioning #root .plan-switcher__icon-button.ant-btn {
   }
 
   .filter-bar__search {
-    grid-template-columns: minmax(0, 1fr) max-content;
+    grid-template-columns:
+      minmax(0, 1fr)
+      var(--filter-search-control-height)
+      max-content;
     gap: 8px;
+  }
+
+  .course-finder__criteria {
+    grid-template-columns: minmax(0, 1fr) max-content;
+  }
+
+  .course-finder__criteria .ant-checkbox-wrapper {
+    grid-column: 1 / -1;
+  }
+
+  .course-finder__selection-count {
+    text-align: left;
+  }
+
+  .course-finder__course-pool .pool-item__head {
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+      "name conflict"
+      "actions actions";
+  }
+
+  .course-finder__course-pool .pool-item__actions {
+    width: 100%;
+    justify-content: flex-end;
   }
 
   .filter-bar__controls {
@@ -4613,7 +4859,8 @@ html.theme-transitioning #root .plan-switcher__icon-button.ant-btn {
   gap: 12px;
 }
 
-.customization__subpage-header {
+.customization__subpage-header,
+.availability-grid-section-header {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
@@ -4646,28 +4893,42 @@ html.theme-transitioning #root .plan-switcher__icon-button.ant-btn {
   transform: translateY(-1px);
 }
 
-.customization__subpage-copy {
+.customization__subpage-copy,
+.availability-grid-section-copy {
   min-width: 0;
 }
 
-.customization__subpage-copy h3 {
+.customization__subpage-copy h3,
+.availability-grid-section-copy h3 {
   margin: 0;
   color: var(--text);
   font-size: 16px;
 }
 
-.customization__subpage-copy p {
+.customization__subpage-copy p,
+.availability-grid-section-copy p {
   margin: 3px 0 0;
   color: var(--text-sub);
   font-size: 12px;
   line-height: 1.45;
 }
 
-.customization__subpage-card {
+.customization__subpage-card,
+.availability-grid-card {
   padding: 14px;
   border: 1px solid var(--border);
   border-radius: 12px;
   background: color-mix(in srgb, var(--text) 2%, var(--panel-bg));
+}
+
+#root .availability-grid-clear-button.ant-btn {
+  width: 72px;
+  min-width: 72px;
+  height: 32px;
+  min-height: 32px;
+  padding: 0 12px;
+  font-size: 13px;
+  line-height: 30px;
 }
 
 .customization__section {
@@ -5479,17 +5740,6 @@ html.theme-transitioning #root .plan-switcher__icon-button.ant-btn {
   background: color-mix(in srgb, var(--accent) 8%, var(--panel-bg));
 }
 
-.availability-grid__cell--selected {
-  background: color-mix(in srgb, var(--text-sub) 28%, var(--panel-bg));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-sub) 62%, var(--border));
-}
-
-.availability-grid__cell--selected:hover {
-  outline: 0;
-  background: color-mix(in srgb, var(--text-sub) 28%, var(--panel-bg));
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-sub) 62%, var(--border));
-}
-
 .availability-grid__cell--blocked {
   background: color-mix(in srgb, var(--text-sub) 28%, var(--panel-bg));
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-sub) 62%, var(--border));
@@ -5602,12 +5852,14 @@ html.theme-transitioning #root .plan-switcher__icon-button.ant-btn {
     text-overflow: ellipsis;
   }
 
-  .customization__subpage-header {
+  .customization__subpage-header,
+  .availability-grid-section-header {
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 8px;
   }
 
-  .customization__subpage-card {
+  .customization__subpage-card,
+  .availability-grid-card {
     padding: 10px;
   }
 
@@ -6221,16 +6473,11 @@ html.theme-transitioning #root .plan-switcher__icon-button.ant-btn {
 }
 
 :root[data-theme='dark'] .customization__group,
-:root[data-theme='dark'] .customization__subpage-card {
+:root[data-theme='dark'] .customization__subpage-card,
+:root[data-theme='dark'] .availability-grid-card {
   background: color-mix(in srgb, var(--text) 3%, var(--panel-bg));
   border-color: var(--border-strong);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
-}
-
-:root[data-theme='dark'] .availability-grid__cell--selected,
-:root[data-theme='dark'] .availability-grid__cell--selected:hover {
-  background: #36414f;
-  box-shadow: inset 0 0 0 1px #637184;
 }
 
 :root[data-theme='dark'] .availability-grid__cell--blocked,

--- a/src/updates/appUpdates.ts
+++ b/src/updates/appUpdates.ts
@@ -92,6 +92,16 @@ export const APP_RELEASES: AppRelease[] = [
       '其他UI改进。',
     ],
   },
+  {
+    version: '2026.07.30.1',
+    publishedAt: '2026-07-30',
+    title: '新增按时间寻找课程功能',
+    items: [
+      '新增实验性“寻找”功能，可通过时间表勾选时间块并按上课时间筛选课程。',
+      '默认仅展示全部上课时间均位于所选时间块内的课程，也可切换为允许额外时间。',
+      '寻找结果支持收藏、选择单个或全部时间组等常规操作，并优化时间表拖选性能。',
+    ],
+  },
 ];
 
 export const CURRENT_APP_VERSION = APP_RELEASES.at(-1)?.version ?? '0';

--- a/src/utils/courseTimeSearch.test.ts
+++ b/src/utils/courseTimeSearch.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import type { CourseGroup, ScheduleSlot } from '@/types';
+import {
+  courseGroupMatchesTimeSelection,
+  courseTimeSlotKeys,
+  filterCourseGroupsByTime,
+} from './courseTimeSearch';
+
+function scheduleSlot(
+  day: number,
+  periods: number[],
+  overrides: Partial<ScheduleSlot> = {},
+): ScheduleSlot {
+  return {
+    weeks: [1, 18],
+    room: '',
+    campus: '本部',
+    day,
+    periods,
+    ...overrides,
+  };
+}
+
+function courseGroup(key: string, schedule: ScheduleSlot[]): CourseGroup {
+  return {
+    key,
+    courseCode: key,
+    courseName: `Course ${key}`,
+    schedule,
+    fingerprint: key,
+    sectionIds: [`${key}.01`],
+    teachers: [],
+    sections: [],
+  };
+}
+
+describe('course time-slot extraction', () => {
+  it('collects unique day-period keys across every schedule slot and week range', () => {
+    const group = courseGroup('MULTI', [
+      scheduleSlot(1, [1, 2, 2], { weeks: [1, 8] }),
+      scheduleSlot(3, [5], { weeks: [9, 16] }),
+      scheduleSlot(1, [2], { weeks: [17, 18] }),
+    ]);
+
+    expect([...courseTimeSlotKeys(group)].sort()).toEqual(['1-1', '1-2', '3-5']);
+  });
+
+  it('uses raw periods even when exact clock times cross a standard-period boundary', () => {
+    const group = courseGroup('EXACT', [
+      scheduleSlot(4, [10], {
+        startTime: '19:15',
+        endTime: '19:45',
+      }),
+    ]);
+
+    expect([...courseTimeSlotKeys(group)]).toEqual(['4-10']);
+    expect(courseGroupMatchesTimeSelection(group, new Set(['4-10']), 'contains')).toBe(true);
+    expect(courseGroupMatchesTimeSelection(group, new Set(['4-11']), 'contains')).toBe(false);
+  });
+});
+
+describe('course time selection modes', () => {
+  const multiSlotGroup = courseGroup('MULTI', [
+    scheduleSlot(1, [1, 2]),
+    scheduleSlot(3, [5]),
+  ]);
+
+  it('matches contains mode when any selected slot intersects the course', () => {
+    expect(courseGroupMatchesTimeSelection(
+      multiSlotGroup,
+      new Set(['1-1', '2-2']),
+      'contains',
+    )).toBe(true);
+    expect(courseGroupMatchesTimeSelection(
+      multiSlotGroup,
+      new Set(['2-2', '4-4']),
+      'contains',
+    )).toBe(false);
+  });
+
+  it('matches within mode only when a non-empty course lies entirely inside the selection', () => {
+    expect(courseGroupMatchesTimeSelection(
+      multiSlotGroup,
+      new Set(['1-1', '1-2', '2-4', '3-5']),
+      'within',
+    )).toBe(true);
+    expect(courseGroupMatchesTimeSelection(
+      multiSlotGroup,
+      new Set(['1-1', '3-5']),
+      'within',
+    )).toBe(false);
+  });
+
+  it('never matches an empty course schedule for a non-empty selection', () => {
+    const emptyGroup = courseGroup('EMPTY', []);
+
+    expect([...courseTimeSlotKeys(emptyGroup)]).toEqual([]);
+    expect(courseGroupMatchesTimeSelection(
+      emptyGroup,
+      new Set(['1-1']),
+      'contains',
+    )).toBe(false);
+    expect(courseGroupMatchesTimeSelection(
+      emptyGroup,
+      new Set(['1-1']),
+      'within',
+    )).toBe(false);
+  });
+
+  it('filters groups in their original order for each mode', () => {
+    const containsAndOutside = courseGroup('A', [scheduleSlot(1, [1]), scheduleSlot(2, [2])]);
+    const exactWithin = courseGroup('B', [scheduleSlot(1, [1])]);
+    const unrelated = courseGroup('C', [scheduleSlot(4, [4])]);
+    const groups = [containsAndOutside, exactWithin, unrelated];
+    const selected = new Set(['1-1']);
+
+    expect(filterCourseGroupsByTime(groups, selected, 'contains'))
+      .toEqual([containsAndOutside, exactWithin]);
+    expect(filterCourseGroupsByTime(groups, selected, 'within'))
+      .toEqual([exactWithin]);
+  });
+});

--- a/src/utils/courseTimeSearch.ts
+++ b/src/utils/courseTimeSearch.ts
@@ -1,0 +1,73 @@
+import { DAYS, PERIODS } from '@/constants/grid';
+import type { CourseGroup } from '@/types';
+import { blockedSlotKey } from './customization';
+
+export type CourseTimeSearchMode = 'contains' | 'within';
+
+const VALID_DAYS: ReadonlySet<number> = new Set(DAYS);
+const VALID_PERIODS: ReadonlySet<number> = new Set(PERIODS);
+
+/**
+ * Return the 7×13 timetable cells occupied by a canonical course time group.
+ *
+ * The search grid has no week dimension, so a cell is occupied when the group
+ * uses that weekday and period in any week. Exact clock times are deliberately
+ * not reinterpreted here: `ScheduleSlot.periods` is also what positions courses
+ * on the timetable grid, including clock-based courses mapped to nearby periods.
+ */
+export function courseTimeSlotKeys(group: CourseGroup): Set<string> {
+  const keys = new Set<string>();
+  for (const slot of group.schedule) {
+    if (!VALID_DAYS.has(slot.day)) continue;
+    for (const period of slot.periods) {
+      if (!VALID_PERIODS.has(period)) continue;
+      keys.add(blockedSlotKey(slot.day, period));
+    }
+  }
+  return keys;
+}
+
+function matchesSelection(
+  group: CourseGroup,
+  selectedSlots: ReadonlySet<string>,
+  mode: CourseTimeSearchMode,
+): boolean {
+  if (selectedSlots.size === 0) return false;
+
+  const occupiedSlots = courseTimeSlotKeys(group);
+  if (mode === 'contains') {
+    // Any overlap is enough; the course may occupy cells outside the selection.
+    return [...selectedSlots].some((key) => occupiedSlots.has(key));
+  }
+
+  // An undetermined schedule must not match merely because the empty set is a
+  // mathematical subset of every selection.
+  return occupiedSlots.size > 0
+    && [...occupiedSlots].every((key) => selectedSlots.has(key));
+}
+
+/**
+ * Match one canonical time group against a grid selection.
+ *
+ * - `contains`: selected and occupied cells have a non-empty intersection.
+ * - `within`: the non-empty occupied cells are a subset of selected cells.
+ * - An empty selection never matches either mode.
+ */
+export function courseGroupMatchesTimeSelection(
+  group: CourseGroup,
+  selectedSlots: Iterable<string>,
+  mode: CourseTimeSearchMode,
+): boolean {
+  return matchesSelection(group, new Set(selectedSlots), mode);
+}
+
+/** Filter canonical time groups while preserving their original order. */
+export function filterCourseGroupsByTime(
+  groups: readonly CourseGroup[],
+  selectedSlots: Iterable<string>,
+  mode: CourseTimeSearchMode,
+): CourseGroup[] {
+  const selection = new Set(selectedSlots);
+  if (selection.size === 0) return [];
+  return groups.filter((group) => matchesSelection(group, selection, mode));
+}


### PR DESCRIPTION
## Summary

- add an experimental time-based course finder opened from a dedicated search-row action
- let users select timetable cells and either match course groups fully contained within those cells or broaden the search to any overlapping course group
- reuse the standard course pool so finder results support favorites, individual group selection, selecting every time group, conflict feedback, and course details
- add a loading state and a centered experimental-results disclaimer
- share the same timetable grid between placeholder customization and the finder, with memoized cells, delegated pointer handling, animation-frame batching, and safer drag cancellation
- refresh the published 2026 Fall and 2026 Summer course catalogs from `catalog.ustc.edu.cn`