### PR TITLE
data: refresh semester courses (2026-08-31)

### DIFF
--- a/public/data/semesters/2026-fall/updates.json
+++ b/public/data/semesters/2026-fall/updates.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "semesterKey": "2026-fall",
-  "currentRevision": "3d7a2aa43cda57c97bdd58c89ba8f88ef666876487e9e31ab9f0679a6fa9a5bf",
+  "currentRevision": "3ff1ca8c9f5299e70f9efc86a9c80b474aa9c525bf833b1b9637334454bd4716",
   "entries": [
     {
       "id": "2026-fall:c0cbaf189652cc27",
@@ -189778,6 +189778,23790 @@
               "label": "课容量",
               "before": 170,
               "after": 180
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2026-fall:3ff1ca8c9f5299e7",
+      "revision": "3ff1ca8c9f5299e70f9efc86a9c80b474aa9c525bf833b1b9637334454bd4716",
+      "previousRevision": "3d7a2aa43cda57c97bdd58c89ba8f88ef666876487e9e31ab9f0679a6fa9a5bf",
+      "publishedAt": "2026-08-31T07:14:00Z",
+      "summary": {
+        "added": 11,
+        "removed": 9,
+        "modified": 300
+      },
+      "added": [
+        {
+          "id": "013X08.01",
+          "courseCode": "013X08",
+          "courseName": "张量初步",
+          "teacher": "刘志峰",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                1,
+                18
+              ],
+              "room": "3A213",
+              "day": 1,
+              "periods": [
+                8,
+                9
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "210075.05",
+          "courseCode": "210075",
+          "courseName": "电子技术实验III",
+          "teacher": "王百宗,胡新伟,肖鸿",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                7,
+                14
+              ],
+              "room": "高新区一号学科楼A105",
+              "day": 3,
+              "periods": [
+                11,
+                12,
+                13
+              ],
+              "campus": "高新区"
+            }
+          ]
+        },
+        {
+          "id": "BIOL7141P.07",
+          "courseCode": "BIOL7141P",
+          "courseName": "细胞生物学文献阅读与分析",
+          "teacher": "方芳,黄的",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                14
+              ],
+              "room": "3A308",
+              "day": 4,
+              "periods": [
+                8,
+                9,
+                10
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "EE1510.01",
+          "courseCode": "EE1510",
+          "courseName": "嵌入式应用设计基础",
+          "teacher": "邵长星",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                1,
+                10
+              ],
+              "room": "3A110",
+              "day": 1,
+              "periods": [
+                8,
+                9
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "EIEN6010P.01",
+          "courseCode": "EIEN6010P",
+          "courseName": "编译工程",
+          "teacher": "徐伟",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                16
+              ],
+              "room": "G2-B502",
+              "day": 4,
+              "periods": [
+                3,
+                4,
+                5
+              ],
+              "campus": "高新区"
+            }
+          ]
+        },
+        {
+          "id": "EIEN6717P.01",
+          "courseCode": "EIEN6717P",
+          "courseName": "信息安全实践",
+          "teacher": "庄严",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                13
+              ],
+              "room": "GT-B103",
+              "day": 3,
+              "periods": [
+                3,
+                4,
+                5
+              ],
+              "campus": "高新区"
+            }
+          ]
+        },
+        {
+          "id": "EPEN6003P.01",
+          "courseCode": "EPEN6003P",
+          "courseName": "现代功率变换技术",
+          "teacher": "王浩,马泽涛",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                4
+              ],
+              "room": "3A315",
+              "day": 4,
+              "periods": [
+                8,
+                9
+              ],
+              "campus": "本部"
+            },
+            {
+              "weeks": [
+                6,
+                7
+              ],
+              "room": "3A315",
+              "day": 4,
+              "periods": [
+                8,
+                9
+              ],
+              "campus": "本部"
+            },
+            {
+              "weeks": [
+                8,
+                12
+              ],
+              "room": "3A315",
+              "day": 4,
+              "periods": [
+                8,
+                9
+              ],
+              "campus": "本部"
+            },
+            {
+              "weeks": [
+                2,
+                4
+              ],
+              "room": "3A315",
+              "day": 5,
+              "periods": [
+                3,
+                4
+              ],
+              "campus": "本部"
+            },
+            {
+              "weeks": [
+                6,
+                7
+              ],
+              "room": "3A315",
+              "day": 5,
+              "periods": [
+                3,
+                4
+              ],
+              "campus": "本部"
+            },
+            {
+              "weeks": [
+                8,
+                12
+              ],
+              "room": "3A315",
+              "day": 5,
+              "periods": [
+                3,
+                4
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "FL1115A.03",
+          "courseCode": "FL1115A",
+          "courseName": "高级英语口语",
+          "teacher": "Samuel GIBSON",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                9
+              ],
+              "room": "2306",
+              "day": 1,
+              "periods": [
+                1,
+                2
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "FL1115A.04",
+          "courseCode": "FL1115A",
+          "courseName": "高级英语口语",
+          "teacher": "Samuel GIBSON",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                10,
+                17
+              ],
+              "room": "2306",
+              "day": 1,
+              "periods": [
+                1,
+                2
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "FL1115A.07",
+          "courseCode": "FL1115A",
+          "courseName": "高级英语口语",
+          "teacher": "Samuel GIBSON",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                10,
+                17
+              ],
+              "room": "2205",
+              "day": 1,
+              "periods": [
+                6,
+                7
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "FS1001.90",
+          "courseCode": "FS1001",
+          "courseName": "“科学与社会”研讨课",
+          "teacher": "冷伟",
+          "level": "本科",
+          "schedule": []
+        }
+      ],
+      "removed": [
+        {
+          "course": {
+            "id": "016119e.01",
+            "courseCode": "016119e",
+            "courseName": "质量与可靠性工程(英)",
+            "teacher": "秦进",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2203",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "017048.01",
+            "courseCode": "017048",
+            "courseName": "概率论",
+            "teacher": "胡太忠",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2404",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2404",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "017048.02",
+              "courseCode": "017048",
+              "courseName": "概率论",
+              "teacher": "冯群强",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "2403",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "2403",
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "232066.01",
+            "courseCode": "232066",
+            "courseName": "安全工程专业英语",
+            "teacher": "刘乃安",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A308",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "ESS4002.01",
+            "courseCode": "ESS4002",
+            "courseName": "航天电子电路设计",
+            "teacher": "郝新军",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "1115",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "GEOP4017.01",
+            "courseCode": "GEOP4017",
+            "courseName": "地质学与大地构造概论",
+            "teacher": "潘路,吴小平",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "2309",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "2309",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "HS1625.01",
+            "courseCode": "HS1625",
+            "courseName": "点亮科技树两千年",
+            "teacher": "王安轶",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "1302",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "MATH3011.03",
+            "courseCode": "MATH3011",
+            "courseName": "运筹学",
+            "teacher": "杨周旺,宋艳枝",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "MATH3011.01",
+              "courseCode": "MATH3011",
+              "courseName": "运筹学",
+              "teacher": "付维明,李曼,秦家虎",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "GT-B212",
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "高新区"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "GT-B212",
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "高新区"
+                }
+              ]
+            },
+            {
+              "id": "MATH3011.02",
+              "courseCode": "MATH3011",
+              "courseName": "运筹学",
+              "teacher": "陈士祥",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5503",
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5503",
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH7424P.01",
+            "courseCode": "MATH7424P",
+            "courseName": "场论与弦论选讲",
+            "teacher": "胡森,叶东恒",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2503",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2503",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "PHYS1003A.05",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "项国勇,吴康达,孙泽亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  11
+                ],
+                "room": "2103",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2103",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  18
+                ],
+                "room": "2103",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  11
+                ],
+                "room": "2103",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2103",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  18
+                ],
+                "room": "2103",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PHYS1003A.01",
+              "courseCode": "PHYS1003A",
+              "courseName": "光学A",
+              "teacher": "周宗权",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "2103",
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "2103",
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003A.02",
+              "courseCode": "PHYS1003A",
+              "courseName": "光学A",
+              "teacher": "孙方稳,陈向东",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5103",
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5103",
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003A.03",
+              "courseCode": "PHYS1003A",
+              "courseName": "光学A",
+              "teacher": "孙方稳,黄坤",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5307",
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5307",
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003A.04",
+              "courseCode": "PHYS1003A",
+              "courseName": "光学A",
+              "teacher": "王安廷",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5106",
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5106",
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003A.06",
+              "courseCode": "PHYS1003A",
+              "courseName": "光学A",
+              "teacher": "董春华,柳必恒",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5307",
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5307",
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003A.07",
+              "courseCode": "PHYS1003A",
+              "courseName": "光学A",
+              "teacher": "王沛",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5206",
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5206",
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003A.08",
+              "courseCode": "PHYS1003A",
+              "courseName": "光学A",
+              "teacher": "鲁拥华",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5206",
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5206",
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003A.09",
+              "courseCode": "PHYS1003A",
+              "courseName": "光学A",
+              "teacher": "陈巍,王纺翔,徐新标",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "room": "5107",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5107",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    10,
+                    18
+                  ],
+                  "room": "5107",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "room": "5107",
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5107",
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    10,
+                    18
+                  ],
+                  "room": "5107",
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003A.10",
+              "courseCode": "PHYS1003A",
+              "courseName": "光学A",
+              "teacher": "陈耕,郭钰",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5406",
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5406",
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003A.11",
+              "courseCode": "PHYS1003A",
+              "courseName": "光学A",
+              "teacher": "许金时",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "1101",
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4
+                  ],
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "1101",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "modified": [
+        {
+          "course": {
+            "id": "001676EX.01",
+            "courseCode": "001676EX",
+            "courseName": "复分析(习题)",
+            "teacher": "韦勇"
+          },
+          "previous": {
+            "id": "001676EX.01",
+            "courseCode": "001676EX",
+            "courseName": "复分析(习题)",
+            "teacher": "韦勇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "5507",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "5507",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "001676EX.01",
+            "courseCode": "001676EX",
+            "courseName": "复分析(习题)",
+            "teacher": "韦勇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5507",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "5507",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "5507",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    9
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    9
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "001706.01",
+            "courseCode": "001706",
+            "courseName": "泛函分析(H)",
+            "teacher": "许小卫,黄文"
+          },
+          "previous": {
+            "id": "001706.01",
+            "courseCode": "001706",
+            "courseName": "泛函分析(H)",
+            "teacher": "黄文",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2506",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2506",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "001706.01",
+            "courseCode": "001706",
+            "courseName": "泛函分析(H)",
+            "teacher": "许小卫,黄文",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "2506",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "2506",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  18
+                ],
+                "room": "2506",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "2506",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2506",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "2506",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "黄文",
+              "after": "许小卫,黄文"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "003044.01",
+            "courseCode": "003044",
+            "courseName": "物理化学实验",
+            "teacher": "刘红,王晓葵,金邦坤,吴强华,雷璇,冯红艳,吴红,李红春,孟征"
+          },
+          "previous": {
+            "id": "003044.01",
+            "courseCode": "003044",
+            "courseName": "物理化学实验",
+            "teacher": "刘红,王晓葵,金邦坤,吴强华,雷璇,冯红艳,吴红,李红春,孟征",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区环资楼501-504",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "003044.01",
+            "courseCode": "003044",
+            "courseName": "物理化学实验",
+            "teacher": "刘红,王晓葵,金邦坤,吴强华,雷璇,冯红艳,吴红,李红春,孟征",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区环资楼501-504",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 75,
+              "after": 15
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "004040.04",
+            "courseCode": "004040",
+            "courseName": "计算物理B",
+            "teacher": "高阳"
+          },
+          "previous": {
+            "id": "004040.04",
+            "courseCode": "004040",
+            "courseName": "计算物理B",
+            "teacher": "高阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1102",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "004040.04",
+            "courseCode": "004040",
+            "courseName": "计算物理B",
+            "teacher": "高阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1102",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 85,
+              "after": 80
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "006197.01",
+            "courseCode": "006197",
+            "courseName": "通信网络与交换",
+            "teacher": "陈小良,朱祖勍"
+          },
+          "previous": {
+            "id": "006197.01",
+            "courseCode": "006197",
+            "courseName": "通信网络与交换",
+            "teacher": "陈小良,朱祖勍",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "GT-A405",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  8,
+                  14
+                ],
+                "room": "GT-A405",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "006197.01",
+            "courseCode": "006197",
+            "courseName": "通信网络与交换",
+            "teacher": "陈小良,朱祖勍",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "GT-A403",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  8,
+                  14
+                ],
+                "room": "GT-A403",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "GT-A405",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "GT-A403",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "010177.01",
+            "courseCode": "010177",
+            "courseName": "现代控制理论",
+            "teacher": "王永"
+          },
+          "previous": {
+            "id": "010177.01",
+            "courseCode": "010177",
+            "courseName": "现代控制理论",
+            "teacher": "王永",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "GT-B110",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "GT-B110",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "010177.01",
+            "courseCode": "010177",
+            "courseName": "现代控制理论",
+            "teacher": "王永",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  17
+                ],
+                "room": "GT-B110",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  17
+                ],
+                "room": "GT-B110",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    17
+                  ],
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    17
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "017046e.01",
+            "courseCode": "017046e",
+            "courseName": "国际金融(英)",
+            "teacher": "王潇"
+          },
+          "previous": {
+            "id": "017046e.01",
+            "courseCode": "017046e",
+            "courseName": "国际金融(英)",
+            "teacher": "王潇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2203",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "017046e.01",
+            "courseCode": "017046e",
+            "courseName": "国际金融(英)",
+            "teacher": "王潇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2306",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 30
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2203",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2306",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "019176.01",
+            "courseCode": "019176",
+            "courseName": "分析化学II",
+            "teacher": "邓兆祥,黄光明,崔华"
+          },
+          "previous": {
+            "id": "019176.01",
+            "courseCode": "019176",
+            "courseName": "分析化学II",
+            "teacher": "邓兆祥,崔华,黄光明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "1201",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  12
+                ],
+                "room": "1201",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  16
+                ],
+                "room": "1201",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  18,
+                  18
+                ],
+                "room": "1201",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "019176.01",
+            "courseCode": "019176",
+            "courseName": "分析化学II",
+            "teacher": "邓兆祥,黄光明,崔华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "1201",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  12
+                ],
+                "room": "1201",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  16
+                ],
+                "room": "1201",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  18,
+                  18
+                ],
+                "room": "1201",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "019176.02",
+            "courseCode": "019176",
+            "courseName": "分析化学II",
+            "teacher": "李涛,姚东宝,朱洪影"
+          },
+          "previous": {
+            "id": "019176.02",
+            "courseCode": "019176",
+            "courseName": "分析化学II",
+            "teacher": "姚东宝,朱洪影,李涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  6
+                ],
+                "room": "2407",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "2407",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  18
+                ],
+                "room": "2407",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "019176.02",
+            "courseCode": "019176",
+            "courseName": "分析化学II",
+            "teacher": "李涛,姚东宝,朱洪影",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  6
+                ],
+                "room": "2407",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "2407",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  18
+                ],
+                "room": "2407",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "023317.01",
+            "courseCode": "023317",
+            "courseName": "电磁场与波",
+            "teacher": "朱旗"
+          },
+          "previous": {
+            "id": "023317.01",
+            "courseCode": "023317",
+            "courseName": "电磁场与波",
+            "teacher": "朱旗",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B212",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B212",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "023317.01",
+            "courseCode": "023317",
+            "courseName": "电磁场与波",
+            "teacher": "朱旗",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B212",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B212",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 71,
+              "after": 108
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "209005.01",
+            "courseCode": "209005",
+            "courseName": "工程科学前沿",
+            "teacher": "公泽"
+          },
+          "previous": {
+            "id": "209005.01",
+            "courseCode": "209005",
+            "courseName": "工程科学前沿",
+            "teacher": "公泽",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  5,
+                  7,
+                  9,
+                  11,
+                  13,
+                  15,
+                  17
+                ],
+                "room": "3B103",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "209005.01",
+            "courseCode": "209005",
+            "courseName": "工程科学前沿",
+            "teacher": "公泽",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  5,
+                  7,
+                  9,
+                  11,
+                  13,
+                  15,
+                  17
+                ],
+                "room": "3B103",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级209院06班",
+                "26级209院02班",
+                "26级209院05班",
+                "26级209院01班",
+                "26级209院03班",
+                "26级209院04班"
+              ],
+              "after": [
+                "26级209院06班",
+                "26级209院02班",
+                "26级209院05班",
+                "26级209院01班",
+                "26级209院03班",
+                "26级209院04班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210036.01",
+            "courseCode": "210036",
+            "courseName": "软件安全与测试",
+            "teacher": "程绍银,方涵"
+          },
+          "previous": {
+            "id": "210036.01",
+            "courseCode": "210036",
+            "courseName": "软件安全与测试",
+            "teacher": "程绍银,方涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "GT-A401",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "210036.01",
+            "courseCode": "210036",
+            "courseName": "软件安全与测试",
+            "teacher": "程绍银,方涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "GT-B106",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "GT-A401",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "GT-B106",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210077.02",
+            "courseCode": "210077",
+            "courseName": "非线性电子线路",
+            "teacher": "陈香"
+          },
+          "previous": {
+            "id": "210077.02",
+            "courseCode": "210077",
+            "courseName": "非线性电子线路",
+            "teacher": "陈香",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-A403",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-A403",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "210077.02",
+            "courseCode": "210077",
+            "courseName": "非线性电子线路",
+            "teacher": "陈香",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-A403",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-A403",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 71,
+              "after": 108
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210078.03",
+            "courseCode": "210078",
+            "courseName": "电子系统设计",
+            "teacher": "尹华锐"
+          },
+          "previous": {
+            "id": "210078.03",
+            "courseCode": "210078",
+            "courseName": "电子系统设计",
+            "teacher": "尹华锐",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "GT-A403",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "GT-A403",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "210078.03",
+            "courseCode": "210078",
+            "courseName": "电子系统设计",
+            "teacher": "尹华锐",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "GT-A403",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "GT-A403",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 70,
+              "after": 80
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "910008.01",
+            "courseCode": "910008",
+            "courseName": "病原生物学",
+            "teacher": "魏海明,马筱玲,计永胜,周永刚,崔国梁"
+          },
+          "previous": {
+            "id": "910008.01",
+            "courseCode": "910008",
+            "courseName": "病原生物学",
+            "teacher": "魏海明,马筱玲,计永胜,周永刚,崔国梁",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  3
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  8
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  15
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  14
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区生物楼附楼K504",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  15,
+                  18
+                ],
+                "room": "西区生物楼附楼K504",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  3
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  8
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  15
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  14
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "910008.01",
+            "courseCode": "910008",
+            "courseName": "病原生物学",
+            "teacher": "魏海明,马筱玲,计永胜,周永刚,崔国梁",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  3
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  8
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  15
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  14
+                ],
+                "room": "3A315",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  15,
+                  18
+                ],
+                "room": "西区生物楼附楼K504",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  3
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  8
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  15
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  14
+                ],
+                "room": "3A315",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    3
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    7
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    8
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    14,
+                    15
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    15,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    3
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    7
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    8
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    14,
+                    15
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    14
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    3
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    7
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    8
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    14,
+                    15
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    15,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    3
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    7
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    8
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    14,
+                    15
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    14
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "AI2001B.01",
+            "courseCode": "AI2001B",
+            "courseName": "人工智能导论B",
+            "teacher": "於俊,王子磊"
+          },
+          "previous": {
+            "id": "AI2001B.01",
+            "courseCode": "AI2001B",
+            "courseName": "人工智能导论B",
+            "teacher": "於俊,王子磊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "GT-B212",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  8,
+                  14
+                ],
+                "room": "GT-B212",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "AI2001B.01",
+            "courseCode": "AI2001B",
+            "courseName": "人工智能导论B",
+            "teacher": "於俊,王子磊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "GT-B212",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  8,
+                  14
+                ],
+                "room": "GT-B212",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 110,
+              "after": 125
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "AI3002.03",
+            "courseCode": "AI3002",
+            "courseName": "人工智能与机器学习基础",
+            "teacher": "冯文杰"
+          },
+          "previous": {
+            "id": "AI3002.03",
+            "courseCode": "AI3002",
+            "courseName": "人工智能与机器学习基础",
+            "teacher": "冯文杰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GH-206",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "AI3002.03",
+            "courseCode": "AI3002",
+            "courseName": "人工智能与机器学习基础",
+            "teacher": "冯文杰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "GH-206",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 5,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "AI3004.01",
+            "courseCode": "AI3004",
+            "courseName": "优化理论基础",
+            "teacher": "陈景润"
+          },
+          "previous": {
+            "id": "AI3004.01",
+            "courseCode": "AI3004",
+            "courseName": "优化理论基础",
+            "teacher": "陈景润",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  13
+                ],
+                "room": "GT-B212",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "AI3004.01",
+            "courseCode": "AI3004",
+            "courseName": "优化理论基础",
+            "teacher": "陈景润",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "GT-B212",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    13
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTA6411P.01",
+            "courseCode": "ASTA6411P",
+            "courseName": "强化学习",
+            "teacher": "李亚光"
+          },
+          "previous": {
+            "id": "ASTA6411P.01",
+            "courseCode": "ASTA6411P",
+            "courseName": "强化学习",
+            "teacher": "李亚光",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTA6411P.01",
+            "courseCode": "ASTA6411P",
+            "courseName": "强化学习",
+            "teacher": "李亚光",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  5
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    12
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    3,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    13
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTR6403P.01",
+            "courseCode": "ASTR6403P",
+            "courseName": "物理宇宙学",
+            "teacher": "方文娟"
+          },
+          "previous": {
+            "id": "ASTR6403P.01",
+            "courseCode": "ASTR6403P",
+            "courseName": "物理宇宙学",
+            "teacher": "方文娟",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2506",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  18,
+                  18
+                ],
+                "room": "2506",
+                "day": 6,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTR6403P.01",
+            "courseCode": "ASTR6403P",
+            "courseName": "物理宇宙学",
+            "teacher": "方文娟",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  18,
+                  18
+                ],
+                "room": "2506",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2506",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    18,
+                    18
+                  ],
+                  "day": 6,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    18,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIO1514G.01",
+            "courseCode": "BIO1514G",
+            "courseName": "生物进化论的历史由来、基本概念及未来发展",
+            "teacher": "占成,薛天,刘静"
+          },
+          "previous": {
+            "id": "BIO1514G.01",
+            "courseCode": "BIO1514G",
+            "courseName": "生物进化论的历史由来、基本概念及未来发展",
+            "teacher": "占成,薛天,刘静",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  9
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  14
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIO1514G.01",
+            "courseCode": "BIO1514G",
+            "courseName": "生物进化论的历史由来、基本概念及未来发展",
+            "teacher": "占成,薛天,刘静",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  9
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  14
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  14
+                ],
+                "room": "5203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL6001P.03",
+            "courseCode": "BIOL6001P",
+            "courseName": "生物实验安全与防护",
+            "teacher": "赵伟"
+          },
+          "previous": {
+            "id": "BIOL6001P.03",
+            "courseCode": "BIOL6001P",
+            "courseName": "生物实验安全与防护",
+            "teacher": "赵伟",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "生物楼附楼",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL6001P.03",
+            "courseCode": "BIOL6001P",
+            "courseName": "生物实验安全与防护",
+            "teacher": "赵伟",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "生物楼附楼",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL6001P.05",
+            "courseCode": "BIOL6001P",
+            "courseName": "生物实验安全与防护",
+            "teacher": "赵伟"
+          },
+          "previous": {
+            "id": "BIOL6001P.05",
+            "courseCode": "BIOL6001P",
+            "courseName": "生物实验安全与防护",
+            "teacher": "赵伟",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "生物楼附楼",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL6001P.05",
+            "courseCode": "BIOL6001P",
+            "courseName": "生物实验安全与防护",
+            "teacher": "赵伟",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "生物楼附楼",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL6121P.01",
+            "courseCode": "BIOL6121P",
+            "courseName": "神经生物学原理I",
+            "teacher": "陈敏,姜浩武"
+          },
+          "previous": {
+            "id": "BIOL6121P.01",
+            "courseCode": "BIOL6121P",
+            "courseName": "神经生物学原理I",
+            "teacher": "陈敏,姜浩武",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  4
+                ],
+                "room": "3A309",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  6
+                ],
+                "room": "3A309",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  16
+                ],
+                "room": "3A309",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL6121P.01",
+            "courseCode": "BIOL6121P",
+            "courseName": "神经生物学原理I",
+            "teacher": "陈敏,姜浩武",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  4
+                ],
+                "room": "3A309",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  6
+                ],
+                "room": "3A309",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  16
+                ],
+                "room": "3A309",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    4,
+                    4
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    6,
+                    6
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    4,
+                    4
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    6,
+                    6
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL6573P.01",
+            "courseCode": "BIOL6573P",
+            "courseName": "生物光谱学实验",
+            "teacher": "孙德猛,张璇"
+          },
+          "previous": {
+            "id": "BIOL6573P.01",
+            "courseCode": "BIOL6573P",
+            "courseName": "生物光谱学实验",
+            "teacher": "张璇",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "生物楼附楼",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  9
+                ],
+                "room": "生物楼附楼",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL6573P.01",
+            "courseCode": "BIOL6573P",
+            "courseName": "生物光谱学实验",
+            "teacher": "孙德猛,张璇",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "生物楼附楼",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  9
+                ],
+                "room": "生物楼附楼",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张璇",
+              "after": "孙德猛,张璇"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BUSI6001P.01",
+            "courseCode": "BUSI6001P",
+            "courseName": "商业数据分析",
+            "teacher": "高梦海"
+          },
+          "previous": {
+            "id": "BUSI6001P.01",
+            "courseCode": "BUSI6001P",
+            "courseName": "商业数据分析",
+            "teacher": "高梦海",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "管理楼三楼机房",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:35",
+                "endTime": "17:30",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "管理楼三楼机房",
+                "day": 1,
+                "periods": [
+                  10,
+                  11,
+                  12
+                ],
+                "startTime": "18:00",
+                "endTime": "20:25",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "BUSI6001P.01",
+            "courseCode": "BUSI6001P",
+            "courseName": "商业数据分析",
+            "teacher": "高梦海",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "管理楼三楼机房",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:35",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "管理楼三楼机房",
+                "day": 1,
+                "periods": [
+                  10,
+                  11,
+                  12
+                ],
+                "startTime": "18:00",
+                "endTime": "20:25",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:35",
+                  "endTime": "17:30"
+                },
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "day": 1,
+                  "periods": [
+                    10,
+                    11,
+                    12
+                  ],
+                  "startTime": "18:00",
+                  "endTime": "20:25"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:35",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "day": 1,
+                  "periods": [
+                    10,
+                    11,
+                    12
+                  ],
+                  "startTime": "18:00",
+                  "endTime": "20:25"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEM6001P.02",
+            "courseCode": "CHEM6001P",
+            "courseName": "结晶化学导论",
+            "teacher": "唐凯斌"
+          },
+          "previous": {
+            "id": "CHEM6001P.02",
+            "courseCode": "CHEM6001P",
+            "courseName": "结晶化学导论",
+            "teacher": "唐凯斌",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2407",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEM6001P.02",
+            "courseCode": "CHEM6001P",
+            "courseName": "结晶化学导论",
+            "teacher": "唐凯斌",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2105",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 70
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2407",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2105",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEM6418P.01",
+            "courseCode": "CHEM6418P",
+            "courseName": "辐射化学",
+            "teacher": "刘华蓉"
+          },
+          "previous": {
+            "id": "CHEM6418P.01",
+            "courseCode": "CHEM6418P",
+            "courseName": "辐射化学",
+            "teacher": "刘华蓉",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  10
+                ],
+                "room": "TH-A203",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEM6418P.01",
+            "courseCode": "CHEM6418P",
+            "courseName": "辐射化学",
+            "teacher": "刘华蓉",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "TH-A203",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "18:35",
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    10
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    11
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "18:35"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEM6428P.01",
+            "courseCode": "CHEM6428P",
+            "courseName": "固体化学原理",
+            "teacher": "汪冬冬,周建斌,卫涛"
+          },
+          "previous": {
+            "id": "CHEM6428P.01",
+            "courseCode": "CHEM6428P",
+            "courseName": "固体化学原理",
+            "teacher": "周建斌,卫涛,汪冬冬",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "TH-A301",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEM6428P.01",
+            "courseCode": "CHEM6428P",
+            "courseName": "固体化学原理",
+            "teacher": "汪冬冬,周建斌,卫涛",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  10
+                ],
+                "room": "TH-A301",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  11,
+                  14
+                ],
+                "room": "TH-A301",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  15,
+                  18
+                ],
+                "room": "TH-A301",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    10
+                  ],
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    11,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    15,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEM7004P.01",
+            "courseCode": "CHEM7004P",
+            "courseName": "有机合成专论",
+            "teacher": "张清伟,孙尚政"
+          },
+          "previous": {
+            "id": "CHEM7004P.01",
+            "courseCode": "CHEM7004P",
+            "courseName": "有机合成专论",
+            "teacher": "张清伟,孙尚政",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "无具体上课时间和地点,咨询导师",
+                "day": 6,
+                "periods": [
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEM7004P.01",
+            "courseCode": "CHEM7004P",
+            "courseName": "有机合成专论",
+            "teacher": "张清伟,孙尚政",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "无具体上课时间和地点,咨询导师",
+                "day": 6,
+                "periods": [
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 31
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CONT5215P.01",
+            "courseCode": "CONT5215P",
+            "courseName": "智能机器人",
+            "teacher": "张彬,张飞,王敬"
+          },
+          "previous": {
+            "id": "CONT5215P.01",
+            "courseCode": "CONT5215P",
+            "courseName": "智能机器人",
+            "teacher": "张彬,张飞,王敬",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "G3-109",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "CONT5215P.01",
+            "courseCode": "CONT5215P",
+            "courseName": "智能机器人",
+            "teacher": "张彬,张飞,王敬",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "G3-109",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CONT6101P.01",
+            "courseCode": "CONT6101P",
+            "courseName": "矩阵代数",
+            "teacher": "季海波,马麒超"
+          },
+          "previous": {
+            "id": "CONT6101P.01",
+            "courseCode": "CONT6101P",
+            "courseName": "矩阵代数",
+            "teacher": "季海波,秦家虎",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "GT-C103",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "GT-C103",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "CONT6101P.01",
+            "courseCode": "CONT6101P",
+            "courseName": "矩阵代数",
+            "teacher": "季海波,马麒超",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "GT-C103",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "GT-C103",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "季海波,秦家虎",
+              "after": "季海波,马麒超"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CONT6201P.01",
+            "courseCode": "CONT6201P",
+            "courseName": "线性系统理论",
+            "teacher": "凌强"
+          },
+          "previous": {
+            "id": "CONT6201P.01",
+            "courseCode": "CONT6201P",
+            "courseName": "线性系统理论",
+            "teacher": "凌强",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G3-113",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G3-113",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "CONT6201P.01",
+            "courseCode": "CONT6201P",
+            "courseName": "线性系统理论",
+            "teacher": "凌强",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G3-113",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G3-113",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "undergradShared",
+              "label": "本研同堂",
+              "before": false,
+              "after": true
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CS1003.03",
+            "courseCode": "CS1003",
+            "courseName": "计算机程序设计",
+            "teacher": "谭立湘"
+          },
+          "previous": {
+            "id": "CS1003.03",
+            "courseCode": "CS1003",
+            "courseName": "计算机程序设计",
+            "teacher": "谭立湘",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A111",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  14
+                ],
+                "room": "西区电一楼机房1厅",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "CS1003.03",
+            "courseCode": "CS1003",
+            "courseName": "计算机程序设计",
+            "teacher": "谭立湘",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A111",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  14
+                ],
+                "room": "西区电一楼机房1厅",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级203院04班",
+                "26级000院05班",
+                "26级000院06班"
+              ],
+              "after": [
+                "26级000院05班",
+                "26级000院06班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CS1003.04",
+            "courseCode": "CS1003",
+            "courseName": "计算机程序设计",
+            "teacher": "谭立湘"
+          },
+          "previous": {
+            "id": "CS1003.04",
+            "courseCode": "CS1003",
+            "courseName": "计算机程序设计",
+            "teacher": "谭立湘",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "2210",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  14
+                ],
+                "room": "西区电一楼机房1厅",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "CS1003.04",
+            "courseCode": "CS1003",
+            "courseName": "计算机程序设计",
+            "teacher": "谭立湘",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "2210",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  14
+                ],
+                "room": "西区电一楼机房1厅",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级203院01班",
+                "26级203院02班"
+              ],
+              "after": [
+                "26级203院01班",
+                "26级203院02班",
+                "26级203院04班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CS1003.14",
+            "courseCode": "CS1003",
+            "courseName": "计算机程序设计",
+            "teacher": "盛捷"
+          },
+          "previous": {
+            "id": "CS1003.14",
+            "courseCode": "CS1003",
+            "courseName": "计算机程序设计",
+            "teacher": "盛捷",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14
+                ],
+                "room": "3A211",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A211",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  14
+                ],
+                "room": "西活二楼机房",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "CS1003.14",
+            "courseCode": "CS1003",
+            "courseName": "计算机程序设计",
+            "teacher": "盛捷",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14
+                ],
+                "room": "3A211",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A211",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  14
+                ],
+                "room": "西活二楼机房",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级209院02班",
+                "26级209院01班",
+                "26级209院03班"
+              ],
+              "after": [
+                "26级209院02班",
+                "26级209院01班",
+                "26级209院03班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.01",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.01",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.01",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.02",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.02",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.02",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.03",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.03",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.03",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.04",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.04",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.04",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.05",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.05",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.05",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.06",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.06",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.06",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.07",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.07",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.07",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.08",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.08",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.08",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.09",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.09",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.09",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.10",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.10",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.10",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.11",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.11",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.11",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.12",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.12",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.12",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.13",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.13",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.13",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EDUS1001.14",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "EDUS1001.14",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "EDUS1001.14",
+            "courseCode": "EDUS1001",
+            "courseName": "劳动教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EE2004.01",
+            "courseCode": "EE2004",
+            "courseName": "计算机网络B",
+            "teacher": "郑烇,何华森"
+          },
+          "previous": {
+            "id": "EE2004.01",
+            "courseCode": "EE2004",
+            "courseName": "计算机网络B",
+            "teacher": "郑烇,何华森",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "GT-B210",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  11
+                ],
+                "room": "GT-B210",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "GT-B210",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  11
+                ],
+                "room": "GT-B210",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "EE2004.01",
+            "courseCode": "EE2004",
+            "courseName": "计算机网络B",
+            "teacher": "郑烇,何华森",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "GT-B210",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  11
+                ],
+                "room": "GT-B210",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "GT-B210",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  11
+                ],
+                "room": "GT-B210",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 100,
+              "after": 105
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EE4008.01",
+            "courseCode": "EE4008",
+            "courseName": "机器学习C",
+            "teacher": "吕文君"
+          },
+          "previous": {
+            "id": "EE4008.01",
+            "courseCode": "EE4008",
+            "courseName": "机器学习C",
+            "teacher": "吕文君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "GT-B110",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "EE4008.01",
+            "courseCode": "EE4008",
+            "courseName": "机器学习C",
+            "teacher": "吕文君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "GT-B211",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  16
+                ],
+                "room": "GT-B211",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 80,
+              "after": 85
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    16
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "GT-B110",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "GT-B211",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EIEN6201U.08",
+            "courseCode": "EIEN6201U",
+            "courseName": "工程硕士专业英语(电子信息)",
+            "teacher": "夏学文"
+          },
+          "previous": {
+            "id": "EIEN6201U.08",
+            "courseCode": "EIEN6201U",
+            "courseName": "工程硕士专业英语(电子信息)",
+            "teacher": "夏学文",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "GT-B211",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "EIEN6201U.08",
+            "courseCode": "EIEN6201U",
+            "courseName": "工程硕士专业英语(电子信息)",
+            "teacher": "夏学文",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  13
+                ],
+                "room": "GT-B211",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    15
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    13
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EIEN6201U.09",
+            "courseCode": "EIEN6201U",
+            "courseName": "工程硕士专业英语(电子信息)",
+            "teacher": "邢鸿飞"
+          },
+          "previous": {
+            "id": "EIEN6201U.09",
+            "courseCode": "EIEN6201U",
+            "courseName": "工程硕士专业英语(电子信息)",
+            "teacher": "邢鸿飞",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GH-407",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "EIEN6201U.09",
+            "courseCode": "EIEN6201U",
+            "courseName": "工程硕士专业英语(电子信息)",
+            "teacher": "邢鸿飞",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  13
+                ],
+                "room": "GH-407",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    13
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EIEN6720P.02",
+            "courseCode": "EIEN6720P",
+            "courseName": "实践综合",
+            "teacher": "丁箐"
+          },
+          "previous": {
+            "id": "EIEN6720P.02",
+            "courseCode": "EIEN6720P",
+            "courseName": "实践综合",
+            "teacher": "丁箐",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "GT-C103",
+                "day": 3,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "GT-C103",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "GT-C103",
+                "day": 4,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "GT-C103",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "EIEN6720P.02",
+            "courseCode": "EIEN6720P",
+            "courseName": "实践综合",
+            "teacher": "丁箐",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "GT-C103",
+                "day": 3,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "GT-C103",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ENVS4010.01",
+            "courseCode": "ENVS4010",
+            "courseName": "固废处理与处置工程",
+            "teacher": "刘武军"
+          },
+          "previous": {
+            "id": "ENVS4010.01",
+            "courseCode": "ENVS4010",
+            "courseName": "固废处理与处置工程",
+            "teacher": "刘武军",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2204",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ENVS4010.01",
+            "courseCode": "ENVS4010",
+            "courseName": "固废处理与处置工程",
+            "teacher": "刘武军",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "2204",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    15
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ENVS4012.01",
+            "courseCode": "ENVS4012",
+            "courseName": "环境工程设计基础",
+            "teacher": "李文卫,黄贵祥"
+          },
+          "previous": {
+            "id": "ENVS4012.01",
+            "courseCode": "ENVS4012",
+            "courseName": "环境工程设计基础",
+            "teacher": "李文卫,黄贵祥",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "2305",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "2305",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ENVS4012.01",
+            "courseCode": "ENVS4012",
+            "courseName": "环境工程设计基础",
+            "teacher": "李文卫,黄贵祥",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "2305",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  18
+                ],
+                "room": "2305",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "undergradShared",
+              "label": "本研同堂",
+              "before": false,
+              "after": true
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EPEN6001U.01",
+            "courseCode": "EPEN6001U",
+            "courseName": "专业英语",
+            "teacher": "徐斌"
+          },
+          "previous": {
+            "id": "EPEN6001U.01",
+            "courseCode": "EPEN6001U",
+            "courseName": "专业英语",
+            "teacher": "徐斌",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "3B101",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "EPEN6001U.01",
+            "courseCode": "EPEN6001U",
+            "courseName": "专业英语",
+            "teacher": "徐斌",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "3B101",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 110,
+              "after": 115
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ESS1505.01",
+            "courseCode": "ESS1505",
+            "courseName": "珠宝玉石鉴赏",
+            "teacher": "高晓英"
+          },
+          "previous": {
+            "id": "ESS1505.01",
+            "courseCode": "ESS1505",
+            "courseName": "珠宝玉石鉴赏",
+            "teacher": "高晓英",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "东区新地空楼708教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ESS1505.01",
+            "courseCode": "ESS1505",
+            "courseName": "珠宝玉石鉴赏",
+            "teacher": "高晓英",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "东区新地空楼708教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FINA6109P.01",
+            "courseCode": "FINA6109P",
+            "courseName": "期货和衍生品",
+            "teacher": "吴遵"
+          },
+          "previous": {
+            "id": "FINA6109P.01",
+            "courseCode": "FINA6109P",
+            "courseName": "期货和衍生品",
+            "teacher": "吴遵",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "囯金院2号楼101室",
+                "day": 1,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  17
+                ],
+                "room": "囯金院2号楼101室",
+                "day": 1,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "FINA6109P.01",
+            "courseCode": "FINA6109P",
+            "courseName": "期货和衍生品",
+            "teacher": "吴遵",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  5
+                ],
+                "room": "囯金院2号楼101室",
+                "day": 1,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  18
+                ],
+                "room": "囯金院2号楼101室",
+                "day": 1,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "09:00",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    17
+                  ],
+                  "day": 1,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "09:00",
+                  "endTime": "12:00"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    3,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "09:00",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "09:00",
+                  "endTime": "12:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FINA6109P.02",
+            "courseCode": "FINA6109P",
+            "courseName": "期货和衍生品",
+            "teacher": "吴遵"
+          },
+          "previous": {
+            "id": "FINA6109P.02",
+            "courseCode": "FINA6109P",
+            "courseName": "期货和衍生品",
+            "teacher": "吴遵",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "国金院2号楼102室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  17
+                ],
+                "room": "国金院2号楼102室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "FINA6109P.02",
+            "courseCode": "FINA6109P",
+            "courseName": "期货和衍生品",
+            "teacher": "吴遵",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  5
+                ],
+                "room": "国金院2号楼102室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  18
+                ],
+                "room": "国金院2号楼102室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    17
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    3,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FINA6403P.02",
+            "courseCode": "FINA6403P",
+            "courseName": "财务会计",
+            "teacher": "张瑞稳"
+          },
+          "previous": {
+            "id": "FINA6403P.02",
+            "courseCode": "FINA6403P",
+            "courseName": "财务会计",
+            "teacher": "张瑞稳",
+            "level": "研究生",
+            "schedule": []
+          },
+          "current": {
+            "id": "FINA6403P.02",
+            "courseCode": "FINA6403P",
+            "courseName": "财务会计",
+            "teacher": "张瑞稳",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "国金院2号楼102室",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  17
+                ],
+                "room": "国金院2号楼102室",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  19,
+                  19
+                ],
+                "room": "国金院2号楼102室",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    6,
+                    17
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    19,
+                    19
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "国金院2号楼102室",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.02",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "孙波"
+          },
+          "previous": {
+            "id": "FL1003.02",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "孙波",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A110",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.02",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "孙波",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A110",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.03",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "孙波"
+          },
+          "previous": {
+            "id": "FL1003.03",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "孙波",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2204",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.03",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "孙波",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2103",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2204",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2103",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.12",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "许振宇"
+          },
+          "previous": {
+            "id": "FL1003.12",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "许振宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2304",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.12",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "许振宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2106",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2304",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2106",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.13",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "许振宇"
+          },
+          "previous": {
+            "id": "FL1003.13",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "许振宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A209",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.13",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "许振宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A209",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.14",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "许振宇"
+          },
+          "previous": {
+            "id": "FL1003.14",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "许振宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2304",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.14",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "许振宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2304",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.15",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "许振宇"
+          },
+          "previous": {
+            "id": "FL1003.15",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "许振宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A209",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.15",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "许振宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A209",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.16",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "谢鲤丞"
+          },
+          "previous": {
+            "id": "FL1003.16",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "谢鲤丞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A302",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.16",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "谢鲤丞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A302",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.17",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "谢鲤丞"
+          },
+          "previous": {
+            "id": "FL1003.17",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "谢鲤丞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2307",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.17",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "谢鲤丞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2307",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.18",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "谢鲤丞"
+          },
+          "previous": {
+            "id": "FL1003.18",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "谢鲤丞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A302",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.18",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "谢鲤丞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A302",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.19",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "FL1003.19",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2403",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.19",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "尹俊",
+              "after": ""
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 0
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": []
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2403",
+                  "campus": "本部"
+                }
+              ],
+              "after": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.20",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊"
+          },
+          "previous": {
+            "id": "FL1003.20",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A304",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.20",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 0
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": []
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A304",
+                  "campus": "本部"
+                }
+              ],
+              "after": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.21",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊"
+          },
+          "previous": {
+            "id": "FL1003.21",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2403",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.21",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 0
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": []
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2403",
+                  "campus": "本部"
+                }
+              ],
+              "after": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.22",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊"
+          },
+          "previous": {
+            "id": "FL1003.22",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A304",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.22",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 0
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": []
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A304",
+                  "campus": "本部"
+                }
+              ],
+              "after": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.23",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "邢鸿飞"
+          },
+          "previous": {
+            "id": "FL1003.23",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "邢鸿飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2405",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.23",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "邢鸿飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2121",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2405",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2121",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.24",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "邢鸿飞"
+          },
+          "previous": {
+            "id": "FL1003.24",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "邢鸿飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A310",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.24",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "邢鸿飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A310",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.25",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "邢鸿飞"
+          },
+          "previous": {
+            "id": "FL1003.25",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "邢鸿飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.25",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "邢鸿飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2405",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.26",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "邢鸿飞"
+          },
+          "previous": {
+            "id": "FL1003.26",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "邢鸿飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2405",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.26",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "邢鸿飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2211",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2405",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2211",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.27",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "李兰兰"
+          },
+          "previous": {
+            "id": "FL1003.27",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "李兰兰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2407",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.27",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "李兰兰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2407",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.28",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "李兰兰"
+          },
+          "previous": {
+            "id": "FL1003.28",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "李兰兰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A405",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.28",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "李兰兰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A405",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.29",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "李兰兰"
+          },
+          "previous": {
+            "id": "FL1003.29",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "李兰兰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A405",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.29",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "李兰兰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A405",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.30",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "李兰兰"
+          },
+          "previous": {
+            "id": "FL1003.30",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "李兰兰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2407",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1003.30",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "李兰兰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2104",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2407",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2104",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.02",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛"
+          },
+          "previous": {
+            "id": "FL1005.02",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2205",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.02",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2205",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.03",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛"
+          },
+          "previous": {
+            "id": "FL1005.03",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A202",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.03",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A202",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.04",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛"
+          },
+          "previous": {
+            "id": "FL1005.04",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2205",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.04",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2205",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.05",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛"
+          },
+          "previous": {
+            "id": "FL1005.05",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A202",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.05",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A202",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.06",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉"
+          },
+          "previous": {
+            "id": "FL1005.06",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A210",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.06",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A210",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.07",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉"
+          },
+          "previous": {
+            "id": "FL1005.07",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2306",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.07",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2306",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.08",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉"
+          },
+          "previous": {
+            "id": "FL1005.08",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A210",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.08",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A210",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.09",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉"
+          },
+          "previous": {
+            "id": "FL1005.09",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2306",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.09",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2306",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.10",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄"
+          },
+          "previous": {
+            "id": "FL1005.10",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.10",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.11",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄"
+          },
+          "previous": {
+            "id": "FL1005.11",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A303",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.11",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A303",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.12",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄"
+          },
+          "previous": {
+            "id": "FL1005.12",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.12",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.13",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄"
+          },
+          "previous": {
+            "id": "FL1005.13",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A303",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.13",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A303",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.14",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄"
+          },
+          "previous": {
+            "id": "FL1005.14",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.14",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.19",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏"
+          },
+          "previous": {
+            "id": "FL1005.19",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.19",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.20",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏"
+          },
+          "previous": {
+            "id": "FL1005.20",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A404",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.20",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A404",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.21",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏"
+          },
+          "previous": {
+            "id": "FL1005.21",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.21",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.22",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏"
+          },
+          "previous": {
+            "id": "FL1005.22",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A404",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.22",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A404",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.23",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏"
+          },
+          "previous": {
+            "id": "FL1005.23",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.23",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.01",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅"
+          },
+          "previous": {
+            "id": "FL1013.01",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A204",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.01",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A204",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.02",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅"
+          },
+          "previous": {
+            "id": "FL1013.02",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A204",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.02",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A204",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.03",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅"
+          },
+          "previous": {
+            "id": "FL1013.03",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2303",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.03",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2303",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.04",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅"
+          },
+          "previous": {
+            "id": "FL1013.04",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2303",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.04",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2303",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.05",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅"
+          },
+          "previous": {
+            "id": "FL1013.05",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A204",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.05",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A204",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.06",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅"
+          },
+          "previous": {
+            "id": "FL1013.06",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A204",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.06",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A204",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.07",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅"
+          },
+          "previous": {
+            "id": "FL1013.07",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2303",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.07",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2303",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.08",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅"
+          },
+          "previous": {
+            "id": "FL1013.08",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2303",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.08",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2303",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.09",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔"
+          },
+          "previous": {
+            "id": "FL1013.09",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2206",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.09",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2206",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.10",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔"
+          },
+          "previous": {
+            "id": "FL1013.10",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2206",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.10",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2206",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.11",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔"
+          },
+          "previous": {
+            "id": "FL1013.11",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A203",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.11",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A203",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.12",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔"
+          },
+          "previous": {
+            "id": "FL1013.12",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A203",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.12",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A203",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.13",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔"
+          },
+          "previous": {
+            "id": "FL1013.13",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2206",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.13",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2206",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.14",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔"
+          },
+          "previous": {
+            "id": "FL1013.14",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2206",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.14",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2206",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.15",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔"
+          },
+          "previous": {
+            "id": "FL1013.15",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A203",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.15",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A203",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.16",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔"
+          },
+          "previous": {
+            "id": "FL1013.16",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A203",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.16",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A203",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1102B.04",
+            "courseCode": "FL1102B",
+            "courseName": "科普英语交流B",
+            "teacher": "张曼君"
+          },
+          "previous": {
+            "id": "FL1102B.04",
+            "courseCode": "FL1102B",
+            "courseName": "科普英语交流B",
+            "teacher": "张曼君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2206",
+                "day": 3,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1102B.04",
+            "courseCode": "FL1102B",
+            "courseName": "科普英语交流B",
+            "teacher": "张曼君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2206",
+                "day": 3,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 45
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1103A.01",
+            "courseCode": "FL1103A",
+            "courseName": "跨文化交流",
+            "teacher": "李献伟"
+          },
+          "previous": {
+            "id": "FL1103A.01",
+            "courseCode": "FL1103A",
+            "courseName": "跨文化交流",
+            "teacher": "李献伟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5102",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1103A.01",
+            "courseCode": "FL1103A",
+            "courseName": "跨文化交流",
+            "teacher": "李献伟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5102",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 70
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1506.01",
+            "courseCode": "FL1506",
+            "courseName": "德国语言与文化(初级)",
+            "teacher": "徐筱春"
+          },
+          "previous": {
+            "id": "FL1506.01",
+            "courseCode": "FL1506",
+            "courseName": "德国语言与文化(初级)",
+            "teacher": "徐筱春",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2204",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2204",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1506.01",
+            "courseCode": "FL1506",
+            "courseName": "德国语言与文化(初级)",
+            "teacher": "徐筱春",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2204",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2204",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1506.02",
+            "courseCode": "FL1506",
+            "courseName": "德国语言与文化(初级)",
+            "teacher": "徐筱春"
+          },
+          "previous": {
+            "id": "FL1506.02",
+            "courseCode": "FL1506",
+            "courseName": "德国语言与文化(初级)",
+            "teacher": "徐筱春",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2204",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2204",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1506.02",
+            "courseCode": "FL1506",
+            "courseName": "德国语言与文化(初级)",
+            "teacher": "徐筱春",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2204",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2204",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 40
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6101U.04",
+            "courseCode": "FORL6101U",
+            "courseName": "研究生综合英语",
+            "teacher": "邢鸿飞"
+          },
+          "previous": {
+            "id": "FORL6101U.04",
+            "courseCode": "FORL6101U",
+            "courseName": "研究生综合英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2604",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2604",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2604",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6101U.04",
+            "courseCode": "FORL6101U",
+            "courseName": "研究生综合英语",
+            "teacher": "邢鸿飞",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2604",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2604",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2604",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "邢鸿飞"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.33",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "龚伟峰"
+          },
+          "previous": {
+            "id": "FORL6102U.33",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2604",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.33",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "龚伟峰",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "待通知",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "龚伟峰"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 0
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2604",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "待通知",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.34",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "龚伟峰"
+          },
+          "previous": {
+            "id": "FORL6102U.34",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2604",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.34",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "龚伟峰",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "地点待定",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "龚伟峰"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 0
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2604",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "地点待定",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.51",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia"
+          },
+          "previous": {
+            "id": "FORL6102U.51",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A402",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.51",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A402",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 35
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.52",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia"
+          },
+          "previous": {
+            "id": "FORL6102U.52",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A406",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.52",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A406",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 35
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.56",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia"
+          },
+          "previous": {
+            "id": "FORL6102U.56",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2306",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.56",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2306",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 35
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.57",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia"
+          },
+          "previous": {
+            "id": "FORL6102U.57",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2207",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.57",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2207",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 35
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.60",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "FORL6102U.60",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": []
+          },
+          "current": {
+            "id": "FORL6102U.60",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2604",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "2604",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6206U.01",
+            "courseCode": "FORL6206U",
+            "courseName": "中国之道：历史传承与当代治理",
+            "teacher": "邢鸿飞,许振宇,瞿昆,沈义竹,田琳,冉懿,胡嘉宇,周蕾,朱孟潇,吴昊"
+          },
+          "previous": {
+            "id": "FORL6206U.01",
+            "courseCode": "FORL6206U",
+            "courseName": "中国之道：历史传承与当代治理",
+            "teacher": "邢鸿飞,许振宇,瞿昆,沈义竹,吴昊,冉懿,胡嘉宇,周蕾,朱孟潇,田琳",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  20
+                ],
+                "room": "2121",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6206U.01",
+            "courseCode": "FORL6206U",
+            "courseName": "中国之道：历史传承与当代治理",
+            "teacher": "邢鸿飞,许振宇,瞿昆,沈义竹,田琳,冉懿,胡嘉宇,周蕾,朱孟潇,吴昊",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  20
+                ],
+                "room": "2121",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "undergradShared",
+              "label": "本研同堂",
+              "before": false,
+              "after": true
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL7101U.02",
+            "courseCode": "FORL7101U",
+            "courseName": "科技论文写作",
+            "teacher": "谢小冬,石龙"
+          },
+          "previous": {
+            "id": "FORL7101U.02",
+            "courseCode": "FORL7101U",
+            "courseName": "科技论文写作",
+            "teacher": "石龙",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A113",
+                "day": 3,
+                "periods": [
+                  10,
+                  11,
+                  12
+                ],
+                "startTime": "17:35",
+                "endTime": "20:50",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL7101U.02",
+            "courseCode": "FORL7101U",
+            "courseName": "科技论文写作",
+            "teacher": "谢小冬,石龙",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A113",
+                "day": 3,
+                "periods": [
+                  10,
+                  11,
+                  12
+                ],
+                "startTime": "17:35",
+                "endTime": "20:50",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "石龙",
+              "after": "谢小冬,石龙"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.28",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "孙帅帅"
+          },
+          "previous": {
+            "id": "FS1001.28",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "孙帅帅",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.28",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "孙帅帅",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级209院05班"
+              ],
+              "after": [
+                "26级209院05班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.2E",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "谈鹏"
+          },
+          "previous": {
+            "id": "FS1001.2E",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "谈鹏",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.2E",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "谈鹏",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级209院05班"
+              ],
+              "after": [
+                "26级209院05班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.2F",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "胡茂彬"
+          },
+          "previous": {
+            "id": "FS1001.2F",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "胡茂彬",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.2F",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "胡茂彬",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级209院05班"
+              ],
+              "after": [
+                "26级209院05班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.2G",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "马浩"
+          },
+          "previous": {
+            "id": "FS1001.2G",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "马浩",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.2G",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "马浩",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级209院05班"
+              ],
+              "after": [
+                "26级209院05班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "GEOL6402P.01",
+            "courseCode": "GEOL6402P",
+            "courseName": "化学地球动力学",
+            "teacher": "陈伊翔,高晓英"
+          },
+          "previous": {
+            "id": "GEOL6402P.01",
+            "courseCode": "GEOL6402P",
+            "courseName": "化学地球动力学",
+            "teacher": "陈伊翔,高晓英",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "5205",
+                "day": 5,
+                "periods": [
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "GEOL6402P.01",
+            "courseCode": "GEOL6402P",
+            "courseName": "化学地球动力学",
+            "teacher": "陈伊翔,高晓英",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "5205",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    15
+                  ],
+                  "day": 5,
+                  "periods": [
+                    2,
+                    3,
+                    4
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    15
+                  ],
+                  "day": 5,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "GEOL7401P.01",
+            "courseCode": "GEOL7401P",
+            "courseName": "化学地球动力学高级讲座",
+            "teacher": "郑永飞,陈伊翔,高彭"
+          },
+          "previous": {
+            "id": "GEOL7401P.01",
+            "courseCode": "GEOL7401P",
+            "courseName": "化学地球动力学高级讲座",
+            "teacher": "郑永飞,陈伊翔,高彭",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "环资楼824会议室",
+                "day": 3,
+                "periods": [
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "GEOL7401P.01",
+            "courseCode": "GEOL7401P",
+            "courseName": "化学地球动力学高级讲座",
+            "teacher": "郑永飞,陈伊翔,高彭",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "理化大楼12008",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    15
+                  ],
+                  "day": 3,
+                  "periods": [
+                    2,
+                    3,
+                    4
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    15
+                  ],
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "环资楼824会议室",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "理化大楼12008",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "GEPH6423P.01",
+            "courseCode": "GEPH6423P",
+            "courseName": "构造物理野外考察",
+            "teacher": "冯吉坤,戴志阳"
+          },
+          "previous": {
+            "id": "GEPH6423P.01",
+            "courseCode": "GEPH6423P",
+            "courseName": "构造物理野外考察",
+            "teacher": "冯吉坤,戴志阳",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  6,
+                  15
+                ],
+                "room": "野外实习:集中授课",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "GEPH6423P.01",
+            "courseCode": "GEPH6423P",
+            "courseName": "构造物理野外考察",
+            "teacher": "冯吉坤,戴志阳",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  6,
+                  15
+                ],
+                "room": "野外实习:集中授课",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.01",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.01",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.01",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.02",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.02",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.02",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.03",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.03",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.03",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.04",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.04",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.04",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.05",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.05",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.05",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.06",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.06",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.06",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.07",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.07",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.07",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.08",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.08",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.08",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.09",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.09",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.09",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.10",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.10",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.10",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.11",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.11",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.11",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.12",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.12",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.12",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.13",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.13",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.13",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.28",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.28",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.28",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.29",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.29",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.29",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.30",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.30",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.30",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.31",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.31",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.31",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.32",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.32",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.32",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.33",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.33",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.33",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.34",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.34",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.34",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.35",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.35",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.35",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.36",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.36",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.36",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.37",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.37",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.37",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1003.38",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1003.38",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1003.38",
+            "courseCode": "HS1003",
+            "courseName": "艺术实践",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "details",
+              "label": "课程简介或教学大纲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1517.01",
+            "courseCode": "HS1517",
+            "courseName": "表达技巧与朗诵艺术",
+            "teacher": "姜立安"
+          },
+          "previous": {
+            "id": "HS1517.01",
+            "courseCode": "HS1517",
+            "courseName": "表达技巧与朗诵艺术",
+            "teacher": "姜立安",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  13
+                ],
+                "room": "5105",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "HS1517.01",
+            "courseCode": "HS1517",
+            "courseName": "表达技巧与朗诵艺术",
+            "teacher": "姜立安",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  13
+                ],
+                "room": "5205",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5105",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5205",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1531.01",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "王国正"
+          },
+          "previous": {
+            "id": "HS1531.01",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "王国正",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3C101",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "HS1531.01",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "王国正",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  15
+                ],
+                "room": "3C101",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 130
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    3,
+                    15
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1531.02",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "张曼莉"
+          },
+          "previous": {
+            "id": "HS1531.02",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "张曼莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3C201",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "HS1531.02",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "张曼莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3C201",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 90,
+              "after": 130
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1531.03",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "何晓松"
+          },
+          "previous": {
+            "id": "HS1531.03",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "何晓松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "1102",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "HS1531.03",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "何晓松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  15
+                ],
+                "room": "1102",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 90,
+              "after": 130
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    3,
+                    15
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1531.04",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "张效初,张隆华"
+          },
+          "previous": {
+            "id": "HS1531.04",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "张效初",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3C102",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "HS1531.04",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "张效初,张隆华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3C102",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张效初",
+              "after": "张效初,张隆华"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 130
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1531.05",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "吕心游"
+          },
+          "previous": {
+            "id": "HS1531.05",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "吕心游",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "2121",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "HS1531.05",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "吕心游",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "2121",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 130
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1531.06",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "杭雨霑"
+          },
+          "previous": {
+            "id": "HS1531.06",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "杭雨霑",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5102",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "HS1531.06",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "杭雨霑",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5102",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 130
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1531.07",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "吴韡"
+          },
+          "previous": {
+            "id": "HS1531.07",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "吴韡",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "1102",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "HS1531.07",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "吴韡",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "1102",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 130
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1531.08",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "徐晓飞"
+          },
+          "previous": {
+            "id": "HS1531.08",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "徐晓飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3C103",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "HS1531.08",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "徐晓飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3C103",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 130
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1531.09",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "郭博文"
+          },
+          "previous": {
+            "id": "HS1531.09",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "郭博文",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "1102",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "HS1531.09",
+            "courseCode": "HS1531",
+            "courseName": "大学生心理学",
+            "teacher": "郭博文",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "1102",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 130
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1536.01",
+            "courseCode": "HS1536",
+            "courseName": "大学生健康教育",
+            "teacher": "刘明"
+          },
+          "previous": {
+            "id": "HS1536.01",
+            "courseCode": "HS1536",
+            "courseName": "大学生健康教育",
+            "teacher": "刘明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  12
+                ],
+                "room": "1101",
+                "day": 1,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "HS1536.01",
+            "courseCode": "HS1536",
+            "courseName": "大学生健康教育",
+            "teacher": "刘明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "1101",
+                "day": 1,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "1101",
+                "day": 1,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    12
+                  ],
+                  "day": 1,
+                  "periods": [
+                    11,
+                    12
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    11,
+                    12
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    13
+                  ],
+                  "day": 1,
+                  "periods": [
+                    11,
+                    12
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1580M.10",
+            "courseCode": "HS1580M",
+            "courseName": "大学生国家安全教育",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "HS1580M.10",
+            "courseCode": "HS1580M",
+            "courseName": "大学生国家安全教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "HS1580M.10",
+            "courseCode": "HS1580M",
+            "courseName": "大学生国家安全教育",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级209院06班",
+                "26级209院02班",
+                "26级209院05班",
+                "26级209院01班",
+                "26级209院03班",
+                "26级209院04班"
+              ],
+              "after": [
+                "26级209院06班",
+                "26级209院02班",
+                "26级209院05班",
+                "26级209院01班",
+                "26级209院03班",
+                "26级209院04班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "IC3001.01",
+            "courseCode": "IC3001",
+            "courseName": "半导体材料与物理",
+            "teacher": "吕頔"
+          },
+          "previous": {
+            "id": "IC3001.01",
+            "courseCode": "IC3001",
+            "courseName": "半导体材料与物理",
+            "teacher": "吕頔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B110",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B110",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "IC3001.01",
+            "courseCode": "IC3001",
+            "courseName": "半导体材料与物理",
+            "teacher": "吕頔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B110",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B110",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 71,
+              "after": 108
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "INFO6414P.01",
+            "courseCode": "INFO6414P",
+            "courseName": "现代医疗仪器",
+            "teacher": "陈勋,吴乐,刘爱萍,李煜"
+          },
+          "previous": {
+            "id": "INFO6414P.01",
+            "courseCode": "INFO6414P",
+            "courseName": "现代医疗仪器",
+            "teacher": "陈勋,吴乐,刘爱萍,李煜",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G2-B503",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "INFO6414P.01",
+            "courseCode": "INFO6414P",
+            "courseName": "现代医疗仪器",
+            "teacher": "陈勋,吴乐,刘爱萍,李煜",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G2-B402",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "G2-B402",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    17
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    17
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    17
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "G2-B503",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "G2-B402",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1011.16",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "胡云峰,苏振源"
+          },
+          "previous": {
+            "id": "MARX1011.16",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "胡云峰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "3A313",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1011.16",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "胡云峰,苏振源",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "3A313",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "胡云峰",
+              "after": "胡云峰,苏振源"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1011.17",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "苏振源,胡云峰"
+          },
+          "previous": {
+            "id": "MARX1011.17",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "胡云峰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "3A313",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1011.17",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "苏振源,胡云峰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "3A313",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "胡云峰",
+              "after": "苏振源,胡云峰"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1011.20",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "胡云峰,张翔"
+          },
+          "previous": {
+            "id": "MARX1011.20",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "胡云峰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "3A111",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1011.20",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "胡云峰,张翔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "3A111",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "胡云峰",
+              "after": "胡云峰,张翔"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1011.26",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "胡云峰,丁浩"
+          },
+          "previous": {
+            "id": "MARX1011.26",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "胡云峰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "3A312",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1011.26",
+            "courseCode": "MARX1011",
+            "courseName": "马克思主义基本原理",
+            "teacher": "胡云峰,丁浩",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "3A312",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "胡云峰",
+              "after": "胡云峰,丁浩"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.05",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君"
+          },
+          "previous": {
+            "id": "MARX1014.05",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5103",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.05",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5103",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26数学学院（大类）"
+              ],
+              "after": [
+                "26数学学院（大类）",
+                "26级203院05班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.06",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "谭小琴"
+          },
+          "previous": {
+            "id": "MARX1014.06",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "谭小琴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5102",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.06",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "谭小琴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5102",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26数学学院（大类）",
+                "26中法英才班U",
+                "26环境科学与工程",
+                "26数学学院（大类）(强基)",
+                "26环境科学与工程+人工智能"
+              ],
+              "after": [
+                "26数学学院（大类）",
+                "26中法英才班U",
+                "26数学学院（大类）(强基)"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.08",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "应验"
+          },
+          "previous": {
+            "id": "MARX1014.08",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "应验",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1101",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.08",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "应验",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1101",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26管理学院（大类）",
+                "26级203院03班",
+                "26级203院04班"
+              ],
+              "after": [
+                "26管理学院（大类）",
+                "26环境科学与工程",
+                "26环境科学与工程+人工智能"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.09",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮"
+          },
+          "previous": {
+            "id": "MARX1014.09",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1202",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.09",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1202",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26管理学院（大类）",
+                "26级203院05班"
+              ],
+              "after": [
+                "26管理学院（大类）",
+                "26级203院04班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.12",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙"
+          },
+          "previous": {
+            "id": "MARX1014.12",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1201",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.12",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1201",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级203院06班",
+                "26级206院012系01班",
+                "26级206院019系01班",
+                "26级206院03班",
+                "26级206院04班"
+              ],
+              "after": [
+                "26量子信息科学(强基)",
+                "26量子信息科技英才班T",
+                "26级203院06班",
+                "26级206院012系01班",
+                "26级206院019系01班",
+                "26级206院03班",
+                "26级206院04班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.13",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮"
+          },
+          "previous": {
+            "id": "MARX1014.13",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1202",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.13",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1202",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26量子信息科学",
+                "26量子信息科学(强基)",
+                "26量子信息科技英才班T"
+              ],
+              "after": [
+                "26量子信息科学",
+                "26级203院03班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.18",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮"
+          },
+          "previous": {
+            "id": "MARX1014.18",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A113",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.18",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A113",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级209院03班",
+                "26级209院04班"
+              ],
+              "after": [
+                "26级209院03班",
+                "26级209院04班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX6102U.62",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "洪孟良"
+          },
+          "previous": {
+            "id": "MARX6102U.62",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "洪孟良",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "囯金院2号楼102教室",
+                "day": 1,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "囯金院2号楼102教室",
+                "day": 1,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX6102U.62",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "洪孟良",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  5
+                ],
+                "room": "囯金院2号楼102教室",
+                "day": 1,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "囯金院2号楼102教室",
+                "day": 1,
+                "periods": [
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "09:00",
+                "endTime": "12:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "09:00",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    12
+                  ],
+                  "day": 1,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "09:00",
+                  "endTime": "12:00"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    3,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "09:00",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    13
+                  ],
+                  "day": 1,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "09:00",
+                  "endTime": "12:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX6102U.63",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "陈海超"
+          },
+          "previous": {
+            "id": "MARX6102U.63",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "陈海超",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "囯金院2号楼101教室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "囯金院2号楼101教室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX6102U.63",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "陈海超",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  5
+                ],
+                "room": "囯金院2号楼101教室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "囯金院2号楼101教室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    12
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    3,
+                    5
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    13
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH1006.03",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "梁兴"
+          },
+          "previous": {
+            "id": "MATH1006.03",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "梁兴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5202",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5202",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5202",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH1006.03",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "梁兴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5202",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5202",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5202",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级000院07班",
+                "26级000院08班"
+              ],
+              "after": [
+                "26级000院06班",
+                "26级000院07班",
+                "26级000院08班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH1006.05",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "段雅丽"
+          },
+          "previous": {
+            "id": "MATH1006.05",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "段雅丽",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5303",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5303",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5303",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH1006.05",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "段雅丽",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5303",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5303",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5303",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26量子信息科学",
+                "26量子信息科学(强基)",
+                "26量子信息科技英才班T",
+                "26级203院03班"
+              ],
+              "after": [
+                "26量子信息科学",
+                "26量子信息科学(强基)",
+                "26量子信息科技英才班T"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH1006.06",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "吴心宇"
+          },
+          "previous": {
+            "id": "MATH1006.06",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "吴心宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5302",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5302",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5302",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH1006.06",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "吴心宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5302",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5302",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5302",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26天文学",
+                "26物理学院（大类）(强基)",
+                "26级203院01班",
+                "26级203院02班"
+              ],
+              "after": [
+                "26天文学",
+                "26物理学院（大类）(强基)",
+                "26级203院01班",
+                "26级203院02班",
+                "26级203院03班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH1006.11",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "夏银华"
+          },
+          "previous": {
+            "id": "MATH1006.11",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "夏银华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C202",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C202",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C202",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH1006.11",
+            "courseCode": "MATH1006",
+            "courseName": "数学分析(B1)",
+            "teacher": "夏银华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C202",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C202",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C202",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26钱学森力学科技英才班T",
+                "26级209院02班",
+                "26级209院01班",
+                "26级209院03班"
+              ],
+              "after": [
+                "26钱学森力学科技英才班T",
+                "26级209院02班",
+                "26级209院01班",
+                "26级209院03班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH1008.02",
+            "courseCode": "MATH1008",
+            "courseName": "数学分析(B3)",
+            "teacher": "许斌"
+          },
+          "previous": {
+            "id": "MATH1008.02",
+            "courseCode": "MATH1008",
+            "courseName": "数学分析(B3)",
+            "teacher": "许斌",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5501",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5501",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH1008.02",
+            "courseCode": "MATH1008",
+            "courseName": "数学分析(B3)",
+            "teacher": "许斌",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5501",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5501",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "5501",
+                "day": 6,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 6,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH1009.03",
+            "courseCode": "MATH1009",
+            "courseName": "线性代数(B1)",
+            "teacher": "陈先进"
+          },
+          "previous": {
+            "id": "MATH1009.03",
+            "courseCode": "MATH1009",
+            "courseName": "线性代数(B1)",
+            "teacher": "陈先进",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C102",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C102",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH1009.03",
+            "courseCode": "MATH1009",
+            "courseName": "线性代数(B1)",
+            "teacher": "陈先进",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C102",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C102",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级209院06班",
+                "26级209院05班"
+              ],
+              "after": [
+                "26级209院06班",
+                "26级209院05班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH6105P.01",
+            "courseCode": "MATH6105P",
+            "courseName": "复几何",
+            "teacher": "夏铭辰"
+          },
+          "previous": {
+            "id": "MATH6105P.01",
+            "courseCode": "MATH6105P",
+            "courseName": "复几何",
+            "teacher": "夏铭辰",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2607",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH6105P.01",
+            "courseCode": "MATH6105P",
+            "courseName": "复几何",
+            "teacher": "夏铭辰",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  4
+                ],
+                "room": "2406",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  18
+                ],
+                "room": "2406",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "2607",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  18
+                ],
+                "room": "2607",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    4
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    6,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ME2005.04",
+            "courseCode": "ME2005",
+            "courseName": "机械设计基础I",
+            "teacher": "文莉"
+          },
+          "previous": {
+            "id": "ME2005.04",
+            "courseCode": "ME2005",
+            "courseName": "机械设计基础I",
+            "teacher": "文莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A318",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A318",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ME2005.04",
+            "courseCode": "ME2005",
+            "courseName": "机械设计基础I",
+            "teacher": "文莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A318",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A318",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级209院02班",
+                "26级209院03班"
+              ],
+              "after": [
+                "26级209院02班",
+                "26级209院03班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ME2006.01",
+            "courseCode": "ME2006",
+            "courseName": "理论力学B",
+            "teacher": "赵凯"
+          },
+          "previous": {
+            "id": "ME2006.01",
+            "courseCode": "ME2006",
+            "courseName": "理论力学B",
+            "teacher": "赵凯",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A311",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A311",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ME2006.01",
+            "courseCode": "ME2006",
+            "courseName": "理论力学B",
+            "teacher": "赵凯",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A311",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A311",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 38,
+              "after": 55
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ME2503.01",
+            "courseCode": "ME2503",
+            "courseName": "先进制造实践",
+            "teacher": "叶回春,刘志刚,许旻,袁小平,倪青,郑航"
+          },
+          "previous": {
+            "id": "ME2503.01",
+            "courseCode": "ME2503",
+            "courseName": "先进制造实践",
+            "teacher": "叶回春,刘志刚,许旻,袁小平,倪青,郑航",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区工程实践中心",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ME2503.01",
+            "courseCode": "ME2503",
+            "courseName": "先进制造实践",
+            "teacher": "叶回春,刘志刚,许旻,袁小平,倪青,郑航",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区工程实践中心",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MECH6210P.01",
+            "courseCode": "MECH6210P",
+            "courseName": "微细加工技术",
+            "teacher": "高怀岭"
+          },
+          "previous": {
+            "id": "MECH6210P.01",
+            "courseCode": "MECH6210P",
+            "courseName": "微细加工技术",
+            "teacher": "高怀岭",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A209",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MECH6210P.01",
+            "courseCode": "MECH6210P",
+            "courseName": "微细加工技术",
+            "teacher": "高怀岭",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A209",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "language",
+              "label": "授课语言",
+              "before": "中文",
+              "after": "英语"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MECH6404P.01",
+            "courseCode": "MECH6404P",
+            "courseName": "结构冲击动力学",
+            "teacher": "文鹤鸣"
+          },
+          "previous": {
+            "id": "MECH6404P.01",
+            "courseCode": "MECH6404P",
+            "courseName": "结构冲击动力学",
+            "teacher": "文鹤鸣",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3B201",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3B201",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MECH6404P.01",
+            "courseCode": "MECH6404P",
+            "courseName": "结构冲击动力学",
+            "teacher": "文鹤鸣",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3B201",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3B201",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MIL1001.05",
+            "courseCode": "MIL1001",
+            "courseName": "军事理论",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "MIL1001.05",
+            "courseCode": "MIL1001",
+            "courseName": "军事理论",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "MIL1001.05",
+            "courseCode": "MIL1001",
+            "courseName": "军事理论",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26生命科学学院（大类）",
+                "26核学院（大类）",
+                "26生命科学学院（大类）(强基)",
+                "26级209院06班",
+                "26级209院02班",
+                "26级209院05班",
+                "26级209院01班",
+                "26级209院03班",
+                "26级209院04班"
+              ],
+              "after": [
+                "26生命科学学院（大类）",
+                "26核学院（大类）",
+                "26生命科学学院（大类）(强基)",
+                "26级209院06班",
+                "26级209院02班",
+                "26级209院05班",
+                "26级209院01班",
+                "26级209院03班",
+                "26级209院04班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MIL1002.09",
+            "courseCode": "MIL1002",
+            "courseName": "军事技能",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "MIL1002.09",
+            "courseCode": "MIL1002",
+            "courseName": "军事技能",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "MIL1002.09",
+            "courseCode": "MIL1002",
+            "courseName": "军事技能",
+            "teacher": "",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级209院06班",
+                "26级209院02班",
+                "26级209院05班",
+                "26级209院01班",
+                "26级209院03班",
+                "26级209院04班"
+              ],
+              "after": [
+                "26级209院06班",
+                "26级209院02班",
+                "26级209院05班",
+                "26级209院01班",
+                "26级209院03班",
+                "26级209院04班",
+                "26级209院07班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MIPR6001P.01",
+            "courseCode": "MIPR6001P",
+            "courseName": "创新与知识产权制度概论",
+            "teacher": "王元地"
+          },
+          "previous": {
+            "id": "MIPR6001P.01",
+            "courseCode": "MIPR6001P",
+            "courseName": "创新与知识产权制度概论",
+            "teacher": "王元地",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2204",
+                "day": 5,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MIPR6001P.01",
+            "courseCode": "MIPR6001P",
+            "courseName": "创新与知识产权制度概论",
+            "teacher": "王元地",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2307",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 5,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 5,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2204",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2307",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MNSC1901.01",
+            "courseCode": "MNSC1901",
+            "courseName": "应急管理与运作",
+            "teacher": "樊彧,王熹徽"
+          },
+          "previous": {
+            "id": "MNSC1901.01",
+            "courseCode": "MNSC1901",
+            "courseName": "应急管理与运作",
+            "teacher": "王熹徽",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5103",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MNSC1901.01",
+            "courseCode": "MNSC1901",
+            "courseName": "应急管理与运作",
+            "teacher": "樊彧,王熹徽",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5103",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "王熹徽",
+              "after": "樊彧,王熹徽"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MNSC4008.01",
+            "courseCode": "MNSC4008",
+            "courseName": "AI大模型原理与应用",
+            "teacher": "叶强,高超越,姜贺敏"
+          },
+          "previous": {
+            "id": "MNSC4008.01",
+            "courseCode": "MNSC4008",
+            "courseName": "AI大模型原理与应用",
+            "teacher": "叶强,高超越",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "5402",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  7
+                ],
+                "room": "5402",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MNSC4008.01",
+            "courseCode": "MNSC4008",
+            "courseName": "AI大模型原理与应用",
+            "teacher": "叶强,高超越,姜贺敏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "5402",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  5
+                ],
+                "room": "5402",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  7
+                ],
+                "room": "5402",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "叶强,高超越",
+              "after": "叶强,高超越,姜贺敏"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6004U.01",
+            "courseCode": "MPAD6004U",
+            "courseName": "研究生综合英语",
+            "teacher": "赵梦雪"
+          },
+          "previous": {
+            "id": "MPAD6004U.01",
+            "courseCode": "MPAD6004U",
+            "courseName": "研究生综合英语",
+            "teacher": "赵梦雪",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "5103",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  10
+                ],
+                "room": "5103",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  14
+                ],
+                "room": "5103",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MPAD6004U.01",
+            "courseCode": "MPAD6004U",
+            "courseName": "研究生综合英语",
+            "teacher": "赵梦雪",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "5103",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  10
+                ],
+                "room": "5103",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  14
+                ],
+                "room": "5103",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    8,
+                    10
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    12,
+                    14
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    8,
+                    10
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    12,
+                    14
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6481P.01",
+            "courseCode": "MPAD6481P",
+            "courseName": "公共健康管理前沿",
+            "teacher": "包巍"
+          },
+          "previous": {
+            "id": "MPAD6481P.01",
+            "courseCode": "MPAD6481P",
+            "courseName": "公共健康管理前沿",
+            "teacher": "包巍",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "2504",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MPAD6481P.01",
+            "courseCode": "MPAD6481P",
+            "courseName": "公共健康管理前沿",
+            "teacher": "包巍",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "2504",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    12
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    7,
+                    13
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6489P.01",
+            "courseCode": "MPAD6489P",
+            "courseName": "社会前沿专题讲座",
+            "teacher": "陈昱"
+          },
+          "previous": {
+            "id": "MPAD6489P.01",
+            "courseCode": "MPAD6489P",
+            "courseName": "社会前沿专题讲座",
+            "teacher": "陈昱",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "2605",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MPAD6489P.01",
+            "courseCode": "MPAD6489P",
+            "courseName": "社会前沿专题讲座",
+            "teacher": "陈昱",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  6,
+                  15
+                ],
+                "room": "2405",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    12
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    6,
+                    15
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2605",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2405",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NSEN6003P.01",
+            "courseCode": "NSEN6003P",
+            "courseName": "纳米科学与工程前沿实验",
+            "teacher": "王毅琳,范雅珣,张振,朱忠鹏,赵创奇,凤建岗,杨俊川"
+          },
+          "previous": {
+            "id": "NSEN6003P.01",
+            "courseCode": "NSEN6003P",
+            "courseName": "纳米科学与工程前沿实验",
+            "teacher": "王毅琳,范雅珣,张振,朱忠鹏,赵创奇,高寒飞,杨俊川",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  6,
+                  12
+                ],
+                "room": "纳米学院纳米科学与工程实验室",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "NSEN6003P.01",
+            "courseCode": "NSEN6003P",
+            "courseName": "纳米科学与工程前沿实验",
+            "teacher": "王毅琳,范雅珣,张振,朱忠鹏,赵创奇,凤建岗,杨俊川",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  6,
+                  12
+                ],
+                "room": "纳米学院纳米科学与工程实验室",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5,
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "王毅琳,范雅珣,张振,朱忠鹏,赵创奇,高寒飞,杨俊川",
+              "after": "王毅琳,范雅珣,张振,朱忠鹏,赵创奇,凤建岗,杨俊川"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NSTE6416P.01",
+            "courseCode": "NSTE6416P",
+            "courseName": "薄膜材料基础与应用",
+            "teacher": "廖昭亮"
+          },
+          "previous": {
+            "id": "NSTE6416P.01",
+            "courseCode": "NSTE6416P",
+            "courseName": "薄膜材料基础与应用",
+            "teacher": "廖昭亮",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A306",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A306",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "NSTE6416P.01",
+            "courseCode": "NSTE6416P",
+            "courseName": "薄膜材料基础与应用",
+            "teacher": "廖昭亮",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A306",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A306",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 25,
+              "after": 35
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NSTE7104P.01",
+            "courseCode": "NSTE7104P",
+            "courseName": "反应堆材料",
+            "teacher": "彭蕾"
+          },
+          "previous": {
+            "id": "NSTE7104P.01",
+            "courseCode": "NSTE7104P",
+            "courseName": "反应堆材料",
+            "teacher": "彭蕾",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "3A313",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "NSTE7104P.01",
+            "courseCode": "NSTE7104P",
+            "courseName": "反应堆材料",
+            "teacher": "彭蕾",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "3A313",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 90
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.01",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "陈若涵"
+          },
+          "previous": {
+            "id": "PE00001.01",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "陈若涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.01",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "陈若涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.02",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "陈若涵"
+          },
+          "previous": {
+            "id": "PE00001.02",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "陈若涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.02",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "陈若涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.03",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "陈若涵"
+          },
+          "previous": {
+            "id": "PE00001.03",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "陈若涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.03",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "陈若涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.04",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "陈若涵"
+          },
+          "previous": {
+            "id": "PE00001.04",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "陈若涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.04",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "陈若涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.05",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "胡洋"
+          },
+          "previous": {
+            "id": "PE00001.05",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "胡洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.05",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "胡洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.06",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "胡洋"
+          },
+          "previous": {
+            "id": "PE00001.06",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "胡洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.06",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "胡洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.07",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "胡洋"
+          },
+          "previous": {
+            "id": "PE00001.07",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "胡洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.07",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "胡洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.08",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李达"
+          },
+          "previous": {
+            "id": "PE00001.08",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李达",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.08",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李达",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.09",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李朴"
+          },
+          "previous": {
+            "id": "PE00001.09",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李朴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.09",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李朴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.10",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李朴"
+          },
+          "previous": {
+            "id": "PE00001.10",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李朴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.10",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李朴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.11",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李朴"
+          },
+          "previous": {
+            "id": "PE00001.11",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李朴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.11",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李朴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.13",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李少松"
+          },
+          "previous": {
+            "id": "PE00001.13",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李少松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.13",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李少松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.14",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李少松"
+          },
+          "previous": {
+            "id": "PE00001.14",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李少松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.14",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李少松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.15",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李少松"
+          },
+          "previous": {
+            "id": "PE00001.15",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李少松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.15",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李少松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.16",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "马震"
+          },
+          "previous": {
+            "id": "PE00001.16",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "马震",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.16",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "马震",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.17",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "渠思源"
+          },
+          "previous": {
+            "id": "PE00001.17",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "渠思源",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.17",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "渠思源",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.18",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "渠思源"
+          },
+          "previous": {
+            "id": "PE00001.18",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "渠思源",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.18",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "渠思源",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.19",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "渠思源"
+          },
+          "previous": {
+            "id": "PE00001.19",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "渠思源",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.19",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "渠思源",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.20",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "渠思源"
+          },
+          "previous": {
+            "id": "PE00001.20",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "渠思源",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.20",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "渠思源",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.21",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "司友志"
+          },
+          "previous": {
+            "id": "PE00001.21",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "司友志",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.21",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "司友志",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.22",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "孙劲松"
+          },
+          "previous": {
+            "id": "PE00001.22",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "孙劲松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.22",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "孙劲松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.23",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "孙劲松"
+          },
+          "previous": {
+            "id": "PE00001.23",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "孙劲松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.23",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "孙劲松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.24",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "孙劲松"
+          },
+          "previous": {
+            "id": "PE00001.24",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "孙劲松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.24",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "孙劲松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.25",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "唐莉"
+          },
+          "previous": {
+            "id": "PE00001.25",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "唐莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.25",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "唐莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.26",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "唐莉"
+          },
+          "previous": {
+            "id": "PE00001.26",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "唐莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.26",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "唐莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.27",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "唐莉"
+          },
+          "previous": {
+            "id": "PE00001.27",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "唐莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.27",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "唐莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.28",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王林"
+          },
+          "previous": {
+            "id": "PE00001.28",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.28",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.29",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王林"
+          },
+          "previous": {
+            "id": "PE00001.29",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.29",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.30",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王永"
+          },
+          "previous": {
+            "id": "PE00001.30",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王永",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.30",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王永",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.31",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "殷剑巍"
+          },
+          "previous": {
+            "id": "PE00001.31",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "殷剑巍",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.31",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "殷剑巍",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.32",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "殷剑巍"
+          },
+          "previous": {
+            "id": "PE00001.32",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "殷剑巍",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.32",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "殷剑巍",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.33",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "殷剑巍"
+          },
+          "previous": {
+            "id": "PE00001.33",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "殷剑巍",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.33",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "殷剑巍",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.35",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李达"
+          },
+          "previous": {
+            "id": "PE00001.35",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李达",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.35",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李达",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.36",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李达"
+          },
+          "previous": {
+            "id": "PE00001.36",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李达",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.36",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李达",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.37",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李朴"
+          },
+          "previous": {
+            "id": "PE00001.37",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李朴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.37",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "李朴",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.38",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "刘德海"
+          },
+          "previous": {
+            "id": "PE00001.38",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "刘德海",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.38",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "刘德海",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.39",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "刘德海"
+          },
+          "previous": {
+            "id": "PE00001.39",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "刘德海",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.39",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "刘德海",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.40",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "刘德海"
+          },
+          "previous": {
+            "id": "PE00001.40",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "刘德海",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.40",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "刘德海",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.41",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "马震"
+          },
+          "previous": {
+            "id": "PE00001.41",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "马震",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.41",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "马震",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.42",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "马震"
+          },
+          "previous": {
+            "id": "PE00001.42",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "马震",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.42",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "马震",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.43",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "马震"
+          },
+          "previous": {
+            "id": "PE00001.43",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "马震",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.43",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "马震",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.44",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "司友志"
+          },
+          "previous": {
+            "id": "PE00001.44",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "司友志",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.44",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "司友志",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.45",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "司友志"
+          },
+          "previous": {
+            "id": "PE00001.45",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "司友志",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.45",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "司友志",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.46",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "汤涛"
+          },
+          "previous": {
+            "id": "PE00001.46",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "汤涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.46",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "汤涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.47",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "汤涛"
+          },
+          "previous": {
+            "id": "PE00001.47",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "汤涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.47",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "汤涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.48",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "汤涛"
+          },
+          "previous": {
+            "id": "PE00001.48",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "汤涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.48",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "汤涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.49",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "殷剑巍"
+          },
+          "previous": {
+            "id": "PE00001.49",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "殷剑巍",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.49",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "殷剑巍",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.50",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王林"
+          },
+          "previous": {
+            "id": "PE00001.50",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.50",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.51",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王永"
+          },
+          "previous": {
+            "id": "PE00001.51",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王永",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.51",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王永",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.52",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王永"
+          },
+          "previous": {
+            "id": "PE00001.52",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王永",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.52",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "王永",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.53",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "吴成林"
+          },
+          "previous": {
+            "id": "PE00001.53",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "吴成林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.53",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "吴成林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.54",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "吴成林"
+          },
+          "previous": {
+            "id": "PE00001.54",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "吴成林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.54",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "吴成林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.55",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "吴成林"
+          },
+          "previous": {
+            "id": "PE00001.55",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "吴成林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.55",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "吴成林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.56",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖腾飞"
+          },
+          "previous": {
+            "id": "PE00001.56",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖腾飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.56",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖腾飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.57",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖腾飞"
+          },
+          "previous": {
+            "id": "PE00001.57",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖腾飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.57",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖腾飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.58",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖腾飞"
+          },
+          "previous": {
+            "id": "PE00001.58",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖腾飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.58",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖腾飞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.60",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "杨旭东"
+          },
+          "previous": {
+            "id": "PE00001.60",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "杨旭东",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.60",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "杨旭东",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.61",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "杨旭东"
+          },
+          "previous": {
+            "id": "PE00001.61",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "杨旭东",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.61",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "杨旭东",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.62",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "窦盛凯"
+          },
+          "previous": {
+            "id": "PE00001.62",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "窦盛凯",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区活动中心四楼(女生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.62",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "窦盛凯",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "东区活动中心四楼(女生)",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "东区操场(男生)",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.65",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "窦盛凯"
+          },
+          "previous": {
+            "id": "PE00001.65",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "窦盛凯",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区活动中心四楼(女生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.65",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "窦盛凯",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "东区活动中心四楼(女生)",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "东区操场(男生)",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.68",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "孙璐璐"
+          },
+          "previous": {
+            "id": "PE00001.68",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "孙璐璐",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区活动中心四楼(女生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.68",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "孙璐璐",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "东区活动中心四楼(女生)",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "东区操场(男生)",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.73",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳"
+          },
+          "previous": {
+            "id": "PE00001.73",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.73",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.74",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳"
+          },
+          "previous": {
+            "id": "PE00001.74",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.74",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.76",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳"
+          },
+          "previous": {
+            "id": "PE00001.76",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.76",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.85",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳"
+          },
+          "previous": {
+            "id": "PE00001.85",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.85",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区操场(男生)",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00001.86",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳"
+          },
+          "previous": {
+            "id": "PE00001.86",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00001.86",
+            "courseCode": "PE00001",
+            "courseName": "基础体育",
+            "teacher": "肖阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "西区操场(男生)",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00120.01",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "陈若涵"
+          },
+          "previous": {
+            "id": "PE00120.01",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "陈若涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区操场",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00120.01",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "陈若涵",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区操场",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 35
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00120.02",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "汤涛"
+          },
+          "previous": {
+            "id": "PE00120.02",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "汤涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "东区操场",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00120.02",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "汤涛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "东区操场",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 35
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00120.03",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "王林"
+          },
+          "previous": {
+            "id": "PE00120.03",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "王林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "东区操场",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00120.03",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "王林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "东区操场",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 35
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00120.04",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "王林"
+          },
+          "previous": {
+            "id": "PE00120.04",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "王林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "东区操场",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00120.04",
+            "courseCode": "PE00120",
+            "courseName": "体适能II",
+            "teacher": "王林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "东区操场",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 28,
+              "after": 35
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00146.01",
+            "courseCode": "PE00146",
+            "courseName": "自卫防身术II",
+            "teacher": "唐莉"
+          },
+          "previous": {
+            "id": "PE00146.01",
+            "courseCode": "PE00146",
+            "courseName": "自卫防身术II",
+            "teacher": "唐莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "中区搏击馆",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00146.01",
+            "courseCode": "PE00146",
+            "courseName": "自卫防身术II",
+            "teacher": "唐莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "ARTS403",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "中区搏击馆",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "中区搏击馆",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "ARTS403",
+                  "campus": "本部"
+                },
+                {
+                  "room": "中区搏击馆",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE00146.02",
+            "courseCode": "PE00146",
+            "courseName": "自卫防身术II",
+            "teacher": "唐莉"
+          },
+          "previous": {
+            "id": "PE00146.02",
+            "courseCode": "PE00146",
+            "courseName": "自卫防身术II",
+            "teacher": "唐莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "中区搏击馆",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE00146.02",
+            "courseCode": "PE00146",
+            "courseName": "自卫防身术II",
+            "teacher": "唐莉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "ARTS403",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "中区搏击馆",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "中区搏击馆",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "ARTS403",
+                  "campus": "本部"
+                },
+                {
+                  "room": "中区搏击馆",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PE1502.01",
+            "courseCode": "PE1502",
+            "courseName": "桥牌基础讲座与技巧",
+            "teacher": "郑惠南"
+          },
+          "previous": {
+            "id": "PE1502.01",
+            "courseCode": "PE1502",
+            "courseName": "桥牌基础讲座与技巧",
+            "teacher": "郑惠南",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "中体Z102",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PE1502.01",
+            "courseCode": "PE1502",
+            "courseName": "桥牌基础讲座与技巧",
+            "teacher": "郑惠南",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "5106",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "中体Z102",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "中体Z102",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "中体Z102",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PEET6402P.01",
+            "courseCode": "PEET6402P",
+            "courseName": "能源转化中的催化与传质",
+            "teacher": "李文志"
+          },
+          "previous": {
+            "id": "PEET6402P.01",
+            "courseCode": "PEET6402P",
+            "courseName": "能源转化中的催化与传质",
+            "teacher": "李文志",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3B201",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PEET6402P.01",
+            "courseCode": "PEET6402P",
+            "courseName": "能源转化中的催化与传质",
+            "teacher": "李文志",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3B201",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 120,
+              "after": 125
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PEET6404P.01",
+            "courseCode": "PEET6404P",
+            "courseName": "量热技术和热物性测定",
+            "teacher": "张海峰"
+          },
+          "previous": {
+            "id": "PEET6404P.01",
+            "courseCode": "PEET6404P",
+            "courseName": "量热技术和热物性测定",
+            "teacher": "张海峰",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A306",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A306",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PEET6404P.01",
+            "courseCode": "PEET6404P",
+            "courseName": "量热技术和热物性测定",
+            "teacher": "张海峰",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A306",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A306",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 100,
+              "after": 110
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PEET6511P.01",
+            "courseCode": "PEET6511P",
+            "courseName": "利用Matlab建筑传热建模",
+            "teacher": "王其梁"
+          },
+          "previous": {
+            "id": "PEET6511P.01",
+            "courseCode": "PEET6511P",
+            "courseName": "利用Matlab建筑传热建模",
+            "teacher": "何立群",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "3A306",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PEET6511P.01",
+            "courseCode": "PEET6511P",
+            "courseName": "利用Matlab建筑传热建模",
+            "teacher": "王其梁",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "3A306",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "何立群",
+              "after": "王其梁"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PEET7322P.01",
+            "courseCode": "PEET7322P",
+            "courseName": "新能源与可再生能源前沿讲座",
+            "teacher": "盛松伟,张亚群,王坤林,王振鹏,张宇,卢静生,马泽涛,庄新姝,宋文吉,关进安"
+          },
+          "previous": {
+            "id": "PEET7322P.01",
+            "courseCode": "PEET7322P",
+            "courseName": "新能源与可再生能源前沿讲座",
+            "teacher": "盛松伟,张亚群,王坤林,王振鹏,张宇,卢静生,马泽涛,庄新姝,宋文吉,关进安",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  4,
+                  4
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  6
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  10,
+                  10
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  12,
+                  12
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  4,
+                  4
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  6
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  10,
+                  10
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  12,
+                  12
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "PEET7322P.01",
+            "courseCode": "PEET7322P",
+            "courseName": "新能源与可再生能源前沿讲座",
+            "teacher": "盛松伟,张亚群,王坤林,王振鹏,张宇,卢静生,马泽涛,庄新姝,宋文吉,关进安",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  4,
+                  4
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  6
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  10,
+                  10
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  12,
+                  12
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  4,
+                  4
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  6
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  9,
+                  9
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  10,
+                  10
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  12,
+                  12
+                ],
+                "room": "节能环保大楼一楼党员活动室",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 35
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHIL6006P.01",
+            "courseCode": "PHIL6006P",
+            "courseName": "科技哲学研究的理论与方法",
+            "teacher": "杜晓柳,徐飞,张贵红"
+          },
+          "previous": {
+            "id": "PHIL6006P.01",
+            "courseCode": "PHIL6006P",
+            "courseName": "科技哲学研究的理论与方法",
+            "teacher": "徐飞,张贵红",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  10
+                ],
+                "room": "2307",
+                "day": 2,
+                "periods": [
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  18
+                ],
+                "room": "2307",
+                "day": 2,
+                "periods": [
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHIL6006P.01",
+            "courseCode": "PHIL6006P",
+            "courseName": "科技哲学研究的理论与方法",
+            "teacher": "杜晓柳,徐飞,张贵红",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2307",
+                "day": 2,
+                "periods": [
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "徐飞,张贵红",
+              "after": "杜晓柳,徐飞,张贵红"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHIL6301U.11",
+            "courseCode": "PHIL6301U",
+            "courseName": "工程伦理",
+            "teacher": "李文忠"
+          },
+          "previous": {
+            "id": "PHIL6301U.11",
+            "courseCode": "PHIL6301U",
+            "courseName": "工程伦理",
+            "teacher": "李文忠",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  13
+                ],
+                "room": "TH-B101",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHIL6301U.11",
+            "courseCode": "PHIL6301U",
+            "courseName": "工程伦理",
+            "teacher": "李文忠",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  13
+                ],
+                "room": "TH-B101",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 150,
+              "after": 170
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1001A.05",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "徐来林"
+          },
+          "previous": {
+            "id": "PHYS1001A.05",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "徐来林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2104",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2104",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1001A.05",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "徐来林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2104",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2104",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级203院04班",
+                "26级000院04班"
+              ],
+              "after": [
+                "26级000院04班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1001A.10",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "秦胜勇"
+          },
+          "previous": {
+            "id": "PHYS1001A.10",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "秦胜勇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5306",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5306",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1001A.10",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "秦胜勇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5306",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5306",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级203院03班"
+              ],
+              "after": [
+                "26级203院03班",
+                "26级203院04班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1001A.11",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "卫子安"
+          },
+          "previous": {
+            "id": "PHYS1001A.11",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "卫子安",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5407",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5407",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1001A.11",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "卫子安",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5407",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5407",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26级203院02班"
+              ],
+              "after": [
+                "26级203院02班",
+                "26级000院05班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1001A.12",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "陶小平"
+          },
+          "previous": {
+            "id": "PHYS1001A.12",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "陶小平",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5207",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5207",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1001A.12",
+            "courseCode": "PHYS1001A",
+            "courseName": "力学A",
+            "teacher": "陶小平",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5207",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5207",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26量子信息科学(强基)",
+                "26量子信息科技英才班T"
+              ],
+              "after": [
+                "26量子信息科学",
+                "26量子信息科学(强基)",
+                "26量子信息科技英才班T"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS5082P.01",
+            "courseCode": "PHYS5082P",
+            "courseName": "放射治疗物理原理",
+            "teacher": "杨益东,唐泽波"
+          },
+          "previous": {
+            "id": "PHYS5082P.01",
+            "courseCode": "PHYS5082P",
+            "courseName": "放射治疗物理原理",
+            "teacher": "杨益东,唐泽波",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2401",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2402",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS5082P.01",
+            "courseCode": "PHYS5082P",
+            "courseName": "放射治疗物理原理",
+            "teacher": "杨益东,唐泽波",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2401",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2402",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS6254P.02",
+            "courseCode": "PHYS6254P",
+            "courseName": "激光光谱",
+            "teacher": "武帅"
+          },
+          "previous": {
+            "id": "PHYS6254P.02",
+            "courseCode": "PHYS6254P",
+            "courseName": "激光光谱",
+            "teacher": "武帅",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "2103",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5107",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS6254P.02",
+            "courseCode": "PHYS6254P",
+            "courseName": "激光光谱",
+            "teacher": "武帅",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "2103",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5107",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 80,
+              "after": 82
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PLNT3002.01",
+            "courseCode": "PLNT3002",
+            "courseName": "行星地质学实验",
+            "teacher": "沈骥"
+          },
+          "previous": {
+            "id": "PLNT3002.01",
+            "courseCode": "PLNT3002",
+            "courseName": "行星地质学实验",
+            "teacher": "沈骥",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "东区新地空楼702室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PLNT3002.01",
+            "courseCode": "PLNT3002",
+            "courseName": "行星地质学实验",
+            "teacher": "沈骥",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  4,
+                  17
+                ],
+                "room": "东区新地空楼702室",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    4,
+                    17
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "STAT3001.01",
+            "courseCode": "STAT3001",
+            "courseName": "机器学习方法",
+            "teacher": "崔文泉"
+          },
+          "previous": {
+            "id": "STAT3001.01",
+            "courseCode": "STAT3001",
+            "courseName": "机器学习方法",
+            "teacher": "崔文泉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5306",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "STAT3001.01",
+            "courseCode": "STAT3001",
+            "courseName": "机器学习方法",
+            "teacher": "崔文泉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5306",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 68,
+              "after": 70
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "WZ003001.01",
+            "courseCode": "WZ003001",
+            "courseName": "密度泛函理论与实践",
+            "teacher": "吴红,胡伟"
+          },
+          "previous": {
+            "id": "WZ003001.01",
+            "courseCode": "WZ003001",
+            "courseName": "密度泛函理论与实践",
+            "teacher": "吴红,胡伟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "线上授课",
+                "day": 2,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "线上授课",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "WZ003001.01",
+            "courseCode": "WZ003001",
+            "courseName": "密度泛函理论与实践",
+            "teacher": "吴红,胡伟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2303",
+                "day": 2,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  16
+                ],
+                "room": "2303",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "线上授课",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2303",
+                  "campus": "本部"
+                }
+              ]
             }
           ]
         }

--- a/public/data/semesters/2026-summer/courses.json
+++ b/public/data/semesters/2026-summer/courses.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-22T11:02:46Z",
+  "generatedAt": "2026-08-31T07:14:01Z",
   "source": {
     "url": "https://catalog.ustc.edu.cn/query/lesson",
     "semesterId": 441
@@ -1140,7 +1140,7 @@
       "examType": "大作业（论文、报告、项目或作品等）",
       "grading": "百分制",
       "undergradShared": false,
-      "enrolled": 12,
+      "enrolled": 11,
       "capacity": 12,
       "classes": [
         "24大气科学"
@@ -2713,7 +2713,7 @@
       "examType": "大作业（论文、报告、项目或作品等）",
       "grading": "百分制",
       "undergradShared": false,
-      "enrolled": 16,
+      "enrolled": 20,
       "capacity": 35,
       "classes": [
         "24信息科技英才班T"

--- a/public/data/semesters/index.json
+++ b/public/data/semesters/index.json
@@ -6,7 +6,7 @@
       "key": "2026-fall",
       "name": "2026年秋季学期",
       "file": "2026-fall/courses.json",
-      "revision": "3d7a2aa43cda57c97bdd58c89ba8f88ef666876487e9e31ab9f0679a6fa9a5bf",
+      "revision": "3ff1ca8c9f5299e70f9efc86a9c80b474aa9c525bf833b1b9637334454bd4716",
       "updatesFile": "2026-fall/updates.json"
     },
     {


### PR DESCRIPTION
## 内容

按 [MAINTENANCE.md](MAINTENANCE.md) §1 同步学期开课数据，执行 `sync_semester_courses.ps1` 抓取 USTC 教务最新课堂详情并自动 `validate-lessons --all`。

## 变更

| 学期 | revision | 变更概要 |
|---|---|---|
| 2026-fall | `3d7a2aa4…` → `3ff1ca8c…` | **新增 11 / 移除 9 / 修改 300**，`updates.json` 追加新 entry |
| 2026-summer | 不变（幂等） | 仅 `generatedAt`/`enrolled` 等易变字段刷新 |

## 验证

- ✅ `validate-lessons --all` 通过（`scheduled_courses == raw_schedule_non_empty`：fall 2437/2437，summer 64/64，时间表解析零失败）
- ✅ revision 四处一致（`index.json` = `courses.json` = `updates.json.currentRevision` = 最新 entry.revision）
- ✅ `defaultSemester` 保持 `2026-fall`
- ✅ 纯数据更新，前端代码 / `APP_RELEASES` 无需改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)