### PR TITLE
data: refresh semester courses (2026-09-14)

### DIFF
--- a/public/data/semesters/2026-fall/updates.json
+++ b/public/data/semesters/2026-fall/updates.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "semesterKey": "2026-fall",
-  "currentRevision": "3ff1ca8c9f5299e70f9efc86a9c80b474aa9c525bf833b1b9637334454bd4716",
+  "currentRevision": "ba1b7ac337294a25f8bcf617f4fecee3b9ec838d8154ecd63133e98ad2240946",
   "entries": [
     {
       "id": "2026-fall:c0cbaf189652cc27",
@@ -213562,6 +213562,25895 @@
                   "campus": "本部"
                 }
               ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2026-fall:ba1b7ac337294a25",
+      "revision": "ba1b7ac337294a25f8bcf617f4fecee3b9ec838d8154ecd63133e98ad2240946",
+      "previousRevision": "3ff1ca8c9f5299e70f9efc86a9c80b474aa9c525bf833b1b9637334454bd4716",
+      "publishedAt": "2026-09-02T10:00:11Z",
+      "summary": {
+        "added": 96,
+        "removed": 13,
+        "modified": 194
+      },
+      "added": [
+        {
+          "id": "011044.02",
+          "courseCode": "011044",
+          "courseName": "计算机导论",
+          "teacher": "孙广中",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                11
+              ],
+              "room": "3C101",
+              "day": 2,
+              "periods": [
+                1,
+                2
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "EE4701.03",
+          "courseCode": "EE4701",
+          "courseName": "信息科研创新实践(H)",
+          "teacher": "张结",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "GT-B101",
+              "day": 2,
+              "periods": [
+                11,
+                12
+              ],
+              "campus": "高新区"
+            }
+          ]
+        },
+        {
+          "id": "FL1012.01",
+          "courseCode": "FL1012",
+          "courseName": "大学综合英语（免修）",
+          "teacher": "",
+          "level": "本科",
+          "schedule": []
+        },
+        {
+          "id": "FL1100.01",
+          "courseCode": "FL1100",
+          "courseName": "大学英语",
+          "teacher": "",
+          "level": "本科",
+          "schedule": []
+        },
+        {
+          "id": "FL1115A.05",
+          "courseCode": "FL1115A",
+          "courseName": "高级英语口语",
+          "teacher": "Matthew Bell",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                10,
+                17
+              ],
+              "room": "2205",
+              "day": 5,
+              "periods": [
+                1,
+                2
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "FL1115A.06",
+          "courseCode": "FL1115A",
+          "courseName": "高级英语口语",
+          "teacher": "Samuel GIBSON",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                9
+              ],
+              "room": "2205",
+              "day": 1,
+              "periods": [
+                6,
+                7
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "FS1001.4F",
+          "courseCode": "FS1001",
+          "courseName": "“科学与社会”研讨课",
+          "teacher": "陈可江",
+          "level": "本科",
+          "schedule": []
+        },
+        {
+          "id": "FS1001.4G",
+          "courseCode": "FS1001",
+          "courseName": "“科学与社会”研讨课",
+          "teacher": "汪玉洁",
+          "level": "本科",
+          "schedule": []
+        },
+        {
+          "id": "FS1001.4H",
+          "courseCode": "FS1001",
+          "courseName": "“科学与社会”研讨课",
+          "teacher": "郭武",
+          "level": "本科",
+          "schedule": []
+        },
+        {
+          "id": "FS1001.5F",
+          "courseCode": "FS1001",
+          "courseName": "“科学与社会”研讨课",
+          "teacher": "程存峰",
+          "level": "本科",
+          "schedule": []
+        },
+        {
+          "id": "FS1001.5G",
+          "courseCode": "FS1001",
+          "courseName": "“科学与社会”研讨课",
+          "teacher": "周经纬",
+          "level": "本科",
+          "schedule": []
+        },
+        {
+          "id": "FS1001.5H",
+          "courseCode": "FS1001",
+          "courseName": "“科学与社会”研讨课",
+          "teacher": "李洪良",
+          "level": "本科",
+          "schedule": []
+        },
+        {
+          "id": "FS1001.5I",
+          "courseCode": "FS1001",
+          "courseName": "“科学与社会”研讨课",
+          "teacher": "梁福田",
+          "level": "本科",
+          "schedule": []
+        },
+        {
+          "id": "MARX1014.25",
+          "courseCode": "MARX1014",
+          "courseName": "习近平新时代中国特色社会主义思想概论",
+          "teacher": "褚建勋,魏荣",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                18
+              ],
+              "room": "3C303",
+              "day": 5,
+              "periods": [
+                8,
+                9,
+                10
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "MARX6102U.66",
+          "courseCode": "MARX6102U",
+          "courseName": "新时代中国特色社会主义理论与实践",
+          "teacher": "虎旭昕",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                14,
+                18
+              ],
+              "room": "2-203",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MARX6102U.67",
+          "courseCode": "MARX6102U",
+          "courseName": "新时代中国特色社会主义理论与实践",
+          "teacher": "丁浩",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "1-201",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                7,
+                9
+              ],
+              "room": "1-201",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MARX6102U.68",
+          "courseCode": "MARX6102U",
+          "courseName": "新时代中国特色社会主义理论与实践",
+          "teacher": "刘海龙",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "3-401",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                15,
+                15
+              ],
+              "room": "3-401",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "3-401",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "3-401",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MARX6102U.69",
+          "courseCode": "MARX6102U",
+          "courseName": "新时代中国特色社会主义理论与实践",
+          "teacher": "刘海龙",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                13,
+                13
+              ],
+              "room": "1-101",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                17,
+                17
+              ],
+              "room": "1-101",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                15,
+                15
+              ],
+              "room": "1-101",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                19,
+                19
+              ],
+              "room": "1-101",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MARX6102U.70",
+          "courseCode": "MARX6102U",
+          "courseName": "新时代中国特色社会主义理论与实践",
+          "teacher": "陈海超",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "2-202",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                4,
+                4
+              ],
+              "room": "2-202",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                9,
+                9
+              ],
+              "room": "2-202",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                17,
+                17
+              ],
+              "room": "2-202",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MARX6102U.71",
+          "courseCode": "MARX6102U",
+          "courseName": "新时代中国特色社会主义理论与实践",
+          "teacher": "宋怡",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                5
+              ],
+              "room": "1-301",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                7,
+                7
+              ],
+              "room": "1-301",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6001U.02",
+          "courseCode": "MBAD6001U",
+          "courseName": "商务英语",
+          "teacher": "汪滔",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                3
+              ],
+              "room": "1-301",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                6,
+                7
+              ],
+              "room": "1-301",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6001U.03",
+          "courseCode": "MBAD6001U",
+          "courseName": "商务英语",
+          "teacher": "陶伟",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                13,
+                16
+              ],
+              "room": "1-102",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6001U.04",
+          "courseCode": "MBAD6001U",
+          "courseName": "商务英语",
+          "teacher": "陈纪梁",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "2-202",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                8
+              ],
+              "room": "2-202",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                12,
+                12
+              ],
+              "room": "2-202",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "2-202",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6001U.05",
+          "courseCode": "MBAD6001U",
+          "courseName": "商务英语",
+          "teacher": "陈纪梁",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "1-101",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                7,
+                9
+              ],
+              "room": "1-101",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6001U.06",
+          "courseCode": "MBAD6001U",
+          "courseName": "商务英语",
+          "teacher": "陈纪梁",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                10,
+                10
+              ],
+              "room": "上研院3-401",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                12,
+                12
+              ],
+              "room": "上研院3-401",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                11,
+                11
+              ],
+              "room": "上研院3-401",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "上研院3-401",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6001U.07",
+          "courseCode": "MBAD6001U",
+          "courseName": "商务英语",
+          "teacher": "陈纪梁",
+          "level": "研究生",
+          "schedule": []
+        },
+        {
+          "id": "MBAD6001U.08",
+          "courseCode": "MBAD6001U",
+          "courseName": "商务英语",
+          "teacher": "汪滔",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                9,
+                12
+              ],
+              "room": "1-302",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6002U.01",
+          "courseCode": "MBAD6002U",
+          "courseName": "商务伦理",
+          "teacher": "张增田",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                3
+              ],
+              "room": "1-301",
+              "day": 1,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6002U.02",
+          "courseCode": "MBAD6002U",
+          "courseName": "商务伦理",
+          "teacher": "张增田",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                8,
+                9
+              ],
+              "room": "1-302",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6002U.03",
+          "courseCode": "MBAD6002U",
+          "courseName": "商务伦理",
+          "teacher": "刘庭",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                19,
+                19
+              ],
+              "room": "2-202",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                19,
+                19
+              ],
+              "room": "2-202",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6002U.04",
+          "courseCode": "MBAD6002U",
+          "courseName": "商务伦理",
+          "teacher": "张增田",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                8,
+                8
+              ],
+              "room": "3-402",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                9,
+                9
+              ],
+              "room": "3--402",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6004P.02",
+          "courseCode": "MBAD6004P",
+          "courseName": "数据、模型与决策",
+          "teacher": "冯群强",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "1-101",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                10
+              ],
+              "room": "1-101",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6004P.03",
+          "courseCode": "MBAD6004P",
+          "courseName": "数据、模型与决策",
+          "teacher": "言小明",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "1-102",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                7,
+                9
+              ],
+              "room": "1-102",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6004P.04",
+          "courseCode": "MBAD6004P",
+          "courseName": "数据、模型与决策",
+          "teacher": "刘素婷",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                13,
+                16
+              ],
+              "room": "1-301",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6004P.05",
+          "courseCode": "MBAD6004P",
+          "courseName": "数据、模型与决策",
+          "teacher": "姬翔",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                18,
+                18
+              ],
+              "room": "1-201",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "1-201",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "1-201",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                17,
+                17
+              ],
+              "room": "1-201",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6004P.06",
+          "courseCode": "MBAD6004P",
+          "courseName": "数据、模型与决策",
+          "teacher": "吴杰",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "A105",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "A105",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                15,
+                15
+              ],
+              "room": "A105",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                17,
+                17
+              ],
+              "room": "A105",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6004P.07",
+          "courseCode": "MBAD6004P",
+          "courseName": "数据、模型与决策",
+          "teacher": "吴杰",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "2-101",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                7,
+                8
+              ],
+              "room": "2-101",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "2-101",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                8
+              ],
+              "room": "2-101",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6004P.08",
+          "courseCode": "MBAD6004P",
+          "courseName": "数据、模型与决策",
+          "teacher": "陈智新",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                12,
+                12
+              ],
+              "room": "2-202",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "2-202",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                19,
+                19
+              ],
+              "room": "2-202",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                20,
+                20
+              ],
+              "room": "2-202",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6004P.09",
+          "courseCode": "MBAD6004P",
+          "courseName": "数据、模型与决策",
+          "teacher": "刘彦",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                8,
+                11
+              ],
+              "room": "2-102",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6005P.01",
+          "courseCode": "MBAD6005P",
+          "courseName": "企业决策模拟",
+          "teacher": "查勇",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                10,
+                11
+              ],
+              "room": "1-301",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                13,
+                13
+              ],
+              "room": "1-301",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "1-301",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6005P.02",
+          "courseCode": "MBAD6005P",
+          "courseName": "企业决策模拟",
+          "teacher": "查勇",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                4,
+                5
+              ],
+              "room": "1-302",
+              "day": 2,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                7,
+                7
+              ],
+              "room": "1-302",
+              "day": 2,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                10,
+                10
+              ],
+              "room": "1-302",
+              "day": 2,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6005P.03",
+          "courseCode": "MBAD6005P",
+          "courseName": "企业决策模拟",
+          "teacher": "许传永",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "2-202",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                8
+              ],
+              "room": "2-202",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                12,
+                12
+              ],
+              "room": "2-202",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "2-202",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6005P.04",
+          "courseCode": "MBAD6005P",
+          "courseName": "企业决策模拟",
+          "teacher": "许传永",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                10,
+                10
+              ],
+              "room": "1-201",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                13,
+                15
+              ],
+              "room": "1-201",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6005P.05",
+          "courseCode": "MBAD6005P",
+          "courseName": "企业决策模拟",
+          "teacher": "查勇",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                9,
+                9
+              ],
+              "room": "A105",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                13,
+                13
+              ],
+              "room": "A105",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                10,
+                10
+              ],
+              "room": "A106",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "A106",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6007P.02",
+          "courseCode": "MBAD6007P",
+          "courseName": "管理经济学",
+          "teacher": "郭新帅",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                4
+              ],
+              "room": "1-301",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                6,
+                6
+              ],
+              "room": "1-301",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6007P.03",
+          "courseCode": "MBAD6007P",
+          "courseName": "管理经济学",
+          "teacher": "李喻天",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                5
+              ],
+              "room": "1-302",
+              "day": 1,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6007P.04",
+          "courseCode": "MBAD6007P",
+          "courseName": "管理经济学",
+          "teacher": "叶五一",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "1-102",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                9,
+                11
+              ],
+              "room": "1-102",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "1-102",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6007P.05",
+          "courseCode": "MBAD6007P",
+          "courseName": "管理经济学",
+          "teacher": "李勇",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "1-201",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                10
+              ],
+              "room": "1-201",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6007P.06",
+          "courseCode": "MBAD6007P",
+          "courseName": "管理经济学",
+          "teacher": "李勇军",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                8,
+                10
+              ],
+              "room": "2-101",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                13,
+                13
+              ],
+              "room": "2-101",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                15,
+                15
+              ],
+              "room": "2-101",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6008P.02",
+          "courseCode": "MBAD6008P",
+          "courseName": "战略管理",
+          "teacher": "古继宝",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                1,
+                2
+              ],
+              "room": "1-301",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                7,
+                8
+              ],
+              "room": "1-301",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6008P.04",
+          "courseCode": "MBAD6008P",
+          "courseName": "战略管理",
+          "teacher": "赵征",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                17,
+                18
+              ],
+              "room": "3-401",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                17,
+                18
+              ],
+              "room": "3-401",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6009P.02",
+          "courseCode": "MBAD6009P",
+          "courseName": "组织行为学",
+          "teacher": "毕功兵",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "2-202",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                8
+              ],
+              "room": "2-202",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "2-202",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                8
+              ],
+              "room": "2-202",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6009P.03",
+          "courseCode": "MBAD6009P",
+          "courseName": "组织行为学",
+          "teacher": "杨小平",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "1-101",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "1-101",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                17,
+                18
+              ],
+              "room": "1-101",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6009P.04",
+          "courseCode": "MBAD6009P",
+          "courseName": "组织行为学",
+          "teacher": "毕功兵",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "2-102",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                9,
+                9
+              ],
+              "room": "2-102",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "2-102",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                9,
+                9
+              ],
+              "room": "2-102",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6009P.05",
+          "courseCode": "MBAD6009P",
+          "courseName": "组织行为学",
+          "teacher": "杨小平",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                5
+              ],
+              "room": "1-301",
+              "day": 2,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6009P.06",
+          "courseCode": "MBAD6009P",
+          "courseName": "组织行为学",
+          "teacher": "吴剑琳",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                4
+              ],
+              "room": "1-302",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                6,
+                6
+              ],
+              "room": "1-302",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6009P.07",
+          "courseCode": "MBAD6009P",
+          "courseName": "组织行为学",
+          "teacher": "毕功兵",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                17,
+                17
+              ],
+              "room": "A105",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                19,
+                19
+              ],
+              "room": "A105",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                18,
+                18
+              ],
+              "room": "A105",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                20,
+                20
+              ],
+              "room": "A105",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6010P.02",
+          "courseCode": "MBAD6010P",
+          "courseName": "营销管理",
+          "teacher": "秦进",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                9,
+                10
+              ],
+              "room": "1-301",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                13,
+                13
+              ],
+              "room": "1-301",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                15,
+                15
+              ],
+              "room": "1-301",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6010P.03",
+          "courseCode": "MBAD6010P",
+          "courseName": "营销管理",
+          "teacher": "张圣亮",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                1,
+                1
+              ],
+              "room": "1-302",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                9
+              ],
+              "room": "1-302",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                8
+              ],
+              "room": "1-302",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6010P.04",
+          "courseCode": "MBAD6010P",
+          "courseName": "营销管理",
+          "teacher": "孙浩",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                11,
+                14
+              ],
+              "room": "1-302",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "1-302",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6011P.02",
+          "courseCode": "MBAD6011P",
+          "courseName": "会计学",
+          "teacher": "张瑞稳",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                8,
+                11
+              ],
+              "room": "1-301",
+              "day": 4,
+              "periods": [
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "10:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6011P.03",
+          "courseCode": "MBAD6011P",
+          "courseName": "会计学",
+          "teacher": "张瑞稳",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                12,
+                15
+              ],
+              "room": "1-302",
+              "day": 2,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6011P.04",
+          "courseCode": "MBAD6011P",
+          "courseName": "会计学",
+          "teacher": "许立新",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                7,
+                7
+              ],
+              "room": "A105",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                10,
+                10
+              ],
+              "room": "A105",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                8
+              ],
+              "room": "A105",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                11,
+                11
+              ],
+              "room": "A105",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6011P.05",
+          "courseCode": "MBAD6011P",
+          "courseName": "会计学",
+          "teacher": "曹崇延",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "2-101",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "2-101",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                9,
+                11
+              ],
+              "room": "2-101",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6012P.01",
+          "courseCode": "MBAD6012P",
+          "courseName": "财务管理",
+          "teacher": "许立新",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                11,
+                11
+              ],
+              "room": "2-202",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                15,
+                15
+              ],
+              "room": "2-202",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "1-302",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                2,
+                3
+              ],
+              "room": "1-302",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                9,
+                9
+              ],
+              "room": "1-302",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                20,
+                20
+              ],
+              "room": "1-302",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6012P.02",
+          "courseCode": "MBAD6012P",
+          "courseName": "财务管理",
+          "teacher": "张瑞稳",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                1,
+                1
+              ],
+              "room": "2-201",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                8
+              ],
+              "room": "2-201",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "2-201",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                8
+              ],
+              "room": "2-201",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6012P.03",
+          "courseCode": "MBAD6012P",
+          "courseName": "财务管理",
+          "teacher": "曹崇延",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                7,
+                10
+              ],
+              "room": "2-203",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6013P.02",
+          "courseCode": "MBAD6013P",
+          "courseName": "人力资源管理",
+          "teacher": "朱宁",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "2-202",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5
+              ],
+              "startTime": "08:30",
+              "endTime": "11:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                7,
+                7
+              ],
+              "room": "2-202",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                11,
+                11
+              ],
+              "room": "2-202",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                15,
+                15
+              ],
+              "room": "2-202",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6013P.03",
+          "courseCode": "MBAD6013P",
+          "courseName": "人力资源管理",
+          "teacher": "朱宁",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                9,
+                10
+              ],
+              "room": "1-301",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                12,
+                12
+              ],
+              "room": "1-301",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "1-301",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6013P.04",
+          "courseCode": "MBAD6013P",
+          "courseName": "人力资源管理",
+          "teacher": "朱宁",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                8,
+                11
+              ],
+              "room": "1-302",
+              "day": 1,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6013P.06",
+          "courseCode": "MBAD6013P",
+          "courseName": "人力资源管理",
+          "teacher": "朱宁",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "2-201",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                7,
+                7
+              ],
+              "room": "2-201",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                9,
+                9
+              ],
+              "room": "2-201",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "2-201",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6014P.01",
+          "courseCode": "MBAD6014P",
+          "courseName": "运营管理",
+          "teacher": "杨锋",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "2-202",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                7,
+                7
+              ],
+              "room": "2-202",
+              "day": 4,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                15,
+                15
+              ],
+              "room": "2-202",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                18,
+                18
+              ],
+              "room": "2-202",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6014P.02",
+          "courseCode": "MBAD6014P",
+          "courseName": "运营管理",
+          "teacher": "丁斌",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                10,
+                10
+              ],
+              "room": "3-401",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "3-401",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                11,
+                11
+              ],
+              "room": "3-401",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                15,
+                15
+              ],
+              "room": "3-401",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6402P.01",
+          "courseCode": "MBAD6402P",
+          "courseName": "证券投资",
+          "teacher": "时建龙",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                13,
+                13
+              ],
+              "room": "A107",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "A107",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "A107",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                17,
+                17
+              ],
+              "room": "A107",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6410P.01",
+          "courseCode": "MBAD6410P",
+          "courseName": "领导方法与艺术",
+          "teacher": "陈丹",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                1,
+                2
+              ],
+              "room": "2-203",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "2-203",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                8
+              ],
+              "room": "2-203",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6414P.02",
+          "courseCode": "MBAD6414P",
+          "courseName": "消费者行为学",
+          "teacher": "黄茜",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                13,
+                16
+              ],
+              "room": "2-201",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6416P.01",
+          "courseCode": "MBAD6416P",
+          "courseName": "网络营销",
+          "teacher": "王德瑞",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                2
+              ],
+              "room": "2-202",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "2-202",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "2-202",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                19,
+                19
+              ],
+              "room": "2-202",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6416P.02",
+          "courseCode": "MBAD6416P",
+          "courseName": "网络营销",
+          "teacher": "张鑫",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                6,
+                6
+              ],
+              "room": "1-301",
+              "day": 2,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                6,
+                6
+              ],
+              "room": "1-301",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                4,
+                4
+              ],
+              "room": "1-301",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13
+              ],
+              "startTime": "08:30",
+              "endTime": "21:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                5,
+                5
+              ],
+              "room": "1-301",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6416P.03",
+          "courseCode": "MBAD6416P",
+          "courseName": "网络营销",
+          "teacher": "马步青",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                9,
+                11
+              ],
+              "room": "2-201",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "2-201",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6418P.02",
+          "courseCode": "MBAD6418P",
+          "courseName": "创新与创业管理",
+          "teacher": "崔志坚",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                15,
+                18
+              ],
+              "room": "2-102",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6419P.01",
+          "courseCode": "MBAD6419P",
+          "courseName": "项目管理原理与实务",
+          "teacher": "周垂日",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                2,
+                3
+              ],
+              "room": "1-301",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                8,
+                9
+              ],
+              "room": "1-301",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6427P.01",
+          "courseCode": "MBAD6427P",
+          "courseName": "博弈论",
+          "teacher": "焦传亚",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                3,
+                3
+              ],
+              "room": "2-203",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                9,
+                11
+              ],
+              "room": "2-203",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6427P.02",
+          "courseCode": "MBAD6427P",
+          "courseName": "博弈论",
+          "teacher": "程丽红",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "1-301",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                17,
+                17
+              ],
+              "room": "1-301",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "1-301",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "1-301",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6427P.03",
+          "courseCode": "MBAD6427P",
+          "courseName": "博弈论",
+          "teacher": "王姚磊",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                17,
+                17
+              ],
+              "room": "1-301",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                11,
+                13,
+                15,
+                17
+              ],
+              "room": "1-301",
+              "day": 5,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6427P.04",
+          "courseCode": "MBAD6427P",
+          "courseName": "博弈论",
+          "teacher": "樊彧",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                14,
+                18
+              ],
+              "room": "1-302",
+              "day": 1,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6428P.01",
+          "courseCode": "MBAD6428P",
+          "courseName": "供应链管理",
+          "teacher": "何荣川",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                6,
+                6
+              ],
+              "room": "1-201",
+              "day": 2,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                6,
+                6
+              ],
+              "room": "1-201",
+              "day": 3,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                4,
+                4
+              ],
+              "room": "1-201",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10,
+                11,
+                12,
+                13
+              ],
+              "startTime": "08:30",
+              "endTime": "21:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                5,
+                5
+              ],
+              "room": "1-201",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "MBAD6429P.01",
+          "courseCode": "MBAD6429P",
+          "courseName": "大模型企业应用与管理实践",
+          "teacher": "高超越",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                10,
+                10
+              ],
+              "room": "1-302",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                13,
+                14
+              ],
+              "room": "1-302",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                14,
+                14
+              ],
+              "room": "1-302",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "PE00106.08",
+          "courseCode": "PE00106",
+          "courseName": "足球II",
+          "teacher": "渠思源",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                1,
+                18
+              ],
+              "room": "西区操场",
+              "day": 5,
+              "periods": [
+                1,
+                2
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "PE00108.04",
+          "courseCode": "PE00108",
+          "courseName": "乒乓球II",
+          "teacher": "孙劲松",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                1,
+                18
+              ],
+              "room": "西区活动中心",
+              "day": 5,
+              "periods": [
+                8,
+                9
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "PE00110.10",
+          "courseCode": "PE00110",
+          "courseName": "羽毛球II",
+          "teacher": "司友志",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                1,
+                18
+              ],
+              "room": "东区羽毛球馆",
+              "day": 3,
+              "periods": [
+                1,
+                2
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "PE00120.05",
+          "courseCode": "PE00120",
+          "courseName": "体适能II",
+          "teacher": "肖阳",
+          "level": "本科",
+          "schedule": [
+            {
+              "weeks": [
+                1,
+                18
+              ],
+              "room": "西区操场",
+              "day": 2,
+              "periods": [
+                8,
+                9
+              ],
+              "campus": "本部"
+            }
+          ]
+        },
+        {
+          "id": "PHIL6101U.29",
+          "courseCode": "PHIL6101U",
+          "courseName": "自然辩证法概论",
+          "teacher": "郭育松,刘立",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                10,
+                10
+              ],
+              "room": "1-102",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "PHIL6101U.30",
+          "courseCode": "PHIL6101U",
+          "courseName": "自然辩证法概论",
+          "teacher": "谭小琴",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "2-101",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                17,
+                17
+              ],
+              "room": "2-101",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "PHIL6101U.31",
+          "courseCode": "PHIL6101U",
+          "courseName": "自然辩证法概论",
+          "teacher": "刘立,王晓燕",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "2-102",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                17,
+                17
+              ],
+              "room": "2-102",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "PHIL6101U.32",
+          "courseCode": "PHIL6101U",
+          "courseName": "自然辩证法概论",
+          "teacher": "谭小琴",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                15,
+                15
+              ],
+              "room": "A105",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                16,
+                16
+              ],
+              "room": "A105",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        },
+        {
+          "id": "PHIL6101U.33",
+          "courseCode": "PHIL6101U",
+          "courseName": "自然辩证法概论",
+          "teacher": "谭小琴",
+          "level": "研究生",
+          "schedule": [
+            {
+              "weeks": [
+                9,
+                9
+              ],
+              "room": "3-401",
+              "day": 6,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            },
+            {
+              "weeks": [
+                10,
+                10
+              ],
+              "room": "3-401",
+              "day": 7,
+              "periods": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9,
+                10
+              ],
+              "startTime": "08:30",
+              "endTime": "17:45",
+              "campus": "其他"
+            }
+          ]
+        }
+      ],
+      "removed": [
+        {
+          "course": {
+            "id": "003044.01",
+            "courseCode": "003044",
+            "courseName": "物理化学实验",
+            "teacher": "刘红,王晓葵,金邦坤,吴强华,雷璇,冯红艳,吴红,李红春,孟征",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "东区环资楼501-504",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "005111e.01",
+            "courseCode": "005111e",
+            "courseName": "多相流体动力学(英）",
+            "teacher": "黄海波",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "3A209",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "007112.01",
+            "courseCode": "007112",
+            "courseName": "普通地球化学",
+            "teacher": "魏春生",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2302",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "015722.01",
+            "courseCode": "015722",
+            "courseName": "人力资源管理",
+            "teacher": "朱宁",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2303",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "MBAD6013P.01",
+              "courseCode": "MBAD6013P",
+              "courseName": "人力资源管理",
+              "teacher": "安南",
+              "level": "研究生",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    4
+                  ],
+                  "room": "2606",
+                  "day": 2,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:40",
+                  "endTime": "12:00",
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    6,
+                    7
+                  ],
+                  "room": "2606",
+                  "day": 2,
+                  "periods": [
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:40",
+                  "endTime": "12:00",
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "room": "2607",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:15",
+                  "campus": "本部"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "room": "2607",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:15",
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "MBAD6013P.02",
+              "courseCode": "MBAD6013P",
+              "courseName": "人力资源管理",
+              "teacher": "朱宁",
+              "level": "研究生",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "room": "2-202",
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "11:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "room": "2-202",
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "room": "2-202",
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "room": "2-202",
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "MBAD6013P.03",
+              "courseCode": "MBAD6013P",
+              "courseName": "人力资源管理",
+              "teacher": "朱宁",
+              "level": "研究生",
+              "schedule": [
+                {
+                  "weeks": [
+                    9,
+                    10
+                  ],
+                  "room": "1-301",
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    12,
+                    12
+                  ],
+                  "room": "1-301",
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    14,
+                    14
+                  ],
+                  "room": "1-301",
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "MBAD6013P.04",
+              "courseCode": "MBAD6013P",
+              "courseName": "人力资源管理",
+              "teacher": "朱宁",
+              "level": "研究生",
+              "schedule": [
+                {
+                  "weeks": [
+                    8,
+                    11
+                  ],
+                  "room": "1-302",
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "MBAD6013P.06",
+              "courseCode": "MBAD6013P",
+              "courseName": "人力资源管理",
+              "teacher": "朱宁",
+              "level": "研究生",
+              "schedule": [
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "room": "2-201",
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "room": "2-201",
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    9,
+                    9
+                  ],
+                  "room": "2-201",
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    3,
+                    3
+                  ],
+                  "room": "2-201",
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "016116.01",
+            "courseCode": "016116",
+            "courseName": "财务管理",
+            "teacher": "曹崇延",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2401",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "MBAD6012P.01",
+              "courseCode": "MBAD6012P",
+              "courseName": "财务管理",
+              "teacher": "许立新",
+              "level": "研究生",
+              "schedule": [
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "room": "2-202",
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "room": "2-202",
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "room": "1-302",
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "room": "1-302",
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    9,
+                    9
+                  ],
+                  "room": "1-302",
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    20,
+                    20
+                  ],
+                  "room": "1-302",
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "MBAD6012P.02",
+              "courseCode": "MBAD6012P",
+              "courseName": "财务管理",
+              "teacher": "张瑞稳",
+              "level": "研究生",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "room": "2-201",
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    8,
+                    8
+                  ],
+                  "room": "2-201",
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "room": "2-201",
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                },
+                {
+                  "weeks": [
+                    8,
+                    8
+                  ],
+                  "room": "2-201",
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                }
+              ]
+            },
+            {
+              "id": "MBAD6012P.03",
+              "courseCode": "MBAD6012P",
+              "courseName": "财务管理",
+              "teacher": "曹崇延",
+              "level": "研究生",
+              "schedule": [
+                {
+                  "weeks": [
+                    7,
+                    10
+                  ],
+                  "room": "2-203",
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "17:45",
+                  "campus": "其他"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "020015.01",
+            "courseCode": "020015",
+            "courseName": "高分子物理实验",
+            "teacher": "肖石燕",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  16
+                ],
+                "room": "环资楼",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "206709.01",
+            "courseCode": "206709",
+            "courseName": "无机化学II(H)",
+            "teacher": "茅瓅波",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "2505",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  10
+                ],
+                "room": "2505",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "206710.01",
+            "courseCode": "206710",
+            "courseName": "化学生物学(H)",
+            "teacher": "袁月,马明明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  12
+                ],
+                "room": "2505",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  17
+                ],
+                "room": "2505",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  12
+                ],
+                "room": "2505",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  17
+                ],
+                "room": "2505",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "ME4033.01",
+            "courseCode": "ME4033",
+            "courseName": "医疗仪器设计",
+            "teacher": "徐晓嵘",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  11
+                ],
+                "room": "3A106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  11
+                ],
+                "room": "3A106",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "ME4701.01",
+            "courseCode": "ME4701",
+            "courseName": "力学工程问题",
+            "teacher": "吴恒安",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A104",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "NSE4001.01",
+            "courseCode": "NSE4001",
+            "courseName": "计算中子学",
+            "teacher": "徐榭,胡国军",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  17,
+                  18
+                ],
+                "room": "3A107",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  6
+                ],
+                "room": "3A107",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  18
+                ],
+                "room": "3A107",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "3A107",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  18,
+                  18
+                ],
+                "room": "3A107",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "NSE4014.01",
+            "courseCode": "NSE4014",
+            "courseName": "放射分析化学",
+            "teacher": "苗庆庆",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "3A203",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": []
+        },
+        {
+          "course": {
+            "id": "PHYS1003B.06",
+            "courseCode": "PHYS1003B",
+            "courseName": "光学B",
+            "teacher": "王轶韬",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2304",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "replacementCandidates": [
+            {
+              "id": "PHYS1003B.01",
+              "courseCode": "PHYS1003B",
+              "courseName": "光学B",
+              "teacher": "席铮",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5503",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003B.02",
+              "courseCode": "PHYS1003B",
+              "courseName": "光学B",
+              "teacher": "银振强",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5107",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003B.03",
+              "courseCode": "PHYS1003B",
+              "courseName": "光学B",
+              "teacher": "姜继安",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "2103",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003B.04",
+              "courseCode": "PHYS1003B",
+              "courseName": "光学B",
+              "teacher": "何海燕",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "2210",
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            },
+            {
+              "id": "PHYS1003B.05",
+              "courseCode": "PHYS1003B",
+              "courseName": "光学B",
+              "teacher": "孙凯",
+              "level": "本科",
+              "schedule": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "room": "5106",
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "modified": [
+        {
+          "course": {
+            "id": "001675f.01",
+            "courseCode": "001675f",
+            "courseName": "泛函分析(法)",
+            "teacher": "Gabriel Dospinescu,沈舜麟"
+          },
+          "previous": {
+            "id": "001675f.01",
+            "courseCode": "001675f",
+            "courseName": "泛函分析(法)",
+            "teacher": "Gabriel Dospinescu,沈舜麟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "5507",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "5507",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "001675f.01",
+            "courseCode": "001675f",
+            "courseName": "泛函分析(法)",
+            "teacher": "Gabriel Dospinescu,沈舜麟",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5507",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  9
+                ],
+                "room": "5507",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "5507",
+                "day": 6,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "day": 1,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    9
+                  ],
+                  "day": 1,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    9
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    3
+                  ],
+                  "day": 6,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "002079.01",
+            "courseCode": "002079",
+            "courseName": "微电子系列实验",
+            "teacher": "郭国平,徐军"
+          },
+          "previous": {
+            "id": "002079.01",
+            "courseCode": "002079",
+            "courseName": "微电子系列实验",
+            "teacher": "郭国平,徐军",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  6,
+                  18
+                ],
+                "room": "物理楼414",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  18
+                ],
+                "room": "物理楼414",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  18
+                ],
+                "room": "物理楼414",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  18
+                ],
+                "room": "物理楼414",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "002079.01",
+            "courseCode": "002079",
+            "courseName": "微电子系列实验",
+            "teacher": "郭国平,徐军",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  6,
+                  18
+                ],
+                "room": "院系安排二次选课请咨询任课教师:上课地点东区物质科研楼C703",
+                "day": 6,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    6,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    6,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    6,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    6,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    6,
+                    18
+                  ],
+                  "day": 6,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "物理楼414",
+                  "campus": "其他"
+                }
+              ],
+              "after": [
+                {
+                  "room": "院系安排二次选课请咨询任课教师:上课地点东区物质科研楼C703",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "004137.01",
+            "courseCode": "004137",
+            "courseName": "近代数学物理方法",
+            "teacher": "黄民信"
+          },
+          "previous": {
+            "id": "004137.01",
+            "courseCode": "004137",
+            "courseName": "近代数学物理方法",
+            "teacher": "黄民信",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2406",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2406",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "004137.01",
+            "courseCode": "004137",
+            "courseName": "近代数学物理方法",
+            "teacher": "黄民信",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2406",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "2406",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "2406",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  18
+                ],
+                "room": "2406",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "2406",
+                "day": 6,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    3
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    3
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "007308.01",
+            "courseCode": "007308",
+            "courseName": "岩石物理学",
+            "teacher": "戴志阳"
+          },
+          "previous": {
+            "id": "007308.01",
+            "courseCode": "007308",
+            "courseName": "岩石物理学",
+            "teacher": "戴志阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2306",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "007308.01",
+            "courseCode": "007308",
+            "courseName": "岩石物理学",
+            "teacher": "戴志阳",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2306",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "010217.04",
+            "courseCode": "010217",
+            "courseName": "系统与控制实验(1)",
+            "teacher": "石春,李隆,王大欣"
+          },
+          "previous": {
+            "id": "010217.04",
+            "courseCode": "010217",
+            "courseName": "系统与控制实验(1)",
+            "teacher": "石春,李隆,王大欣",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "高新区1号学科楼G1_A104",
+                "day": 4,
+                "periods": [
+                  11
+                ],
+                "startTime": "19:00",
+                "endTime": "19:30",
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  13,
+                  17
+                ],
+                "room": "西区电四楼308",
+                "day": 4,
+                "periods": [
+                  11
+                ],
+                "startTime": "19:00",
+                "endTime": "19:30",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "高新区1号学科楼G1_A104",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  13,
+                  17
+                ],
+                "room": "西区电四楼308",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "010217.04",
+            "courseCode": "010217",
+            "courseName": "系统与控制实验(1)",
+            "teacher": "石春,李隆,王大欣",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "高新区1号学科楼G1_A104",
+                "day": 4,
+                "periods": [
+                  11
+                ],
+                "startTime": "19:00",
+                "endTime": "19:30",
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  13,
+                  17
+                ],
+                "room": "西区电四楼308",
+                "day": 4,
+                "periods": [
+                  11
+                ],
+                "startTime": "19:00",
+                "endTime": "19:30",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  12
+                ],
+                "room": "高新区1号学科楼G1_A104",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  13,
+                  17
+                ],
+                "room": "西区电四楼308",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 25,
+              "after": 26
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "011040.02",
+            "courseCode": "011040",
+            "courseName": "图论",
+            "teacher": "徐宏力,赵功名"
+          },
+          "previous": {
+            "id": "011040.02",
+            "courseCode": "011040",
+            "courseName": "图论",
+            "teacher": "徐宏力,赵功名",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "3C301",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  15
+                ],
+                "room": "3C301",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "3C301",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  15
+                ],
+                "room": "3C301",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "011040.02",
+            "courseCode": "011040",
+            "courseName": "图论",
+            "teacher": "徐宏力,赵功名",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "3C301",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  15
+                ],
+                "room": "3C301",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  7
+                ],
+                "room": "3C301",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  15
+                ],
+                "room": "3C301",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "3C301",
+                "day": 7,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    8
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    15
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    7
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    8,
+                    15
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    8
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    15
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    7
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    8,
+                    15
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "013090.01",
+            "courseCode": "013090",
+            "courseName": "热物理基础实验(1)",
+            "teacher": "焦冬生,倪青"
+          },
+          "previous": {
+            "id": "013090.01",
+            "courseCode": "013090",
+            "courseName": "热物理基础实验(1)",
+            "teacher": "焦冬生,倪青",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区力一楼6L",
+                "day": 3,
+                "periods": [
+                  11
+                ],
+                "startTime": "19:00",
+                "endTime": "19:30",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区力一楼6L",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "013090.01",
+            "courseCode": "013090",
+            "courseName": "热物理基础实验(1)",
+            "teacher": "焦冬生,倪青",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区力四楼220",
+                "day": 3,
+                "periods": [
+                  11
+                ],
+                "startTime": "19:00",
+                "endTime": "19:30",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "西区力四楼220",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "西区力一楼6L",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "西区力四楼220",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "015005.01",
+            "courseCode": "015005",
+            "courseName": "微观经济学",
+            "teacher": "周亚平,程丽红"
+          },
+          "previous": {
+            "id": "015005.01",
+            "courseCode": "015005",
+            "courseName": "微观经济学",
+            "teacher": "周亚平,程丽红",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1301",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16,
+                  18
+                ],
+                "room": "1301",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1301",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "015005.01",
+            "courseCode": "015005",
+            "courseName": "微观经济学",
+            "teacher": "周亚平,程丽红",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  4,
+                  6,
+                  8,
+                  10,
+                  12,
+                  14,
+                  16,
+                  18
+                ],
+                "room": "1301",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "1301",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    4,
+                    6,
+                    8,
+                    10,
+                    12,
+                    14,
+                    16,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    4,
+                    6,
+                    8,
+                    10,
+                    12,
+                    14,
+                    16,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "022118.01",
+            "courseCode": "022118",
+            "courseName": "固体物理B",
+            "teacher": "郑奇靖"
+          },
+          "previous": {
+            "id": "022118.01",
+            "courseCode": "022118",
+            "courseName": "固体物理B",
+            "teacher": "郑奇靖",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2207",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2207",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "022118.01",
+            "courseCode": "022118",
+            "courseName": "固体物理B",
+            "teacher": "郑奇靖",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2103",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2103",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2207",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2103",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "210077.02",
+            "courseCode": "210077",
+            "courseName": "非线性电子线路",
+            "teacher": "陈香"
+          },
+          "previous": {
+            "id": "210077.02",
+            "courseCode": "210077",
+            "courseName": "非线性电子线路",
+            "teacher": "陈香",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-A403",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-A403",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "210077.02",
+            "courseCode": "210077",
+            "courseName": "非线性电子线路",
+            "teacher": "陈香",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B112",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B112",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "GT-A403",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "GT-B112",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "AI1001B.04",
+            "courseCode": "AI1001B",
+            "courseName": "人工智能数学原理与算法B",
+            "teacher": "程万,夏晓波"
+          },
+          "previous": {
+            "id": "AI1001B.04",
+            "courseCode": "AI1001B",
+            "courseName": "人工智能数学原理与算法B",
+            "teacher": "程万",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  13
+                ],
+                "room": "3C303",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "AI1001B.04",
+            "courseCode": "AI1001B",
+            "courseName": "人工智能数学原理与算法B",
+            "teacher": "程万,夏晓波",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  13
+                ],
+                "room": "3C303",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "程万",
+              "after": "程万,夏晓波"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "AI1501.01",
+            "courseCode": "AI1501",
+            "courseName": "生成式人工智能概述",
+            "teacher": "刘武,杨勋,常晓军"
+          },
+          "previous": {
+            "id": "AI1501.01",
+            "courseCode": "AI1501",
+            "courseName": "生成式人工智能概述",
+            "teacher": "刘武,杨勋,常晓军",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  10
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  14
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "AI1501.01",
+            "courseCode": "AI1501",
+            "courseName": "生成式人工智能概述",
+            "teacher": "刘武,杨勋,常晓军",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  10
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  14
+                ],
+                "room": "3A113",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "3A113",
+                "day": 7,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    5
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    6,
+                    10
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    11,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    6,
+                    10
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    11,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 7,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "AI3002.01",
+            "courseCode": "AI3002",
+            "courseName": "人工智能与机器学习基础",
+            "teacher": "王翔,吴剑灿"
+          },
+          "previous": {
+            "id": "AI3002.01",
+            "courseCode": "AI3002",
+            "courseName": "人工智能与机器学习基础",
+            "teacher": "王翔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "GT-B112",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "AI3002.01",
+            "courseCode": "AI3002",
+            "courseName": "人工智能与机器学习基础",
+            "teacher": "王翔,吴剑灿",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "GT-B112",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "GT-B112",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "王翔",
+              "after": "王翔,吴剑灿"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ARCH6506P.01",
+            "courseCode": "ARCH6506P",
+            "courseName": "地质考古学",
+            "teacher": "秦颍"
+          },
+          "previous": {
+            "id": "ARCH6506P.01",
+            "courseCode": "ARCH6506P",
+            "courseName": "地质考古学",
+            "teacher": "秦颍",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2504",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ARCH6506P.01",
+            "courseCode": "ARCH6506P",
+            "courseName": "地质考古学",
+            "teacher": "秦颍",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2504",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "基础",
+              "after": "专业"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTA6002P.01",
+            "courseCode": "ASTA6002P",
+            "courseName": "回归分析与数据思维",
+            "teacher": "曾靖,吴彬"
+          },
+          "previous": {
+            "id": "ASTA6002P.01",
+            "courseCode": "ASTA6002P",
+            "courseName": "回归分析与数据思维",
+            "teacher": "曾靖,吴彬",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  4
+                ],
+                "room": "国金院5号楼101教室",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "18:30",
+                "endTime": "21:30",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  9
+                ],
+                "room": "国金院5号楼101教室",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "18:30",
+                "endTime": "21:30",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "国金院5号楼101室",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "18:30",
+                "endTime": "21:30",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "国金院5号楼101室",
+                "day": 3,
+                "periods": [
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "国金院5号楼101室",
+                "day": 3,
+                "periods": [
+                  12,
+                  13
+                ],
+                "startTime": "20:30",
+                "endTime": "21:30",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTA6002P.01",
+            "courseCode": "ASTA6002P",
+            "courseName": "回归分析与数据思维",
+            "teacher": "曾靖,吴彬",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "国金院5号楼101教室",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "18:30",
+                "endTime": "21:30",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  9
+                ],
+                "room": "国金院5号楼101教室",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "18:30",
+                "endTime": "21:30",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "国金院5号楼101室",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "18:30",
+                "endTime": "21:30",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "国金院5号楼101室",
+                "day": 3,
+                "periods": [
+                  12,
+                  13
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "国金院5号楼101室",
+                "day": 3,
+                "periods": [
+                  12,
+                  13
+                ],
+                "startTime": "20:30",
+                "endTime": "21:30",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    4
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "startTime": "18:30",
+                  "endTime": "21:30"
+                },
+                {
+                  "weeks": [
+                    6,
+                    9
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "startTime": "18:30",
+                  "endTime": "21:30"
+                },
+                {
+                  "weeks": [
+                    10,
+                    16
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "startTime": "18:30",
+                  "endTime": "21:30"
+                },
+                {
+                  "weeks": [
+                    17,
+                    17
+                  ],
+                  "day": 3,
+                  "periods": [
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    17,
+                    17
+                  ],
+                  "day": 3,
+                  "periods": [
+                    12,
+                    13
+                  ],
+                  "startTime": "20:30",
+                  "endTime": "21:30"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "startTime": "18:30",
+                  "endTime": "21:30"
+                },
+                {
+                  "weeks": [
+                    7,
+                    9
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "startTime": "18:30",
+                  "endTime": "21:30"
+                },
+                {
+                  "weeks": [
+                    10,
+                    16
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ],
+                  "startTime": "18:30",
+                  "endTime": "21:30"
+                },
+                {
+                  "weeks": [
+                    17,
+                    17
+                  ],
+                  "day": 3,
+                  "periods": [
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    17,
+                    17
+                  ],
+                  "day": 3,
+                  "periods": [
+                    12,
+                    13
+                  ],
+                  "startTime": "20:30",
+                  "endTime": "21:30"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTA6007P.01",
+            "courseCode": "ASTA6007P",
+            "courseName": "统计学基础",
+            "teacher": "张洪,王占锋"
+          },
+          "previous": {
+            "id": "ASTA6007P.01",
+            "courseCode": "ASTA6007P",
+            "courseName": "统计学基础",
+            "teacher": "张洪,王占锋",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "startTime": "14:00",
+                "endTime": "15:20",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  9
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 4,
+                "periods": [
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "15:30",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTA6007P.01",
+            "courseCode": "ASTA6007P",
+            "courseName": "统计学基础",
+            "teacher": "张洪,王占锋",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "startTime": "14:00",
+                "endTime": "15:20",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  4
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  6,
+                  9
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  10,
+                  16
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "14:00",
+                "endTime": "17:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "囯金院5号楼101室",
+                "day": 4,
+                "periods": [
+                  7,
+                  8,
+                  9
+                ],
+                "startTime": "15:30",
+                "endTime": "17:00",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    17,
+                    17
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "15:20"
+                },
+                {
+                  "weeks": [
+                    2,
+                    5
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    9
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    10,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    17,
+                    17
+                  ],
+                  "day": 4,
+                  "periods": [
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "15:30",
+                  "endTime": "17:00"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    17,
+                    17
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "15:20"
+                },
+                {
+                  "weeks": [
+                    2,
+                    4
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    6,
+                    9
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    10,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:00"
+                },
+                {
+                  "weeks": [
+                    17,
+                    17
+                  ],
+                  "day": 4,
+                  "periods": [
+                    7,
+                    8,
+                    9
+                  ],
+                  "startTime": "15:30",
+                  "endTime": "17:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ASTR5001P.01",
+            "courseCode": "ASTR5001P",
+            "courseName": "广义相对论",
+            "teacher": "赵文"
+          },
+          "previous": {
+            "id": "ASTR5001P.01",
+            "courseCode": "ASTR5001P",
+            "courseName": "广义相对论",
+            "teacher": "赵文",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5107",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "5107",
+                "day": 1,
+                "periods": [
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5106",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ASTR5001P.01",
+            "courseCode": "ASTR5001P",
+            "courseName": "广义相对论",
+            "teacher": "赵文",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5504",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "5504",
+                "day": 1,
+                "periods": [
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5504",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 80,
+              "after": 100
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5106",
+                  "campus": "本部"
+                },
+                {
+                  "room": "5107",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5504",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BADM2002.01",
+            "courseCode": "BADM2002",
+            "courseName": "人类行为的管理学原理",
+            "teacher": "杨锋"
+          },
+          "previous": {
+            "id": "BADM2002.01",
+            "courseCode": "BADM2002",
+            "courseName": "人类行为的管理学原理",
+            "teacher": "杨锋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5102",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BADM2002.01",
+            "courseCode": "BADM2002",
+            "courseName": "人类行为的管理学原理",
+            "teacher": "杨锋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5102",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIO1502.01",
+            "courseCode": "BIO1502",
+            "courseName": "生命科学与医学导论",
+            "teacher": "魏海明"
+          },
+          "previous": {
+            "id": "BIO1502.01",
+            "courseCode": "BIO1502",
+            "courseName": "生命科学与医学导论",
+            "teacher": "魏海明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "第二第三周在生物楼一楼报告厅",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  18
+                ],
+                "room": "3B103",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIO1502.01",
+            "courseCode": "BIO1502",
+            "courseName": "生命科学与医学导论",
+            "teacher": "魏海明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "第二第三周在生物楼一楼报告厅",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  18
+                ],
+                "room": "3B103",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 20,
+              "after": 150
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIO1512.01",
+            "courseCode": "BIO1512",
+            "courseName": "生物学与生活",
+            "teacher": "李旭"
+          },
+          "previous": {
+            "id": "BIO1512.01",
+            "courseCode": "BIO1512",
+            "courseName": "生物学与生活",
+            "teacher": "李旭",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  13
+                ],
+                "room": "3A110",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIO1512.01",
+            "courseCode": "BIO1512",
+            "courseName": "生物学与生活",
+            "teacher": "李旭",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  14
+                ],
+                "room": "3A110",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    13
+                  ],
+                  "day": 5,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    3,
+                    14
+                  ],
+                  "day": 5,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL5121P.01",
+            "courseCode": "BIOL5121P",
+            "courseName": "基础神经科学",
+            "teacher": "仓春蕾,张隆华,熊伟,马玉乾"
+          },
+          "previous": {
+            "id": "BIOL5121P.01",
+            "courseCode": "BIOL5121P",
+            "courseName": "基础神经科学",
+            "teacher": "张隆华,熊伟,仓春蕾",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A408",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL5121P.01",
+            "courseCode": "BIOL5121P",
+            "courseName": "基础神经科学",
+            "teacher": "仓春蕾,张隆华,熊伟,马玉乾",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A408",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张隆华,熊伟,仓春蕾",
+              "after": "仓春蕾,张隆华,熊伟,马玉乾"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL5121P.02",
+            "courseCode": "BIOL5121P",
+            "courseName": "基础神经科学",
+            "teacher": "张隆华,熊伟,仓春蕾,马玉乾"
+          },
+          "previous": {
+            "id": "BIOL5121P.02",
+            "courseCode": "BIOL5121P",
+            "courseName": "基础神经科学",
+            "teacher": "熊伟,张隆华,仓春蕾",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A409",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL5121P.02",
+            "courseCode": "BIOL5121P",
+            "courseName": "基础神经科学",
+            "teacher": "张隆华,熊伟,仓春蕾,马玉乾",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A409",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "熊伟,张隆华,仓春蕾",
+              "after": "张隆华,熊伟,仓春蕾,马玉乾"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL7111P.01",
+            "courseCode": "BIOL7111P",
+            "courseName": "微生物学文献阅读与分析",
+            "teacher": "杨新星,段屹"
+          },
+          "previous": {
+            "id": "BIOL7111P.01",
+            "courseCode": "BIOL7111P",
+            "courseName": "微生物学文献阅读与分析",
+            "teacher": "杨新星,段屹",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A104",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL7111P.01",
+            "courseCode": "BIOL7111P",
+            "courseName": "微生物学文献阅读与分析",
+            "teacher": "杨新星,段屹",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "3A104",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  4
+                ],
+                "room": "3A104",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  15
+                ],
+                "room": "3A104",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    4
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    5,
+                    15
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "BIOL7111P.02",
+            "courseCode": "BIOL7111P",
+            "courseName": "微生物学文献阅读与分析",
+            "teacher": "杨新星,段屹"
+          },
+          "previous": {
+            "id": "BIOL7111P.02",
+            "courseCode": "BIOL7111P",
+            "courseName": "微生物学文献阅读与分析",
+            "teacher": "杨新星,段屹",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "3A303",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "BIOL7111P.02",
+            "courseCode": "BIOL7111P",
+            "courseName": "微生物学文献阅读与分析",
+            "teacher": "杨新星,段屹",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "3A303",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  4
+                ],
+                "room": "3A303",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  15
+                ],
+                "room": "3A303",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    4
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                },
+                {
+                  "weeks": [
+                    5,
+                    15
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEM5005P.01",
+            "courseCode": "CHEM5005P",
+            "courseName": "药物化学",
+            "teacher": "顾振华,张凤莲"
+          },
+          "previous": {
+            "id": "CHEM5005P.01",
+            "courseCode": "CHEM5005P",
+            "courseName": "药物化学",
+            "teacher": "顾振华,张凤莲",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  10
+                ],
+                "room": "TH-C101",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  11,
+                  18
+                ],
+                "room": "TH-C101",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEM5005P.01",
+            "courseCode": "CHEM5005P",
+            "courseName": "药物化学",
+            "teacher": "顾振华,张凤莲",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  10
+                ],
+                "room": "TH-C101",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  11,
+                  18
+                ],
+                "room": "TH-C101",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 200,
+              "after": 211
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEM5010P.01",
+            "courseCode": "CHEM5010P",
+            "courseName": "统计力学",
+            "teacher": "朱超原"
+          },
+          "previous": {
+            "id": "CHEM5010P.01",
+            "courseCode": "CHEM5010P",
+            "courseName": "统计力学",
+            "teacher": "朱超原",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "TH-A103",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "TH-A103",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEM5010P.01",
+            "courseCode": "CHEM5010P",
+            "courseName": "统计力学",
+            "teacher": "朱超原",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "TH-A202",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "TH-A202",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 80,
+              "after": 40
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "TH-A103",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "TH-A202",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CHEM5012P.02",
+            "courseCode": "CHEM5012P",
+            "courseName": "电化学研究方法",
+            "teacher": "陈艳霞"
+          },
+          "previous": {
+            "id": "CHEM5012P.02",
+            "courseCode": "CHEM5012P",
+            "courseName": "电化学研究方法",
+            "teacher": "陈艳霞",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "2106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "2106",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "CHEM5012P.02",
+            "courseCode": "CHEM5012P",
+            "courseName": "电化学研究方法",
+            "teacher": "陈艳霞",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "2106",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "2106",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 70
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CS1003L.02",
+            "courseCode": "CS1003L",
+            "courseName": "计算机程序设计(L)",
+            "teacher": "苏觉"
+          },
+          "previous": {
+            "id": "CS1003L.02",
+            "courseCode": "CS1003L",
+            "courseName": "计算机程序设计(L)",
+            "teacher": "苏觉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "西区电一楼机房2厅",
+                "day": 2,
+                "periods": [
+                  11
+                ],
+                "startTime": "19:00",
+                "endTime": "19:30",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "西区电一楼机房2厅",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "2104",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "CS1003L.02",
+            "courseCode": "CS1003L",
+            "courseName": "计算机程序设计(L)",
+            "teacher": "苏觉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  14
+                ],
+                "room": "西区电一楼机房2厅",
+                "day": 2,
+                "periods": [
+                  11
+                ],
+                "startTime": "19:00",
+                "endTime": "19:30",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  14
+                ],
+                "room": "西区电一楼机房2厅",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "西区 西区虚拟教学楼 西区电一楼",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "2104",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    11
+                  ],
+                  "startTime": "19:00",
+                  "endTime": "19:30"
+                },
+                {
+                  "weeks": [
+                    2,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    14
+                  ],
+                  "day": 5,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    3,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    11
+                  ],
+                  "startTime": "19:00",
+                  "endTime": "19:30"
+                },
+                {
+                  "weeks": [
+                    3,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "day": 2,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    14
+                  ],
+                  "day": 5,
+                  "periods": [
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2104",
+                  "campus": "本部"
+                },
+                {
+                  "room": "西区电一楼机房2厅",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2104",
+                  "campus": "本部"
+                },
+                {
+                  "room": "西区 西区虚拟教学楼 西区电一楼",
+                  "campus": "本部"
+                },
+                {
+                  "room": "西区电一楼机房2厅",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CS2701.01",
+            "courseCode": "CS2701",
+            "courseName": "图论(H)",
+            "teacher": "赵功名,彭攀"
+          },
+          "previous": {
+            "id": "CS2701.01",
+            "courseCode": "CS2701",
+            "courseName": "图论(H)",
+            "teacher": "彭攀",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "CS2701.01",
+            "courseCode": "CS2701",
+            "courseName": "图论(H)",
+            "teacher": "赵功名,彭攀",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "3A212",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "3A212",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  15
+                ],
+                "room": "3A212",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "3A212",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "3A212",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "彭攀",
+              "after": "赵功名,彭攀"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "CYSC6401P.01",
+            "courseCode": "CYSC6401P",
+            "courseName": "密码分析学",
+            "teacher": "张斌"
+          },
+          "previous": {
+            "id": "CYSC6401P.01",
+            "courseCode": "CYSC6401P",
+            "courseName": "密码分析学",
+            "teacher": "张斌",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "GT-B210",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "CYSC6401P.01",
+            "courseCode": "CYSC6401P",
+            "courseName": "密码分析学",
+            "teacher": "张斌",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "GT-B210",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "examType",
+              "label": "考试方式",
+              "before": "笔试（开卷）",
+              "after": "笔试（闭卷）"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EE3006.01",
+            "courseCode": "EE3006",
+            "courseName": "计算机控制基础",
+            "teacher": "王兴虎,秦家虎"
+          },
+          "previous": {
+            "id": "EE3006.01",
+            "courseCode": "EE3006",
+            "courseName": "计算机控制基础",
+            "teacher": "王兴虎,秦家虎",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "GT-B112",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  16
+                ],
+                "room": "GT-B112",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "GT-B112",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  16
+                ],
+                "room": "GT-B112",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "EE3006.01",
+            "courseCode": "EE3006",
+            "courseName": "计算机控制基础",
+            "teacher": "王兴虎,秦家虎",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "GT-B106",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  16
+                ],
+                "room": "GT-B106",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "GT-B106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  9,
+                  16
+                ],
+                "room": "GT-B106",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "GT-B112",
+                  "campus": "高新区"
+                }
+              ],
+              "after": [
+                {
+                  "room": "GT-B106",
+                  "campus": "高新区"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EE4002.01",
+            "courseCode": "EE4002",
+            "courseName": "现代信息技术概览",
+            "teacher": "高南,李骜,张天柱,陈晓辉,陈雪锦,周武旸,胡红钢,秦家虎,朱旗,吴枫,陈勋,查正军,邵长星,康宇"
+          },
+          "previous": {
+            "id": "EE4002.01",
+            "courseCode": "EE4002",
+            "courseName": "现代信息技术概览",
+            "teacher": "陈晓辉,陈勋,陈雪锦,李骜,周武旸,朱旗,吴枫,康宇,秦家虎,查正军,张天柱,胡红钢,高南,陈金雯",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  16
+                ],
+                "room": "3B103",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "EE4002.01",
+            "courseCode": "EE4002",
+            "courseName": "现代信息技术概览",
+            "teacher": "高南,李骜,张天柱,陈晓辉,陈雪锦,周武旸,胡红钢,秦家虎,朱旗,吴枫,陈勋,查正军,邵长星,康宇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  16
+                ],
+                "room": "3B103",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "陈晓辉,陈勋,陈雪锦,李骜,周武旸,朱旗,吴枫,康宇,秦家虎,查正军,张天柱,胡红钢,高南,陈金雯",
+              "after": "高南,李骜,张天柱,陈晓辉,陈雪锦,周武旸,胡红钢,秦家虎,朱旗,吴枫,陈勋,查正军,邵长星,康宇"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EIEN7010P.01",
+            "courseCode": "EIEN7010P",
+            "courseName": "泛在操作系统",
+            "teacher": "朱宗卫"
+          },
+          "previous": {
+            "id": "EIEN7010P.01",
+            "courseCode": "EIEN7010P",
+            "courseName": "泛在操作系统",
+            "teacher": "朱宗卫",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "GT-A403",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "GT-A403",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "G3-115",
+                "day": 6,
+                "periods": [
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "G3-115",
+                "day": 6,
+                "periods": [
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "EIEN7010P.01",
+            "courseCode": "EIEN7010P",
+            "courseName": "泛在操作系统",
+            "teacher": "朱宗卫",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "GT-A403",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "GT-A403",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "G3-115",
+                "day": 6,
+                "periods": [
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "G3-115",
+                "day": 6,
+                "periods": [
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  12,
+                  12
+                ],
+                "room": "GT-A403",
+                "day": 6,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    12
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 6,
+                  "periods": [
+                    2,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    12
+                  ],
+                  "day": 6,
+                  "periods": [
+                    2,
+                    3,
+                    4
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    12
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8
+                  ]
+                },
+                {
+                  "weeks": [
+                    3,
+                    3
+                  ],
+                  "day": 6,
+                  "periods": [
+                    2,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    12
+                  ],
+                  "day": 6,
+                  "periods": [
+                    2,
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    12,
+                    12
+                  ],
+                  "day": 6,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "EIEN7403P.04",
+            "courseCode": "EIEN7403P",
+            "courseName": "电子信息类前沿课程",
+            "teacher": "汪炀"
+          },
+          "previous": {
+            "id": "EIEN7403P.04",
+            "courseCode": "EIEN7403P",
+            "courseName": "电子信息类前沿课程",
+            "teacher": "汪炀",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "苏州唯真楼500会议室",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "苏州唯真楼500会议室",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "EIEN7403P.04",
+            "courseCode": "EIEN7403P",
+            "courseName": "电子信息类前沿课程",
+            "teacher": "汪炀",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  5
+                ],
+                "room": "苏州唯真楼500会议室",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "苏州唯真楼500会议室",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 15
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ENVI6412P.01",
+            "courseCode": "ENVI6412P",
+            "courseName": "环境生物化学与分子毒理学",
+            "teacher": "袁丽"
+          },
+          "previous": {
+            "id": "ENVI6412P.01",
+            "courseCode": "ENVI6412P",
+            "courseName": "环境生物化学与分子毒理学",
+            "teacher": "袁丽",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2309",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ENVI6412P.01",
+            "courseCode": "ENVI6412P",
+            "courseName": "环境生物化学与分子毒理学",
+            "teacher": "袁丽",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "ENVS4013.01",
+            "courseCode": "ENVS4013",
+            "courseName": "土壤污染与修复技术",
+            "teacher": "蔡琛,杨一"
+          },
+          "previous": {
+            "id": "ENVS4013.01",
+            "courseCode": "ENVS4013",
+            "courseName": "土壤污染与修复技术",
+            "teacher": "蔡琛,杨一",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "2509",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  14
+                ],
+                "room": "2509",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  12
+                ],
+                "room": "2509",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  14
+                ],
+                "room": "2509",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "ENVS4013.01",
+            "courseCode": "ENVS4013",
+            "courseName": "土壤污染与修复技术",
+            "teacher": "蔡琛,杨一",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  6
+                ],
+                "room": "2509",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  13
+                ],
+                "room": "2509",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "2509",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    7
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    13,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    8,
+                    12
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    14,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    6
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    13,
+                    13
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    13
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.20",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "陈馥梅"
+          },
+          "previous": {
+            "id": "FL1003.20",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FL1003.20",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A110",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "尹俊",
+              "after": "陈馥梅"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 0,
+              "after": 50
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "3A110",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.21",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "陈馥梅"
+          },
+          "previous": {
+            "id": "FL1003.21",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FL1003.21",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2204",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "尹俊",
+              "after": "陈馥梅"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 0,
+              "after": 50
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "2204",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1003.22",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "陈馥梅"
+          },
+          "previous": {
+            "id": "FL1003.22",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "尹俊",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FL1003.22",
+            "courseCode": "FL1003",
+            "courseName": "英语交流I",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A109",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "尹俊",
+              "after": "陈馥梅"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 0,
+              "after": 50
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "3A109",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.02",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛"
+          },
+          "previous": {
+            "id": "FL1005.02",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2205",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.02",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "管琛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2210",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2205",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2210",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.09",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉"
+          },
+          "previous": {
+            "id": "FL1005.09",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2306",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.09",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "马仁蓉",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2321",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2306",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2321",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.10",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄"
+          },
+          "previous": {
+            "id": "FL1005.10",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.10",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2211",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2309",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2211",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.14",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄"
+          },
+          "previous": {
+            "id": "FL1005.14",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.14",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "陈澄",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5103",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2309",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5103",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.19",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏"
+          },
+          "previous": {
+            "id": "FL1005.19",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.19",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2421",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2406",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2421",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1005.23",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏"
+          },
+          "previous": {
+            "id": "FL1005.23",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2406",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1005.23",
+            "courseCode": "FL1005",
+            "courseName": "英语读写I",
+            "teacher": "斯骏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5104",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2406",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5104",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.01",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "David Garcia"
+          },
+          "previous": {
+            "id": "FL1013.01",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A204",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.01",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "David Garcia",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A204",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "陈馥梅",
+              "after": "David Garcia"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.02",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "David Garcia"
+          },
+          "previous": {
+            "id": "FL1013.02",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A204",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.02",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "David Garcia",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A204",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "陈馥梅",
+              "after": "David Garcia"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.03",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "David Garcia"
+          },
+          "previous": {
+            "id": "FL1013.03",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2303",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.03",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "David Garcia",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2303",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "陈馥梅",
+              "after": "David Garcia"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.04",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "David Garcia"
+          },
+          "previous": {
+            "id": "FL1013.04",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2303",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.04",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "David Garcia",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2303",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "陈馥梅",
+              "after": "David Garcia"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.05",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "David Garcia"
+          },
+          "previous": {
+            "id": "FL1013.05",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A204",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.05",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "David Garcia",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2304",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "陈馥梅",
+              "after": "David Garcia"
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    9
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    9
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A204",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2304",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.06",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "David Garcia"
+          },
+          "previous": {
+            "id": "FL1013.06",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "陈馥梅",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A204",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.06",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "David Garcia",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2304",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "陈馥梅",
+              "after": "David Garcia"
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    10,
+                    17
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    10,
+                    17
+                  ],
+                  "day": 1,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A204",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2304",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.15",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔"
+          },
+          "previous": {
+            "id": "FL1013.15",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A203",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.15",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "3A107",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A203",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "3A107",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1013.16",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔"
+          },
+          "previous": {
+            "id": "FL1013.16",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A203",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1013.16",
+            "courseCode": "FL1013",
+            "courseName": "大学英语交流",
+            "teacher": "汪滔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "3A107",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A203",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "3A107",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1102B.04",
+            "courseCode": "FL1102B",
+            "courseName": "科普英语交流B",
+            "teacher": "张曼君"
+          },
+          "previous": {
+            "id": "FL1102B.04",
+            "courseCode": "FL1102B",
+            "courseName": "科普英语交流B",
+            "teacher": "张曼君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2206",
+                "day": 3,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1102B.04",
+            "courseCode": "FL1102B",
+            "courseName": "科普英语交流B",
+            "teacher": "张曼君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "2206",
+                "day": 3,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 45,
+              "after": 50
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1115A.03",
+            "courseCode": "FL1115A",
+            "courseName": "高级英语口语",
+            "teacher": "Samuel GIBSON"
+          },
+          "previous": {
+            "id": "FL1115A.03",
+            "courseCode": "FL1115A",
+            "courseName": "高级英语口语",
+            "teacher": "Samuel GIBSON",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2306",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1115A.03",
+            "courseCode": "FL1115A",
+            "courseName": "高级英语口语",
+            "teacher": "Samuel GIBSON",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "2306",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 0,
+              "after": 20
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1115A.04",
+            "courseCode": "FL1115A",
+            "courseName": "高级英语口语",
+            "teacher": "Samuel GIBSON"
+          },
+          "previous": {
+            "id": "FL1115A.04",
+            "courseCode": "FL1115A",
+            "courseName": "高级英语口语",
+            "teacher": "Samuel GIBSON",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2306",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1115A.04",
+            "courseCode": "FL1115A",
+            "courseName": "高级英语口语",
+            "teacher": "Samuel GIBSON",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2306",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 0,
+              "after": 20
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FL1115A.07",
+            "courseCode": "FL1115A",
+            "courseName": "高级英语口语",
+            "teacher": "Samuel GIBSON"
+          },
+          "previous": {
+            "id": "FL1115A.07",
+            "courseCode": "FL1115A",
+            "courseName": "高级英语口语",
+            "teacher": "Samuel GIBSON",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2205",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FL1115A.07",
+            "courseCode": "FL1115A",
+            "courseName": "高级英语口语",
+            "teacher": "Samuel GIBSON",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  10,
+                  17
+                ],
+                "room": "2205",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 0,
+              "after": 20
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.04",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sean Fitzgerlad"
+          },
+          "previous": {
+            "id": "FORL6102U.04",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sonny Kohet",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A202",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.04",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sean Fitzgerlad",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A202",
+                "day": 4,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Sonny Kohet",
+              "after": "Sean Fitzgerlad"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.08",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sean Fitzgerlad"
+          },
+          "previous": {
+            "id": "FORL6102U.08",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sonny Kohet",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A202",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.08",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sean Fitzgerlad",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A202",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Sonny Kohet",
+              "after": "Sean Fitzgerlad"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.09",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sean Fitzgerlad"
+          },
+          "previous": {
+            "id": "FORL6102U.09",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sonny Kohet",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A203",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.09",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sean Fitzgerlad",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A203",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Sonny Kohet",
+              "after": "Sean Fitzgerlad"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.10",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sean Fitzgerlad"
+          },
+          "previous": {
+            "id": "FORL6102U.10",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sonny Kohet",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A203",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.10",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sean Fitzgerlad",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A203",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Sonny Kohet",
+              "after": "Sean Fitzgerlad"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.14",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie"
+          },
+          "previous": {
+            "id": "FORL6102U.14",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GT-B103",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.14",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B103",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.15",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie"
+          },
+          "previous": {
+            "id": "FORL6102U.15",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GT-B103",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.15",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B103",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.16",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie"
+          },
+          "previous": {
+            "id": "FORL6102U.16",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GT-B103",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.16",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B103",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.17",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday"
+          },
+          "previous": {
+            "id": "FORL6102U.17",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Colm Orourke",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B203",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.17",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B203",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Colm Orourke",
+              "after": "Robert Peberday"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.18",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday"
+          },
+          "previous": {
+            "id": "FORL6102U.18",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Colm Orourke",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B105",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.18",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B105",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Colm Orourke",
+              "after": "Robert Peberday"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.19",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday"
+          },
+          "previous": {
+            "id": "FORL6102U.19",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Colm Orourke",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B105",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.19",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B105",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Colm Orourke",
+              "after": "Robert Peberday"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.20",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha"
+          },
+          "previous": {
+            "id": "FORL6102U.20",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GT-B108",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.20",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B108",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.21",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha"
+          },
+          "previous": {
+            "id": "FORL6102U.21",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GT-B108",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.21",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B108",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.22",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha"
+          },
+          "previous": {
+            "id": "FORL6102U.22",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "GT-B108",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.22",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GT-B108",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 1,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.26",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sean Fitzgerlad"
+          },
+          "previous": {
+            "id": "FORL6102U.26",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Colm Orourke",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2607",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.26",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sean Fitzgerlad",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2607",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Colm Orourke",
+              "after": "Sean Fitzgerlad"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.27",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sean Fitzgerlad"
+          },
+          "previous": {
+            "id": "FORL6102U.27",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Colm Orourke",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2607",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.27",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Sean Fitzgerlad",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2607",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Colm Orourke",
+              "after": "Sean Fitzgerlad"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.28",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan"
+          },
+          "previous": {
+            "id": "FORL6102U.28",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Rogers",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2404",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.28",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2404",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Donald Rogers",
+              "after": "Donald Sheehan"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.29",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan"
+          },
+          "previous": {
+            "id": "FORL6102U.29",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Rogers",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2404",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.29",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2404",
+                "day": 1,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Donald Rogers",
+              "after": "Donald Sheehan"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.30",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan"
+          },
+          "previous": {
+            "id": "FORL6102U.30",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Rogers",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2207",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.30",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2207",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Donald Rogers",
+              "after": "Donald Sheehan"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.31",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan"
+          },
+          "previous": {
+            "id": "FORL6102U.31",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Rogers",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2207",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.31",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2207",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Donald Rogers",
+              "after": "Donald Sheehan"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.35",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday"
+          },
+          "previous": {
+            "id": "FORL6102U.35",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Colm Orourke",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2204",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.35",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2204",
+                "day": 1,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Colm Orourke",
+              "after": "Robert Peberday"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.36",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday"
+          },
+          "previous": {
+            "id": "FORL6102U.36",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Colm Orourke",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2204",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.36",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2204",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Colm Orourke",
+              "after": "Robert Peberday"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.41",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie"
+          },
+          "previous": {
+            "id": "FORL6102U.41",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.41",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2309",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.42",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie"
+          },
+          "previous": {
+            "id": "FORL6102U.42",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.42",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2309",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 2,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.43",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday"
+          },
+          "previous": {
+            "id": "FORL6102U.43",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": []
+          },
+          "current": {
+            "id": "FORL6102U.43",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2307",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "Robert Peberday"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 0,
+              "after": 25
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [],
+              "after": [
+                {
+                  "room": "2307",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.44",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday"
+          },
+          "previous": {
+            "id": "FORL6102U.44",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Matthew Bell",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3A411",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.44",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Robert Peberday",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2404",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Matthew Bell",
+              "after": "Robert Peberday"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A411",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2404",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.46",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha"
+          },
+          "previous": {
+            "id": "FORL6102U.46",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2204",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.46",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2204",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 3,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 3,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.50",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha"
+          },
+          "previous": {
+            "id": "FORL6102U.50",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.50",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Steve Masashi Musha",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2309",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.53",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie"
+          },
+          "previous": {
+            "id": "FORL6102U.53",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2206",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.53",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2206",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.54",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie"
+          },
+          "previous": {
+            "id": "FORL6102U.54",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2206",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.54",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Patrick Mackie",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2206",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 5,
+                  "periods": [
+                    8,
+                    9
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.55",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "FORL6102U.55",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2205",
+                "day": 1,
+                "periods": [
+                  11,
+                  12
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.55",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "David Garcia",
+              "after": ""
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 40,
+              "after": 0
+            },
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 1,
+                  "periods": [
+                    11,
+                    12
+                  ]
+                }
+              ],
+              "after": []
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2205",
+                  "campus": "本部"
+                }
+              ],
+              "after": []
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.56",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Matthew Bell"
+          },
+          "previous": {
+            "id": "FORL6102U.56",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2306",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.56",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Matthew Bell",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2306",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "David Garcia",
+              "after": "Matthew Bell"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.57",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Matthew Bell"
+          },
+          "previous": {
+            "id": "FORL6102U.57",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "David Garcia",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2207",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.57",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Matthew Bell",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "2207",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "David Garcia",
+              "after": "Matthew Bell"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.64",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": ""
+          },
+          "previous": {
+            "id": "FORL6102U.64",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2207",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.64",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2207",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 0,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.70",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan"
+          },
+          "previous": {
+            "id": "FORL6102U.70",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Rogers",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A203",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.70",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A203",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Donald Rogers",
+              "after": "Donald Sheehan"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.71",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan"
+          },
+          "previous": {
+            "id": "FORL6102U.71",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Rogers",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A203",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.71",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A203",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Donald Rogers",
+              "after": "Donald Sheehan"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.72",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan"
+          },
+          "previous": {
+            "id": "FORL6102U.72",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Rogers",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A202",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.72",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A202",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Donald Rogers",
+              "after": "Donald Sheehan"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6102U.73",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan"
+          },
+          "previous": {
+            "id": "FORL6102U.73",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Rogers",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A202",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6102U.73",
+            "courseCode": "FORL6102U",
+            "courseName": "日常交流英语",
+            "teacher": "Donald Sheehan",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  17
+                ],
+                "room": "TH-A202",
+                "day": 3,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "Donald Rogers",
+              "after": "Donald Sheehan"
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 35,
+              "after": 30
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6103U.01",
+            "courseCode": "FORL6103U",
+            "courseName": "学术交流英语",
+            "teacher": "John Gandy"
+          },
+          "previous": {
+            "id": "FORL6103U.01",
+            "courseCode": "FORL6103U",
+            "courseName": "学术交流英语",
+            "teacher": "John Gandy",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5503",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6103U.01",
+            "courseCode": "FORL6103U",
+            "courseName": "学术交流英语",
+            "teacher": "John Gandy",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5503",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 45
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FORL6103U.02",
+            "courseCode": "FORL6103U",
+            "courseName": "学术交流英语",
+            "teacher": "John Gandy"
+          },
+          "previous": {
+            "id": "FORL6103U.02",
+            "courseCode": "FORL6103U",
+            "courseName": "学术交流英语",
+            "teacher": "John Gandy",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5503",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "FORL6103U.02",
+            "courseCode": "FORL6103U",
+            "courseName": "学术交流英语",
+            "teacher": "John Gandy",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5503",
+                "day": 2,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 45
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.35",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "黄虎"
+          },
+          "previous": {
+            "id": "FS1001.35",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "黄虎",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.35",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "黄虎",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.37",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "毛震东"
+          },
+          "previous": {
+            "id": "FS1001.37",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "毛震东",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.37",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "毛震东",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.38",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "陈彦"
+          },
+          "previous": {
+            "id": "FS1001.38",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "陈彦",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.38",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "陈彦",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.40",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "薛天"
+          },
+          "previous": {
+            "id": "FS1001.40",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "薛天",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.40",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "薛天",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.41",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "臧建业"
+          },
+          "previous": {
+            "id": "FS1001.41",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "臧建业",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.41",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "臧建业",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.4E",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "董建阔"
+          },
+          "previous": {
+            "id": "FS1001.4E",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "董建阔",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.4E",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "董建阔",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.4Q",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "周荣斌"
+          },
+          "previous": {
+            "id": "FS1001.4Q",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "周荣斌",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.4Q",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "周荣斌",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.4R",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "光寿红"
+          },
+          "previous": {
+            "id": "FS1001.4R",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "光寿红",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.4R",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "光寿红",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.4S",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "刘强"
+          },
+          "previous": {
+            "id": "FS1001.4S",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "刘强",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.4S",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "刘强",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.4T",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "杨昱鹏"
+          },
+          "previous": {
+            "id": "FS1001.4T",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "杨昱鹏",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.4T",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "杨昱鹏",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.4U",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "金腾川"
+          },
+          "previous": {
+            "id": "FS1001.4U",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "金腾川",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.4U",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "金腾川",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.4V",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "王朝"
+          },
+          "previous": {
+            "id": "FS1001.4V",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "王朝",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.4V",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "王朝",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.4W",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "项晟祺"
+          },
+          "previous": {
+            "id": "FS1001.4W",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "项晟祺",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.4W",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "项晟祺",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.4X",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "孙林峰"
+          },
+          "previous": {
+            "id": "FS1001.4X",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "孙林峰",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.4X",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "孙林峰",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.4Y",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "刘行"
+          },
+          "previous": {
+            "id": "FS1001.4Y",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "刘行",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.4Y",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "刘行",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "FS1001.4Z",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "唐姗"
+          },
+          "previous": {
+            "id": "FS1001.4Z",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "唐姗",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "FS1001.4Z",
+            "courseCode": "FS1001",
+            "courseName": "“科学与社会”研讨课",
+            "teacher": "唐姗",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 10,
+              "after": 11
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "GEOL4006.01",
+            "courseCode": "GEOL4006",
+            "courseName": "地球化学分析",
+            "teacher": "陈伊翔,李王晔"
+          },
+          "previous": {
+            "id": "GEOL4006.01",
+            "courseCode": "GEOL4006",
+            "courseName": "地球化学分析",
+            "teacher": "李王晔,陈伊翔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "东区新地空楼708室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "东区新地空楼708室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "GEOL4006.01",
+            "courseCode": "GEOL4006",
+            "courseName": "地球化学分析",
+            "teacher": "陈伊翔,李王晔",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "东区新地空楼702教室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  17
+                ],
+                "room": "东区新地空楼702教室",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "东区新地空楼708室",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "东区新地空楼702教室",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "GEOL7402P.01",
+            "courseCode": "GEOL7402P",
+            "courseName": "地球的物理和化学高级讲座",
+            "teacher": "郑永飞,夏琼霞"
+          },
+          "previous": {
+            "id": "GEOL7402P.01",
+            "courseCode": "GEOL7402P",
+            "courseName": "地球的物理和化学高级讲座",
+            "teacher": "郑永飞,戴立群,夏琼霞",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "2609",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "GEOL7402P.01",
+            "courseCode": "GEOL7402P",
+            "courseName": "地球的物理和化学高级讲座",
+            "teacher": "郑永飞,夏琼霞",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  15
+                ],
+                "room": "2609",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "郑永飞,戴立群,夏琼霞",
+              "after": "郑永飞,夏琼霞"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "HS1592.01",
+            "courseCode": "HS1592",
+            "courseName": "科学与哲学史",
+            "teacher": "张贵红"
+          },
+          "previous": {
+            "id": "HS1592.01",
+            "courseCode": "HS1592",
+            "courseName": "科学与哲学史",
+            "teacher": "张贵红",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "G2-B302",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "HS1592.01",
+            "courseCode": "HS1592",
+            "courseName": "科学与哲学史",
+            "teacher": "张贵红",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "G2-B302",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  8
+                ],
+                "room": "G2-B302",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    7
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    5
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    8
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.01",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "应验,刘立"
+          },
+          "previous": {
+            "id": "MARX1014.01",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "应验,刘立",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1101",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.01",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "应验,刘立",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1101",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.02",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "刘立,应验"
+          },
+          "previous": {
+            "id": "MARX1014.02",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "应验,刘立",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1101",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.02",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "刘立,应验",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1101",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.03",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君,褚建勋"
+          },
+          "previous": {
+            "id": "MARX1014.03",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君,褚建勋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5103",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.03",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君,褚建勋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5103",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.04",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君,褚建勋"
+          },
+          "previous": {
+            "id": "MARX1014.04",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君,褚建勋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5103",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.04",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君,褚建勋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5103",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.05",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君"
+          },
+          "previous": {
+            "id": "MARX1014.05",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5103",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.05",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5103",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.07",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙"
+          },
+          "previous": {
+            "id": "MARX1014.07",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1201",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.07",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1201",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.08",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "应验"
+          },
+          "previous": {
+            "id": "MARX1014.08",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "应验",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1101",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.08",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "应验",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1101",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.09",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮"
+          },
+          "previous": {
+            "id": "MARX1014.09",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1202",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.09",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1202",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.10",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松,徐灿"
+          },
+          "previous": {
+            "id": "MARX1014.10",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松,徐灿",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1301",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.10",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松,徐灿",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1301",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.11",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞"
+          },
+          "previous": {
+            "id": "MARX1014.11",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1302",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.11",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1302",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.12",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙"
+          },
+          "previous": {
+            "id": "MARX1014.12",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1201",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.12",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1201",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.13",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮"
+          },
+          "previous": {
+            "id": "MARX1014.13",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1202",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.13",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "1202",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.14",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞"
+          },
+          "previous": {
+            "id": "MARX1014.14",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C203",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.14",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C203",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.15",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松"
+          },
+          "previous": {
+            "id": "MARX1014.15",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A112",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.15",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A112",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.16",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞"
+          },
+          "previous": {
+            "id": "MARX1014.16",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C203",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.16",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C203",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.17",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙"
+          },
+          "previous": {
+            "id": "MARX1014.17",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A211",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.17",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A211",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            },
+            {
+              "field": "classes",
+              "label": "面向班级",
+              "before": [
+                "26王小谟网络空间科技英才班T",
+                "26信息安全",
+                "26网络空间安全",
+                "26级209院06班"
+              ],
+              "after": [
+                "26级209院06班",
+                "26级209院04班"
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.18",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮"
+          },
+          "previous": {
+            "id": "MARX1014.18",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A113",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.18",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A113",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.19",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮"
+          },
+          "previous": {
+            "id": "MARX1014.19",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A113",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.19",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "孔亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A113",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.20",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君"
+          },
+          "previous": {
+            "id": "MARX1014.20",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A213",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.20",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "彭莉君",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A213",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.21",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松"
+          },
+          "previous": {
+            "id": "MARX1014.21",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A112",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.21",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A112",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.22",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙"
+          },
+          "previous": {
+            "id": "MARX1014.22",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A211",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.22",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "李金龙",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A211",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.23",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞"
+          },
+          "previous": {
+            "id": "MARX1014.23",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.23",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "陈慧瑞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3C203",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX1014.24",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松"
+          },
+          "previous": {
+            "id": "MARX1014.24",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A112",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX1014.24",
+            "courseCode": "MARX1014",
+            "courseName": "习近平新时代中国特色社会主义思想概论",
+            "teacher": "郭育松",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A112",
+                "day": 5,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 95,
+              "after": 100
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MARX6102U.08",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "虎旭昕"
+          },
+          "previous": {
+            "id": "MARX6102U.08",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  18
+                ],
+                "room": "科大南区软件学院楼202教室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MARX6102U.08",
+            "courseCode": "MARX6102U",
+            "courseName": "新时代中国特色社会主义理论与实践",
+            "teacher": "虎旭昕",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  8,
+                  18
+                ],
+                "room": "科大南区软件学院楼202教室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "",
+              "after": "虎旭昕"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH1010.02",
+            "courseCode": "MATH1010",
+            "courseName": "线性代数(B2)",
+            "teacher": "叶郁"
+          },
+          "previous": {
+            "id": "MATH1010.02",
+            "courseCode": "MATH1010",
+            "courseName": "线性代数(B2)",
+            "teacher": "叶郁",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5504",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5504",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH1010.02",
+            "courseCode": "MATH1010",
+            "courseName": "线性代数(B2)",
+            "teacher": "叶郁",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5504",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5406",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH2501.02",
+            "courseCode": "MATH2501",
+            "courseName": "复变函数(化学)",
+            "teacher": "王尧,叶绿洲"
+          },
+          "previous": {
+            "id": "MATH2501.02",
+            "courseCode": "MATH2501",
+            "courseName": "复变函数(化学)",
+            "teacher": "王尧,叶绿洲",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "2104",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  14
+                ],
+                "room": "2104",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  11
+                ],
+                "room": "2104",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH2501.02",
+            "courseCode": "MATH2501",
+            "courseName": "复变函数(化学)",
+            "teacher": "王尧,叶绿洲",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  5
+                ],
+                "room": "5503",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  12,
+                  14
+                ],
+                "room": "5503",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  6,
+                  11
+                ],
+                "room": "5503",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2104",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5503",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH3003.01",
+            "courseCode": "MATH3003",
+            "courseName": "拓扑学",
+            "teacher": "宋百林"
+          },
+          "previous": {
+            "id": "MATH3003.01",
+            "courseCode": "MATH3003",
+            "courseName": "拓扑学",
+            "teacher": "宋百林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "1202",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "1202",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH3003.01",
+            "courseCode": "MATH3003",
+            "courseName": "拓扑学",
+            "teacher": "宋百林",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "1202",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "1202",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH3004.01",
+            "courseCode": "MATH3004",
+            "courseName": "泛函分析",
+            "teacher": "廖羽晨"
+          },
+          "previous": {
+            "id": "MATH3004.01",
+            "courseCode": "MATH3004",
+            "courseName": "泛函分析",
+            "teacher": "廖羽晨",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2421",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2421",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH3004.01",
+            "courseCode": "MATH3004",
+            "courseName": "泛函分析",
+            "teacher": "廖羽晨",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "5502",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "5502",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2421",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5502",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH3004.02",
+            "courseCode": "MATH3004",
+            "courseName": "泛函分析",
+            "teacher": "刘聪文"
+          },
+          "previous": {
+            "id": "MATH3004.02",
+            "courseCode": "MATH3004",
+            "courseName": "泛函分析",
+            "teacher": "刘聪文",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2121",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2121",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH3004.02",
+            "courseCode": "MATH3004",
+            "courseName": "泛函分析",
+            "teacher": "刘聪文",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2121",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2121",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH3007.01",
+            "courseCode": "MATH3007",
+            "courseName": "概率论",
+            "teacher": "刘党政"
+          },
+          "previous": {
+            "id": "MATH3007.01",
+            "courseCode": "MATH3007",
+            "courseName": "概率论",
+            "teacher": "刘党政",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2211",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2211",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH3007.01",
+            "courseCode": "MATH3007",
+            "courseName": "概率论",
+            "teacher": "刘党政",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2211",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2211",
+                "day": 4,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH3009.01",
+            "courseCode": "MATH3009",
+            "courseName": "微分几何",
+            "teacher": "俞建青"
+          },
+          "previous": {
+            "id": "MATH3009.01",
+            "courseCode": "MATH3009",
+            "courseName": "微分几何",
+            "teacher": "俞建青",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2321",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2321",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH3009.01",
+            "courseCode": "MATH3009",
+            "courseName": "微分几何",
+            "teacher": "俞建青",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2321",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2321",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH3009.02",
+            "courseCode": "MATH3009",
+            "courseName": "微分几何",
+            "teacher": "崔洪斌"
+          },
+          "previous": {
+            "id": "MATH3009.02",
+            "courseCode": "MATH3009",
+            "courseName": "微分几何",
+            "teacher": "崔洪斌",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2121",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  14
+                ],
+                "room": "2121",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH3009.02",
+            "courseCode": "MATH3009",
+            "courseName": "微分几何",
+            "teacher": "崔洪斌",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2121",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  15
+                ],
+                "room": "2121",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    14
+                  ],
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 1,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    15
+                  ],
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH3011.02",
+            "courseCode": "MATH3011",
+            "courseName": "运筹学",
+            "teacher": "陈士祥"
+          },
+          "previous": {
+            "id": "MATH3011.02",
+            "courseCode": "MATH3011",
+            "courseName": "运筹学",
+            "teacher": "陈士祥",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5503",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5503",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH3011.02",
+            "courseCode": "MATH3011",
+            "courseName": "运筹学",
+            "teacher": "陈士祥",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5503",
+                "day": 1,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5503",
+                "day": 3,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 150,
+              "after": 175
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH5006P.01",
+            "courseCode": "MATH5006P",
+            "courseName": "图论",
+            "teacher": "侯新民"
+          },
+          "previous": {
+            "id": "MATH5006P.01",
+            "courseCode": "MATH5006P",
+            "courseName": "图论",
+            "teacher": "侯新民",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5502",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5502",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH5006P.01",
+            "courseCode": "MATH5006P",
+            "courseName": "图论",
+            "teacher": "侯新民",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5402",
+                "day": 2,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5402",
+                "day": 4,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5502",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5402",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MATH7413P.01",
+            "courseCode": "MATH7413P",
+            "courseName": "动力系统选讲",
+            "teacher": "雷内"
+          },
+          "previous": {
+            "id": "MATH7413P.01",
+            "courseCode": "MATH7413P",
+            "courseName": "动力系统选讲",
+            "teacher": "雷内",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5402",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5402",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MATH7413P.01",
+            "courseCode": "MATH7413P",
+            "courseName": "动力系统选讲",
+            "teacher": "雷内",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2301",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2301",
+                "day": 3,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5402",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "2301",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MEEN6103P.02",
+            "courseCode": "MEEN6103P",
+            "courseName": "微机电系统设计与制造",
+            "teacher": "褚家如,赵钢"
+          },
+          "previous": {
+            "id": "MEEN6103P.02",
+            "courseCode": "MEEN6103P",
+            "courseName": "微机电系统设计与制造",
+            "teacher": "褚家如,赵钢",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A306",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A306",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MEEN6103P.02",
+            "courseCode": "MEEN6103P",
+            "courseName": "微机电系统设计与制造",
+            "teacher": "褚家如,赵钢",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A306",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "3A306",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 86,
+              "after": 87
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MEEN6108P.01",
+            "courseCode": "MEEN6108P",
+            "courseName": "机器人技术",
+            "teacher": "金虎"
+          },
+          "previous": {
+            "id": "MEEN6108P.01",
+            "courseCode": "MEEN6108P",
+            "courseName": "机器人技术",
+            "teacher": "金虎",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "GX-C1001",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "MEEN6108P.01",
+            "courseCode": "MEEN6108P",
+            "courseName": "机器人技术",
+            "teacher": "金虎",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  6,
+                  18
+                ],
+                "room": "GX-C1001",
+                "day": 5,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 3,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    6,
+                    18
+                  ],
+                  "day": 5,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6009P.01",
+            "courseCode": "MPAD6009P",
+            "courseName": "公共政策分析",
+            "teacher": "王善勇,雷于萱"
+          },
+          "previous": {
+            "id": "MPAD6009P.01",
+            "courseCode": "MPAD6009P",
+            "courseName": "公共政策分析",
+            "teacher": "王善勇,雷于萱",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  13
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  13
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MPAD6009P.01",
+            "courseCode": "MPAD6009P",
+            "courseName": "公共政策分析",
+            "teacher": "王善勇,雷于萱",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  13,
+                  13
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  13
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    8,
+                    8
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    13,
+                    13
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    8,
+                    13
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    8,
+                    8
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    13,
+                    13
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    8,
+                    13
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6009P.04",
+            "courseCode": "MPAD6009P",
+            "courseName": "公共政策分析",
+            "teacher": "高硕"
+          },
+          "previous": {
+            "id": "MPAD6009P.04",
+            "courseCode": "MPAD6009P",
+            "courseName": "公共政策分析",
+            "teacher": "高硕",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "南区301",
+                "day": 3,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "南区301",
+                "day": 3,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "南区301",
+                "day": 5,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "2103",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "2103",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "南区301",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "2103",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "2103",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MPAD6009P.04",
+            "courseCode": "MPAD6009P",
+            "courseName": "公共政策分析",
+            "teacher": "高硕",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "南区301",
+                "day": 3,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "南区301",
+                "day": 3,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "南区301",
+                "day": 5,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  5,
+                  5
+                ],
+                "room": "南区301",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "2103",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "2103",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "南区301",
+                "day": 6,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "2103",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  8
+                ],
+                "room": "2103",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    8,
+                    8
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "day": 3,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    15,
+                    15
+                  ],
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    5,
+                    5
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "day": 6,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    8,
+                    8
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6406P.01",
+            "courseCode": "MPAD6406P",
+            "courseName": "公共人力资源管理",
+            "teacher": "谢云东"
+          },
+          "previous": {
+            "id": "MPAD6406P.01",
+            "courseCode": "MPAD6406P",
+            "courseName": "公共人力资源管理",
+            "teacher": "谢云东",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  14,
+                  14
+                ],
+                "room": "5102",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  16,
+                  17
+                ],
+                "room": "5103",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  19,
+                  19
+                ],
+                "room": "5103",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "5103",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "5103",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  18,
+                  18
+                ],
+                "room": "5103",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  20,
+                  20
+                ],
+                "room": "5103",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MPAD6406P.01",
+            "courseCode": "MPAD6406P",
+            "courseName": "公共人力资源管理",
+            "teacher": "谢云东",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  14,
+                  14
+                ],
+                "room": "5102",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  16,
+                  17
+                ],
+                "room": "5103",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  19,
+                  19
+                ],
+                "room": "5103",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  15,
+                  15
+                ],
+                "room": "5103",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  17,
+                  17
+                ],
+                "room": "5103",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  18,
+                  18
+                ],
+                "room": "5103",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  20,
+                  20
+                ],
+                "room": "5103",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 50,
+              "after": 60
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6461P.02",
+            "courseCode": "MPAD6461P",
+            "courseName": "博弈论",
+            "teacher": "陈鹏展"
+          },
+          "previous": {
+            "id": "MPAD6461P.02",
+            "courseCode": "MPAD6461P",
+            "courseName": "博弈论",
+            "teacher": "陈鹏展",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2210",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  12
+                ],
+                "room": "2210",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MPAD6461P.02",
+            "courseCode": "MPAD6461P",
+            "courseName": "博弈论",
+            "teacher": "陈鹏展",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  2
+                ],
+                "room": "2210",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  12
+                ],
+                "room": "2210",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  14
+                ],
+                "room": "2210",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    2
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    7,
+                    12
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    2
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    8,
+                    12
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    14,
+                    14
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6461P.03",
+            "courseCode": "MPAD6461P",
+            "courseName": "博弈论",
+            "teacher": "陈鹏展"
+          },
+          "previous": {
+            "id": "MPAD6461P.03",
+            "courseCode": "MPAD6461P",
+            "courseName": "博弈论",
+            "teacher": "陈鹏展",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "南区301",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "南区301",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "南区301",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "南区301",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "南区301",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "MPAD6461P.03",
+            "courseCode": "MPAD6461P",
+            "courseName": "博弈论",
+            "teacher": "陈鹏展",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "南区301",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "南区301",
+                "day": 3,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "南区301",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "南区301",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              },
+              {
+                "weeks": [
+                  11,
+                  11
+                ],
+                "room": "南区301",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 3,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 4,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    11,
+                    11
+                  ],
+                  "day": 5,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6463P.01",
+            "courseCode": "MPAD6463P",
+            "courseName": "网络空间治理概论",
+            "teacher": "杨林"
+          },
+          "previous": {
+            "id": "MPAD6463P.01",
+            "courseCode": "MPAD6463P",
+            "courseName": "网络空间治理概论",
+            "teacher": "杨林",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  1
+                ],
+                "room": "2105",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  13
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MPAD6463P.01",
+            "courseCode": "MPAD6463P",
+            "courseName": "网络空间治理概论",
+            "teacher": "杨林",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  13
+                ],
+                "room": "2105",
+                "day": 7,
+                "periods": [
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "startTime": "08:30",
+                "endTime": "12:00",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    1
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    3,
+                    3
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    8,
+                    13
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                },
+                {
+                  "weeks": [
+                    8,
+                    13
+                  ],
+                  "day": 7,
+                  "periods": [
+                    1,
+                    2,
+                    3,
+                    4,
+                    5
+                  ],
+                  "startTime": "08:30",
+                  "endTime": "12:00"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MPAD6463P.03",
+            "courseCode": "MPAD6463P",
+            "courseName": "网络空间治理概论",
+            "teacher": "邹振烽"
+          },
+          "previous": {
+            "id": "MPAD6463P.03",
+            "courseCode": "MPAD6463P",
+            "courseName": "网络空间治理概论",
+            "teacher": "邹振烽",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "2210",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  12
+                ],
+                "room": "2210",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  14,
+                  14
+                ],
+                "room": "2210",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MPAD6463P.03",
+            "courseCode": "MPAD6463P",
+            "courseName": "网络空间治理概论",
+            "teacher": "邹振烽",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "2210",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "2210",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  12
+                ],
+                "room": "2210",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "startTime": "14:00",
+                "endTime": "17:45",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    8,
+                    12
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    14,
+                    14
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                },
+                {
+                  "weeks": [
+                    8,
+                    12
+                  ],
+                  "day": 7,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9,
+                    10
+                  ],
+                  "startTime": "14:00",
+                  "endTime": "17:45"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "MSAE7127P.01",
+            "courseCode": "MSAE7127P",
+            "courseName": "随机与鲁棒优化",
+            "teacher": "朱宁"
+          },
+          "previous": {
+            "id": "MSAE7127P.01",
+            "courseCode": "MSAE7127P",
+            "courseName": "随机与鲁棒优化",
+            "teacher": "朱宁",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "18:30",
+                "endTime": "21:40",
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "MSAE7127P.01",
+            "courseCode": "MSAE7127P",
+            "courseName": "随机与鲁棒优化",
+            "teacher": "朱宁",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  11
+                ],
+                "room": "5106",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "startTime": "18:30",
+                "endTime": "21:40",
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 30,
+              "after": 35
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NSE3013.01",
+            "courseCode": "NSE3013",
+            "courseName": "辐射与放射分析化学",
+            "teacher": "苗庆庆,叶亚楠"
+          },
+          "previous": {
+            "id": "NSE3013.01",
+            "courseCode": "NSE3013",
+            "courseName": "辐射与放射分析化学",
+            "teacher": "苗庆庆,叶亚楠",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "3A204",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  16
+                ],
+                "room": "3A204",
+                "day": 1,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "3A204",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  16
+                ],
+                "room": "3A204",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "NSE3013.01",
+            "courseCode": "NSE3013",
+            "courseName": "辐射与放射分析化学",
+            "teacher": "苗庆庆,叶亚楠",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "3A202",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  16
+                ],
+                "room": "3A202",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  8
+                ],
+                "room": "3A202",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  9,
+                  16
+                ],
+                "room": "3A202",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    8
+                  ],
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    16
+                  ],
+                  "day": 1,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    8
+                  ],
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    16
+                  ],
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    1,
+                    8
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    16
+                  ],
+                  "day": 3,
+                  "periods": [
+                    11,
+                    12,
+                    13
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    8
+                  ],
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                },
+                {
+                  "weeks": [
+                    9,
+                    16
+                  ],
+                  "day": 5,
+                  "periods": [
+                    1,
+                    2
+                  ]
+                }
+              ]
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "3A204",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "3A202",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "NSTE5003P.01",
+            "courseCode": "NSTE5003P",
+            "courseName": "核聚变工程导论",
+            "teacher": "陈红丽,毛世峰"
+          },
+          "previous": {
+            "id": "NSTE5003P.01",
+            "courseCode": "NSTE5003P",
+            "courseName": "核聚变工程导论",
+            "teacher": "陈红丽,毛世峰",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3B101",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "3B101",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "NSTE5003P.01",
+            "courseCode": "NSTE5003P",
+            "courseName": "核聚变工程导论",
+            "teacher": "陈红丽,毛世峰",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "3B101",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  4
+                ],
+                "room": "3B101",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  5
+                ],
+                "room": "3B101",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  7,
+                  7
+                ],
+                "room": "3B101",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  8,
+                  18
+                ],
+                "room": "3B101",
+                "day": 2,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "3B101",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  4,
+                  4
+                ],
+                "room": "3B101",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  5,
+                  17
+                ],
+                "room": "3B101",
+                "day": 4,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    16
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    4
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    5,
+                    5
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    7
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    8,
+                    18
+                  ],
+                  "day": 2,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    4,
+                    4
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                },
+                {
+                  "weeks": [
+                    5,
+                    17
+                  ],
+                  "day": 4,
+                  "periods": [
+                    6,
+                    7
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHIL6006P.01",
+            "courseCode": "PHIL6006P",
+            "courseName": "科技哲学研究的理论与方法",
+            "teacher": "徐飞,杜晓柳"
+          },
+          "previous": {
+            "id": "PHIL6006P.01",
+            "courseCode": "PHIL6006P",
+            "courseName": "科技哲学研究的理论与方法",
+            "teacher": "杜晓柳,徐飞,张贵红",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2307",
+                "day": 2,
+                "periods": [
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHIL6006P.01",
+            "courseCode": "PHIL6006P",
+            "courseName": "科技哲学研究的理论与方法",
+            "teacher": "徐飞,杜晓柳",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2307",
+                "day": 2,
+                "periods": [
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "杜晓柳,徐飞,张贵红",
+              "after": "徐飞,杜晓柳"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHIL6301U.01",
+            "courseCode": "PHIL6301U",
+            "courseName": "工程伦理",
+            "teacher": "王高峰"
+          },
+          "previous": {
+            "id": "PHIL6301U.01",
+            "courseCode": "PHIL6301U",
+            "courseName": "工程伦理",
+            "teacher": "王高峰",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  3
+                ],
+                "room": "G3-109",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "G3-109",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHIL6301U.01",
+            "courseCode": "PHIL6301U",
+            "courseName": "工程伦理",
+            "teacher": "王高峰",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  3
+                ],
+                "room": "G3-109",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  7,
+                  13
+                ],
+                "room": "G3-109",
+                "day": 6,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "高新区"
+              },
+              {
+                "weeks": [
+                  2,
+                  2
+                ],
+                "room": "G3-109",
+                "day": 6,
+                "periods": [
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "高新区"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    2,
+                    3
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    13
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    3,
+                    3
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    7,
+                    13
+                  ],
+                  "day": 6,
+                  "periods": [
+                    6,
+                    7,
+                    8,
+                    9
+                  ]
+                },
+                {
+                  "weeks": [
+                    2,
+                    2
+                  ],
+                  "day": 6,
+                  "periods": [
+                    7,
+                    8,
+                    9,
+                    10
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHIL7001P.01",
+            "courseCode": "PHIL7001P",
+            "courseName": "科技哲学前沿问题专题研究",
+            "teacher": "张贵红,徐飞"
+          },
+          "previous": {
+            "id": "PHIL7001P.01",
+            "courseCode": "PHIL7001P",
+            "courseName": "科技哲学前沿问题专题研究",
+            "teacher": "徐飞",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2404",
+                "day": 4,
+                "periods": [
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHIL7001P.01",
+            "courseCode": "PHIL7001P",
+            "courseName": "科技哲学前沿问题专题研究",
+            "teacher": "张贵红,徐飞",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2404",
+                "day": 4,
+                "periods": [
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "徐飞",
+              "after": "张贵红,徐飞"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHIL7101U.15",
+            "courseCode": "PHIL7101U",
+            "courseName": "中国马克思主义与当代",
+            "teacher": "应验,张德广,苏振源"
+          },
+          "previous": {
+            "id": "PHIL7101U.15",
+            "courseCode": "PHIL7101U",
+            "courseName": "中国马克思主义与当代",
+            "teacher": "应验,张德广,苏振源",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "苏高院公共教学楼101教室",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHIL7101U.15",
+            "courseCode": "PHIL7101U",
+            "courseName": "中国马克思主义与当代",
+            "teacher": "应验,张德广,苏振源",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "苏高院公共教学楼101教室",
+                "day": 7,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "其他"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 80,
+              "after": 95
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1003A.07",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "王沛,孙泽亮"
+          },
+          "previous": {
+            "id": "PHYS1003A.07",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "王沛",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5206",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5206",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1003A.07",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "王沛,孙泽亮",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5206",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5206",
+                "day": 5,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "王沛",
+              "after": "王沛,孙泽亮"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1003A.10",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "陈耕,郭钰"
+          },
+          "previous": {
+            "id": "PHYS1003A.10",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "陈耕,郭钰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5406",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1003A.10",
+            "courseCode": "PHYS1003A",
+            "courseName": "光学A",
+            "teacher": "陈耕,郭钰",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5402",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  18
+                ],
+                "room": "5402",
+                "day": 3,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "5406",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5402",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009A.01",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "曲广媛,韦先涛,梁燕,刘应玲,郭玉刚,代如成,王晓方,王鹤,张增明,王中平,李恒一,吴玉椿,浦其荣,李海欧,张华洋,赵伟,祝巍,张杨,赵霞,蒋景华,陶小平,曾华凌,孙晓宇,蔡俊,沈镇,岳盈,张权,宋国锋,张乔枫,胡晓敏"
+          },
+          "previous": {
+            "id": "PHYS1009A.01",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009A.01",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "曲广媛,韦先涛,梁燕,刘应玲,郭玉刚,代如成,王晓方,王鹤,张增明,王中平,李恒一,吴玉椿,浦其荣,李海欧,张华洋,赵伟,祝巍,张杨,赵霞,蒋景华,陶小平,曾华凌,孙晓宇,蔡俊,沈镇,岳盈,张权,宋国锋,张乔枫,胡晓敏",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+              "after": "曲广媛,韦先涛,梁燕,刘应玲,郭玉刚,代如成,王晓方,王鹤,张增明,王中平,李恒一,吴玉椿,浦其荣,李海欧,张华洋,赵伟,祝巍,张杨,赵霞,蒋景华,陶小平,曾华凌,孙晓宇,蔡俊,沈镇,岳盈,张权,宋国锋,张乔枫,胡晓敏"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009A.02",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "胡晓敏,曲广媛,郭玉刚,梁燕,沈镇,浦其荣,张增明,孙晓宇,赵伟,张华洋,吴玉椿,李恒一,王中平,李海欧,祝巍,赵霞,张杨,蔡俊,王鹤,王晓方,张乔枫,韦先涛,曾华凌,岳盈,宋国锋,陶小平,代如成,张权,蒋景华,刘应玲"
+          },
+          "previous": {
+            "id": "PHYS1009A.02",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009A.02",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "胡晓敏,曲广媛,郭玉刚,梁燕,沈镇,浦其荣,张增明,孙晓宇,赵伟,张华洋,吴玉椿,李恒一,王中平,李海欧,祝巍,赵霞,张杨,蔡俊,王鹤,王晓方,张乔枫,韦先涛,曾华凌,岳盈,宋国锋,陶小平,代如成,张权,蒋景华,刘应玲",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+              "after": "胡晓敏,曲广媛,郭玉刚,梁燕,沈镇,浦其荣,张增明,孙晓宇,赵伟,张华洋,吴玉椿,李恒一,王中平,李海欧,祝巍,赵霞,张杨,蔡俊,王鹤,王晓方,张乔枫,韦先涛,曾华凌,岳盈,宋国锋,陶小平,代如成,张权,蒋景华,刘应玲"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009A.03",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "王鹤,陶小平,曾华凌,张华洋,孙晓宇,祝巍,梁燕,胡晓敏,沈镇,蔡俊,赵霞,赵伟,李恒一,吴玉椿,张增明,韦先涛,王中平,王晓方,宋国锋,刘应玲,郭玉刚,李海欧,岳盈,张乔枫,曲广媛,张杨,张权,蒋景华,代如成,浦其荣"
+          },
+          "previous": {
+            "id": "PHYS1009A.03",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009A.03",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "王鹤,陶小平,曾华凌,张华洋,孙晓宇,祝巍,梁燕,胡晓敏,沈镇,蔡俊,赵霞,赵伟,李恒一,吴玉椿,张增明,韦先涛,王中平,王晓方,宋国锋,刘应玲,郭玉刚,李海欧,岳盈,张乔枫,曲广媛,张杨,张权,蒋景华,代如成,浦其荣",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+              "after": "王鹤,陶小平,曾华凌,张华洋,孙晓宇,祝巍,梁燕,胡晓敏,沈镇,蔡俊,赵霞,赵伟,李恒一,吴玉椿,张增明,韦先涛,王中平,王晓方,宋国锋,刘应玲,郭玉刚,李海欧,岳盈,张乔枫,曲广媛,张杨,张权,蒋景华,代如成,浦其荣"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009A.04",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "曾华凌,张华洋,蔡俊,沈镇,浦其荣,赵霞,祝巍,孙晓宇,王鹤,胡晓敏,曲广媛,蒋景华,张乔枫,韦先涛,张权,岳盈,王晓方,吴玉椿,代如成,郭玉刚,宋国锋,王中平,张增明,刘应玲,张杨,李海欧,梁燕,李恒一,赵伟,陶小平"
+          },
+          "previous": {
+            "id": "PHYS1009A.04",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009A.04",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "曾华凌,张华洋,蔡俊,沈镇,浦其荣,赵霞,祝巍,孙晓宇,王鹤,胡晓敏,曲广媛,蒋景华,张乔枫,韦先涛,张权,岳盈,王晓方,吴玉椿,代如成,郭玉刚,宋国锋,王中平,张增明,刘应玲,张杨,李海欧,梁燕,李恒一,赵伟,陶小平",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+              "after": "曾华凌,张华洋,蔡俊,沈镇,浦其荣,赵霞,祝巍,孙晓宇,王鹤,胡晓敏,曲广媛,蒋景华,张乔枫,韦先涛,张权,岳盈,王晓方,吴玉椿,代如成,郭玉刚,宋国锋,王中平,张增明,刘应玲,张杨,李海欧,梁燕,李恒一,赵伟,陶小平"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009A.05",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "胡晓敏,宋国锋,沈镇,刘应玲,孙晓宇,王中平,吴玉椿,浦其荣,张华洋,张增明,李恒一,赵伟,张杨,祝巍,李海欧,赵霞,曾华凌,代如成,郭玉刚,蔡俊,王晓方,王鹤,岳盈,陶小平,张乔枫,韦先涛,蒋景华,张权,曲广媛,梁燕"
+          },
+          "previous": {
+            "id": "PHYS1009A.05",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009A.05",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "胡晓敏,宋国锋,沈镇,刘应玲,孙晓宇,王中平,吴玉椿,浦其荣,张华洋,张增明,李恒一,赵伟,张杨,祝巍,李海欧,赵霞,曾华凌,代如成,郭玉刚,蔡俊,王晓方,王鹤,岳盈,陶小平,张乔枫,韦先涛,蒋景华,张权,曲广媛,梁燕",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+              "after": "胡晓敏,宋国锋,沈镇,刘应玲,孙晓宇,王中平,吴玉椿,浦其荣,张华洋,张增明,李恒一,赵伟,张杨,祝巍,李海欧,赵霞,曾华凌,代如成,郭玉刚,蔡俊,王晓方,王鹤,岳盈,陶小平,张乔枫,韦先涛,蒋景华,张权,曲广媛,梁燕"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009A.06",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "祝巍,蔡俊,张华洋,赵伟,曾华凌,蒋景华,陶小平,李海欧,李恒一,王鹤,张杨,梁燕,浦其荣,刘应玲,岳盈,郭玉刚,宋国锋,王中平,王晓方,曲广媛,张增明,吴玉椿,代如成,沈镇,张乔枫,韦先涛,张权,孙晓宇,胡晓敏,赵霞"
+          },
+          "previous": {
+            "id": "PHYS1009A.06",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009A.06",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "祝巍,蔡俊,张华洋,赵伟,曾华凌,蒋景华,陶小平,李海欧,李恒一,王鹤,张杨,梁燕,浦其荣,刘应玲,岳盈,郭玉刚,宋国锋,王中平,王晓方,曲广媛,张增明,吴玉椿,代如成,沈镇,张乔枫,韦先涛,张权,孙晓宇,胡晓敏,赵霞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+              "after": "祝巍,蔡俊,张华洋,赵伟,曾华凌,蒋景华,陶小平,李海欧,李恒一,王鹤,张杨,梁燕,浦其荣,刘应玲,岳盈,郭玉刚,宋国锋,王中平,王晓方,曲广媛,张增明,吴玉椿,代如成,沈镇,张乔枫,韦先涛,张权,孙晓宇,胡晓敏,赵霞"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009A.07",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张权,代如成,浦其荣,梁燕,胡晓敏,蔡俊,张华洋,赵伟,王中平,孙晓宇,张增明,李恒一,吴玉椿,李海欧,张杨,张乔枫,赵霞,韦先涛,祝巍,陶小平,宋国锋,岳盈,曾华凌,王晓方,郭玉刚,刘应玲,蒋景华,王鹤,曲广媛,沈镇"
+          },
+          "previous": {
+            "id": "PHYS1009A.07",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009A.07",
+            "courseCode": "PHYS1009A",
+            "courseName": "大学物理-综合实验A",
+            "teacher": "张权,代如成,浦其荣,梁燕,胡晓敏,蔡俊,张华洋,赵伟,王中平,孙晓宇,张增明,李恒一,吴玉椿,李海欧,张杨,张乔枫,赵霞,韦先涛,祝巍,陶小平,宋国锋,岳盈,曾华凌,王晓方,郭玉刚,刘应玲,蒋景华,王鹤,曲广媛,沈镇",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "第一教学楼",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋,蒋景华",
+              "after": "张权,代如成,浦其荣,梁燕,胡晓敏,蔡俊,张华洋,赵伟,王中平,孙晓宇,张增明,李恒一,吴玉椿,李海欧,张杨,张乔枫,赵霞,韦先涛,祝巍,陶小平,宋国锋,岳盈,曾华凌,王晓方,郭玉刚,刘应玲,蒋景华,王鹤,曲广媛,沈镇"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009B.01",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "韦先涛,赵霞,张乔枫,王中平,代如成,吴玉椿,宋国锋,蒋景华,陶小平,曾华凌,梁燕,张杨,郭玉刚,王晓方,刘应玲,浦其荣,李海欧,李恒一,沈镇,王鹤,张华洋,曲广媛,张权,赵伟,祝巍,岳盈,胡晓敏,蔡俊,孙晓宇,张增明"
+          },
+          "previous": {
+            "id": "PHYS1009B.01",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "代如成,刘应玲,吴玉椿,孙晓宇,宋国锋,岳盈,张乔枫,张华洋,张增明,张权,张杨,曲广媛,曾华凌,李恒一,梁燕,沈镇,浦其荣,王中平,王晓方,王鹤,祝巍,胡晓敏,蔡俊,赵伟,赵霞,郭玉刚,陶小平,韦先涛,蒋景华",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009B.01",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "韦先涛,赵霞,张乔枫,王中平,代如成,吴玉椿,宋国锋,蒋景华,陶小平,曾华凌,梁燕,张杨,郭玉刚,王晓方,刘应玲,浦其荣,李海欧,李恒一,沈镇,王鹤,张华洋,曲广媛,张权,赵伟,祝巍,岳盈,胡晓敏,蔡俊,孙晓宇,张增明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 1,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "代如成,刘应玲,吴玉椿,孙晓宇,宋国锋,岳盈,张乔枫,张华洋,张增明,张权,张杨,曲广媛,曾华凌,李恒一,梁燕,沈镇,浦其荣,王中平,王晓方,王鹤,祝巍,胡晓敏,蔡俊,赵伟,赵霞,郭玉刚,陶小平,韦先涛,蒋景华",
+              "after": "韦先涛,赵霞,张乔枫,王中平,代如成,吴玉椿,宋国锋,蒋景华,陶小平,曾华凌,梁燕,张杨,郭玉刚,王晓方,刘应玲,浦其荣,李海欧,李恒一,沈镇,王鹤,张华洋,曲广媛,张权,赵伟,祝巍,岳盈,胡晓敏,蔡俊,孙晓宇,张增明"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009B.02",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "曾华凌,蒋景华,孙晓宇,王鹤,祝巍,赵霞,蔡俊,沈镇,浦其荣,梁燕,李恒一,赵伟,张增明,吴玉椿,王中平,刘应玲,郭玉刚,宋国锋,韦先涛,王晓方,岳盈,张乔枫,李海欧,胡晓敏,张杨,张权,曲广媛,代如成,陶小平,张华洋"
+          },
+          "previous": {
+            "id": "PHYS1009B.02",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009B.02",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "曾华凌,蒋景华,孙晓宇,王鹤,祝巍,赵霞,蔡俊,沈镇,浦其荣,梁燕,李恒一,赵伟,张增明,吴玉椿,王中平,刘应玲,郭玉刚,宋国锋,韦先涛,王晓方,岳盈,张乔枫,李海欧,胡晓敏,张杨,张权,曲广媛,代如成,陶小平,张华洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 1,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+              "after": "曾华凌,蒋景华,孙晓宇,王鹤,祝巍,赵霞,蔡俊,沈镇,浦其荣,梁燕,李恒一,赵伟,张增明,吴玉椿,王中平,刘应玲,郭玉刚,宋国锋,韦先涛,王晓方,岳盈,张乔枫,李海欧,胡晓敏,张杨,张权,曲广媛,代如成,陶小平,张华洋"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009B.03",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "祝巍,孙晓宇,赵伟,陶小平,蒋景华,张华洋,李海欧,浦其荣,梁燕,张杨,曾华凌,郭玉刚,刘应玲,王晓方,王鹤,曲广媛,代如成,吴玉椿,胡晓敏,王中平,张权,宋国锋,韦先涛,岳盈,李恒一,张乔枫,张增明,蔡俊,沈镇,赵霞"
+          },
+          "previous": {
+            "id": "PHYS1009B.03",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009B.03",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "祝巍,孙晓宇,赵伟,陶小平,蒋景华,张华洋,李海欧,浦其荣,梁燕,张杨,曾华凌,郭玉刚,刘应玲,王晓方,王鹤,曲广媛,代如成,吴玉椿,胡晓敏,王中平,张权,宋国锋,韦先涛,岳盈,李恒一,张乔枫,张增明,蔡俊,沈镇,赵霞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 2,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+              "after": "祝巍,孙晓宇,赵伟,陶小平,蒋景华,张华洋,李海欧,浦其荣,梁燕,张杨,曾华凌,郭玉刚,刘应玲,王晓方,王鹤,曲广媛,代如成,吴玉椿,胡晓敏,王中平,张权,宋国锋,韦先涛,岳盈,李恒一,张乔枫,张增明,蔡俊,沈镇,赵霞"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009B.04",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "岳盈,吴玉椿,郭玉刚,刘应玲,王中平,梁燕,张乔枫,胡晓敏,李海欧,韦先涛,张权,王晓方,曲广媛,王鹤,曾华凌,陶小平,代如成,蒋景华,祝巍,张华洋,赵霞,赵伟,蔡俊,张杨,浦其荣,李恒一,沈镇,孙晓宇,张增明,宋国锋"
+          },
+          "previous": {
+            "id": "PHYS1009B.04",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009B.04",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "岳盈,吴玉椿,郭玉刚,刘应玲,王中平,梁燕,张乔枫,胡晓敏,李海欧,韦先涛,张权,王晓方,曲广媛,王鹤,曾华凌,陶小平,代如成,蒋景华,祝巍,张华洋,赵霞,赵伟,蔡俊,张杨,浦其荣,李恒一,沈镇,孙晓宇,张增明,宋国锋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 2,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+              "after": "岳盈,吴玉椿,郭玉刚,刘应玲,王中平,梁燕,张乔枫,胡晓敏,李海欧,韦先涛,张权,王晓方,曲广媛,王鹤,曾华凌,陶小平,代如成,蒋景华,祝巍,张华洋,赵霞,赵伟,蔡俊,张杨,浦其荣,李恒一,沈镇,孙晓宇,张增明,宋国锋"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009B.05",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张权,张增明,蔡俊,浦其荣,孙晓宇,胡晓敏,梁燕,沈镇,宋国锋,曾华凌,郭玉刚,刘应玲,岳盈,王晓方,曲广媛,陶小平,代如成,蒋景华,李海欧,张乔枫,韦先涛,赵霞,张杨,祝巍,赵伟,张华洋,王中平,吴玉椿,李恒一,王鹤"
+          },
+          "previous": {
+            "id": "PHYS1009B.05",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009B.05",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张权,张增明,蔡俊,浦其荣,孙晓宇,胡晓敏,梁燕,沈镇,宋国锋,曾华凌,郭玉刚,刘应玲,岳盈,王晓方,曲广媛,陶小平,代如成,蒋景华,李海欧,张乔枫,韦先涛,赵霞,张杨,祝巍,赵伟,张华洋,王中平,吴玉椿,李恒一,王鹤",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 3,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+              "after": "张权,张增明,蔡俊,浦其荣,孙晓宇,胡晓敏,梁燕,沈镇,宋国锋,曾华凌,郭玉刚,刘应玲,岳盈,王晓方,曲广媛,陶小平,代如成,蒋景华,李海欧,张乔枫,韦先涛,赵霞,张杨,祝巍,赵伟,张华洋,王中平,吴玉椿,李恒一,王鹤"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009B.06",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "王中平,赵伟,曲广媛,胡晓敏,刘应玲,郭玉刚,梁燕,蒋景华,沈镇,王鹤,蔡俊,曾华凌,王晓方,张乔枫,韦先涛,岳盈,张权,宋国锋,陶小平,代如成,祝巍,张杨,赵霞,李海欧,浦其荣,孙晓宇,张增明,张华洋,吴玉椿,李恒一"
+          },
+          "previous": {
+            "id": "PHYS1009B.06",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009B.06",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "王中平,赵伟,曲广媛,胡晓敏,刘应玲,郭玉刚,梁燕,蒋景华,沈镇,王鹤,蔡俊,曾华凌,王晓方,张乔枫,韦先涛,岳盈,张权,宋国锋,陶小平,代如成,祝巍,张杨,赵霞,李海欧,浦其荣,孙晓宇,张增明,张华洋,吴玉椿,李恒一",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+              "after": "王中平,赵伟,曲广媛,胡晓敏,刘应玲,郭玉刚,梁燕,蒋景华,沈镇,王鹤,蔡俊,曾华凌,王晓方,张乔枫,韦先涛,岳盈,张权,宋国锋,陶小平,代如成,祝巍,张杨,赵霞,李海欧,浦其荣,孙晓宇,张增明,张华洋,吴玉椿,李恒一"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS1009B.07",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "韦先涛,梁燕,张增明,李海欧,王中平,吴玉椿,郭玉刚,代如成,王晓方,祝巍,蒋景华,赵霞,曲广媛,宋国锋,张权,岳盈,蔡俊,胡晓敏,李恒一,王鹤,沈镇,浦其荣,孙晓宇,曾华凌,陶小平,赵伟,刘应玲,张杨,张华洋,张乔枫"
+          },
+          "previous": {
+            "id": "PHYS1009B.07",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS1009B.07",
+            "courseCode": "PHYS1009B",
+            "courseName": "大学物理-综合实验B",
+            "teacher": "韦先涛,梁燕,张增明,李海欧,王中平,吴玉椿,郭玉刚,代如成,王晓方,祝巍,蒋景华,赵霞,曲广媛,宋国锋,张权,岳盈,蔡俊,胡晓敏,李恒一,王鹤,沈镇,浦其荣,孙晓宇,曾华凌,陶小平,赵伟,刘应玲,张杨,张华洋,张乔枫",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "东区教1楼物理实验室",
+                "day": 5,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "张杨,蔡俊,陶小平,浦其荣,吴玉椿,王中平,梁燕,张权,韦先涛,赵伟,赵霞,郭玉刚,祝巍,刘应玲,张增明,曾华凌,王晓方,代如成,曲广媛,李恒一,沈镇,胡晓敏,蒋景华,张乔枫,孙晓宇,宋国锋,岳盈,王鹤,张华洋",
+              "after": "韦先涛,梁燕,张增明,李海欧,王中平,吴玉椿,郭玉刚,代如成,王晓方,祝巍,蒋景华,赵霞,曲广媛,宋国锋,张权,岳盈,蔡俊,胡晓敏,李恒一,王鹤,沈镇,浦其荣,孙晓宇,曾华凌,陶小平,赵伟,刘应玲,张杨,张华洋,张乔枫"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS2701.01",
+            "courseCode": "PHYS2701",
+            "courseName": "物理创新能力提升实验I",
+            "teacher": "许劲松,彭晨晖,浦其荣,张增明,陶小平,项国勇,岳盈,曲广媛,何俊峰,王中平,陈文翔,赵伟,赵霞"
+          },
+          "previous": {
+            "id": "PHYS2701.01",
+            "courseCode": "PHYS2701",
+            "courseName": "物理创新能力提升实验I",
+            "teacher": "项国勇,陶小平,浦其荣,王中平,赵伟,赵霞,许劲松,曲广媛,何俊峰,彭晨晖,陈文翔,孙晓宇,张增明",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "每周四晚上7:00-10:00,地点:第一教学楼1418实验室、1318实验室等",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS2701.01",
+            "courseCode": "PHYS2701",
+            "courseName": "物理创新能力提升实验I",
+            "teacher": "许劲松,彭晨晖,浦其荣,张增明,陶小平,项国勇,岳盈,曲广媛,何俊峰,王中平,陈文翔,赵伟,赵霞",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "每周四晚上7:00-10:00,地点:第一教学楼1418实验室、1318实验室等",
+                "day": 4,
+                "periods": [
+                  11,
+                  12,
+                  13
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "项国勇,陶小平,浦其荣,王中平,赵伟,赵霞,许劲松,曲广媛,何俊峰,彭晨晖,陈文翔,孙晓宇,张增明",
+              "after": "许劲松,彭晨晖,浦其荣,张增明,陶小平,项国勇,岳盈,曲广媛,何俊峰,王中平,陈文翔,赵伟,赵霞"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS2702.01",
+            "courseCode": "PHYS2702",
+            "courseName": "物理创新能力提升实验II",
+            "teacher": "赵伟,王鹤,韦先涛,王中平,曲广媛,张增明,宋国锋,祝巍,代如成"
+          },
+          "previous": {
+            "id": "PHYS2702.01",
+            "courseCode": "PHYS2702",
+            "courseName": "物理创新能力提升实验II",
+            "teacher": "王中平,韦先涛,赵伟,祝巍,张增明,张华洋,代如成,曲广媛,孙晓宇,岳盈,王鹤,陈宇翱",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "每周四下午2:00-6:00,地点:第一教学楼1418实验室、1318实验室等",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS2702.01",
+            "courseCode": "PHYS2702",
+            "courseName": "物理创新能力提升实验II",
+            "teacher": "赵伟,王鹤,韦先涛,王中平,曲广媛,张增明,宋国锋,祝巍,代如成",
+            "level": "本科",
+            "schedule": [
+              {
+                "weeks": [
+                  3,
+                  18
+                ],
+                "room": "每周四下午2:00-6:00,地点:第一教学楼1418实验室、1318实验室等",
+                "day": 4,
+                "periods": [
+                  6,
+                  7,
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "王中平,韦先涛,赵伟,祝巍,张增明,张华洋,代如成,曲广媛,孙晓宇,岳盈,王鹤,陈宇翱",
+              "after": "赵伟,王鹤,韦先涛,王中平,曲广媛,张增明,宋国锋,祝巍,代如成"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS5052P.01",
+            "courseCode": "PHYS5052P",
+            "courseName": "核与粒子物理实验方法",
+            "teacher": "杨洪洮,彭海平,薛明萱"
+          },
+          "previous": {
+            "id": "PHYS5052P.01",
+            "courseCode": "PHYS5052P",
+            "courseName": "核与粒子物理实验方法",
+            "teacher": "杨洪洮,彭海平",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "1102",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  17,
+                  18
+                ],
+                "room": "1102",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "1102",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  17,
+                  18
+                ],
+                "room": "1102",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS5052P.01",
+            "courseCode": "PHYS5052P",
+            "courseName": "核与粒子物理实验方法",
+            "teacher": "杨洪洮,彭海平,薛明萱",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "1102",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  17,
+                  18
+                ],
+                "room": "1102",
+                "day": 1,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  16
+                ],
+                "room": "1102",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  17,
+                  18
+                ],
+                "room": "1102",
+                "day": 5,
+                "periods": [
+                  3,
+                  4
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "杨洪洮,彭海平",
+              "after": "杨洪洮,彭海平,薛明萱"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS5257P.01",
+            "courseCode": "PHYS5257P",
+            "courseName": "量子信息技术",
+            "teacher": "韩正甫,李明"
+          },
+          "previous": {
+            "id": "PHYS5257P.01",
+            "courseCode": "PHYS5257P",
+            "courseName": "量子信息技术",
+            "teacher": "韩正甫,李明",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5104",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  17
+                ],
+                "room": "5104",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  10
+                ],
+                "room": "5104",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5104",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  17
+                ],
+                "room": "5104",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  10
+                ],
+                "room": "5104",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS5257P.01",
+            "courseCode": "PHYS5257P",
+            "courseName": "量子信息技术",
+            "teacher": "韩正甫,李明",
+            "level": "本研贯通",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5104",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  17
+                ],
+                "room": "5104",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  10
+                ],
+                "room": "5104",
+                "day": 2,
+                "periods": [
+                  1,
+                  2
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  9
+                ],
+                "room": "5104",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  11,
+                  17
+                ],
+                "room": "5104",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  10,
+                  10
+                ],
+                "room": "5104",
+                "day": 4,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 100,
+              "after": 110
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "PHYS6403P.01",
+            "courseCode": "PHYS6403P",
+            "courseName": "量子多体理论(I)",
+            "teacher": "刘国柱"
+          },
+          "previous": {
+            "id": "PHYS6403P.01",
+            "courseCode": "PHYS6403P",
+            "courseName": "量子多体理论(I)",
+            "teacher": "刘国柱",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5502",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5502",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "PHYS6403P.01",
+            "courseCode": "PHYS6403P",
+            "courseName": "量子多体理论(I)",
+            "teacher": "刘国柱",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5502",
+                "day": 5,
+                "periods": [
+                  6,
+                  7
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "5502",
+                "day": 5,
+                "periods": [
+                  8,
+                  9
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 130,
+              "after": 150
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "REEN6202U.01",
+            "courseCode": "REEN6202U",
+            "courseName": "专业英语(环境工程)",
+            "teacher": "杨一"
+          },
+          "previous": {
+            "id": "REEN6202U.01",
+            "courseCode": "REEN6202U",
+            "courseName": "专业英语(环境工程)",
+            "teacher": "杨一",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "3A405",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "3A405",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "REEN6202U.01",
+            "courseCode": "REEN6202U",
+            "courseName": "专业英语(环境工程)",
+            "teacher": "杨一",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  7
+                ],
+                "room": "3A405",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              },
+              {
+                "weeks": [
+                  1,
+                  7
+                ],
+                "room": "3A405",
+                "day": 4,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "schedule",
+              "label": "上课时间与周次",
+              "before": [
+                {
+                  "weeks": [
+                    1,
+                    7
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    7
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ],
+              "after": [
+                {
+                  "weeks": [
+                    2,
+                    7
+                  ],
+                  "day": 2,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                },
+                {
+                  "weeks": [
+                    1,
+                    7
+                  ],
+                  "day": 4,
+                  "periods": [
+                    3,
+                    4,
+                    5
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "SCTH6001Q.01",
+            "courseCode": "SCTH6001Q",
+            "courseName": "文学与科技史",
+            "teacher": "宫旭"
+          },
+          "previous": {
+            "id": "SCTH6001Q.01",
+            "courseCode": "SCTH6001Q",
+            "courseName": "文学与科技史",
+            "teacher": "宫旭",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "2408",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "SCTH6001Q.01",
+            "courseCode": "SCTH6001Q",
+            "courseName": "文学与科技史",
+            "teacher": "宫旭",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  14
+                ],
+                "room": "5505",
+                "day": 2,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "基础",
+              "after": "公选课"
+            },
+            {
+              "field": "undergradShared",
+              "label": "本研同堂",
+              "before": false,
+              "after": true
+            },
+            {
+              "field": "capacity",
+              "label": "课容量",
+              "before": 60,
+              "after": 50
+            },
+            {
+              "field": "location",
+              "label": "上课地点或校区",
+              "before": [
+                {
+                  "room": "2408",
+                  "campus": "本部"
+                }
+              ],
+              "after": [
+                {
+                  "room": "5505",
+                  "campus": "本部"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "SCTH6404P.01",
+            "courseCode": "SCTH6404P",
+            "courseName": "生命科学史",
+            "teacher": "刘锐"
+          },
+          "previous": {
+            "id": "SCTH6404P.01",
+            "courseCode": "SCTH6404P",
+            "courseName": "生命科学史",
+            "teacher": "刘锐",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2404",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "SCTH6404P.01",
+            "courseCode": "SCTH6404P",
+            "courseName": "生命科学史",
+            "teacher": "刘锐",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2404",
+                "day": 2,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "基础",
+              "after": "专业"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "SCTH6405P.01",
+            "courseCode": "SCTH6405P",
+            "courseName": "中国传统医学史",
+            "teacher": "柯资能"
+          },
+          "previous": {
+            "id": "SCTH6405P.01",
+            "courseCode": "SCTH6405P",
+            "courseName": "中国传统医学史",
+            "teacher": "柯资能",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "SCTH6405P.01",
+            "courseCode": "SCTH6405P",
+            "courseName": "中国传统医学史",
+            "teacher": "柯资能",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2303",
+                "day": 1,
+                "periods": [
+                  8,
+                  9,
+                  10
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "基础",
+              "after": "专业"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "SCTH6409P.01",
+            "courseCode": "SCTH6409P",
+            "courseName": "科技政策史",
+            "teacher": "付邦红"
+          },
+          "previous": {
+            "id": "SCTH6409P.01",
+            "courseCode": "SCTH6409P",
+            "courseName": "科技政策史",
+            "teacher": "付邦红",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2305",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "SCTH6409P.01",
+            "courseCode": "SCTH6409P",
+            "courseName": "科技政策史",
+            "teacher": "付邦红",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2305",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "基础",
+              "after": "专业"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "SCTH7401P.01",
+            "courseCode": "SCTH7401P",
+            "courseName": "科技史前沿专题讨论",
+            "teacher": "石云里,钮卫星,王安轶,王程韡,丁兆君"
+          },
+          "previous": {
+            "id": "SCTH7401P.01",
+            "courseCode": "SCTH7401P",
+            "courseName": "科技史前沿专题讨论",
+            "teacher": "石云里,钮卫星,王安轶,王程韡,丁兆君",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "SCTH7401P.01",
+            "courseCode": "SCTH7401P",
+            "courseName": "科技史前沿专题讨论",
+            "teacher": "石云里,钮卫星,王安轶,王程韡,丁兆君",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2309",
+                "day": 3,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "基础",
+              "after": "专业"
+            }
+          ]
+        },
+        {
+          "course": {
+            "id": "SCTH7404P.01",
+            "courseCode": "SCTH7404P",
+            "courseName": "中西科技交流史专题",
+            "teacher": "钮卫星,朱浩浩,范安川,王安轶"
+          },
+          "previous": {
+            "id": "SCTH7404P.01",
+            "courseCode": "SCTH7404P",
+            "courseName": "中西科技交流史专题",
+            "teacher": "钮卫星,朱浩浩,范安川,王安轶",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2409",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "current": {
+            "id": "SCTH7404P.01",
+            "courseCode": "SCTH7404P",
+            "courseName": "中西科技交流史专题",
+            "teacher": "钮卫星,朱浩浩,范安川,王安轶",
+            "level": "研究生",
+            "schedule": [
+              {
+                "weeks": [
+                  2,
+                  18
+                ],
+                "room": "2409",
+                "day": 5,
+                "periods": [
+                  3,
+                  4,
+                  5
+                ],
+                "campus": "本部"
+              }
+            ]
+          },
+          "changes": [
+            {
+              "field": "sectionType",
+              "label": "教学班类型",
+              "before": "基础",
+              "after": "专业"
             }
           ]
         }

--- a/public/data/semesters/2026-summer/courses.json
+++ b/public/data/semesters/2026-summer/courses.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-31T07:14:01Z",
+  "generatedAt": "2026-09-02T10:00:11Z",
   "source": {
     "url": "https://catalog.ustc.edu.cn/query/lesson",
     "semesterId": 441
@@ -517,7 +517,7 @@
         "code": "013",
         "name": "热科学和能源工程系"
       },
-      "teacher": "胡茂彬",
+      "teacher": "李华山,龙臻,张宇",
       "credits": 2,
       "hours": 40,
       "level": "本科",
@@ -2713,7 +2713,7 @@
       "examType": "大作业（论文、报告、项目或作品等）",
       "grading": "百分制",
       "undergradShared": false,
-      "enrolled": 20,
+      "enrolled": 24,
       "capacity": 35,
       "classes": [
         "24信息科技英才班T"
@@ -6386,7 +6386,7 @@
       "examType": "笔试（开卷）",
       "grading": "百分制",
       "undergradShared": true,
-      "enrolled": 12,
+      "enrolled": 8,
       "capacity": 100,
       "classes": [],
       "rawSchedule": "5106: 1(3,4,5);5106: 2(3,4,5);5106: 3(3,4,5);5106: 4(3,4,5)",
@@ -11487,5 +11487,5 @@
       }
     }
   },
-  "revision": "545a0522aa4f3f117169d11d89b3ee96055be807d989a71aa2afbb13b152efca"
+  "revision": "d18f360b6d28ee83d94a7d3c2d8a5bd58ebf2e6c7b981f63c44fb50b56d157e4"
 }

--- a/public/data/semesters/2026-summer/updates.json
+++ b/public/data/semesters/2026-summer/updates.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "semesterKey": "2026-summer",
-  "currentRevision": "545a0522aa4f3f117169d11d89b3ee96055be807d989a71aa2afbb13b152efca",
+  "currentRevision": "d18f360b6d28ee83d94a7d3c2d8a5bd58ebf2e6c7b981f63c44fb50b56d157e4",
   "entries": [
     {
       "id": "2026-summer:193249c0acc6eee0",
@@ -6604,6 +6604,53 @@
               "label": "授课教师",
               "before": "",
               "after": "David Garcia,Matthew Bell"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "2026-summer:d18f360b6d28ee83",
+      "revision": "d18f360b6d28ee83d94a7d3c2d8a5bd58ebf2e6c7b981f63c44fb50b56d157e4",
+      "previousRevision": "545a0522aa4f3f117169d11d89b3ee96055be807d989a71aa2afbb13b152efca",
+      "publishedAt": "2026-09-02T10:00:11Z",
+      "summary": {
+        "added": 0,
+        "removed": 0,
+        "modified": 1
+      },
+      "added": [],
+      "removed": [],
+      "modified": [
+        {
+          "course": {
+            "id": "013J01.01",
+            "courseCode": "013J01",
+            "courseName": "新能源利用技术前沿",
+            "teacher": "李华山,龙臻,张宇"
+          },
+          "previous": {
+            "id": "013J01.01",
+            "courseCode": "013J01",
+            "courseName": "新能源利用技术前沿",
+            "teacher": "胡茂彬",
+            "level": "本科",
+            "schedule": []
+          },
+          "current": {
+            "id": "013J01.01",
+            "courseCode": "013J01",
+            "courseName": "新能源利用技术前沿",
+            "teacher": "李华山,龙臻,张宇",
+            "level": "本科",
+            "schedule": []
+          },
+          "changes": [
+            {
+              "field": "teacher",
+              "label": "授课教师",
+              "before": "胡茂彬",
+              "after": "李华山,龙臻,张宇"
             }
           ]
         }

--- a/public/data/semesters/index.json
+++ b/public/data/semesters/index.json
@@ -6,14 +6,14 @@
       "key": "2026-fall",
       "name": "2026年秋季学期",
       "file": "2026-fall/courses.json",
-      "revision": "3ff1ca8c9f5299e70f9efc86a9c80b474aa9c525bf833b1b9637334454bd4716",
+      "revision": "ba1b7ac337294a25f8bcf617f4fecee3b9ec838d8154ecd63133e98ad2240946",
       "updatesFile": "2026-fall/updates.json"
     },
     {
       "key": "2026-summer",
       "name": "2026年夏季学期",
       "file": "2026-summer/courses.json",
-      "revision": "545a0522aa4f3f117169d11d89b3ee96055be807d989a71aa2afbb13b152efca",
+      "revision": "d18f360b6d28ee83d94a7d3c2d8a5bd58ebf2e6c7b981f63c44fb50b56d157e4",
       "updatesFile": "2026-summer/updates.json"
     }
   ]

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,6 @@ wheels = [
 name = "class-arrange"
 version = "0.1.0"
 source = { virtual = "." }
-dependencies = []
 
 [package.dev-dependencies]
 dev = [
@@ -101,7 +100,6 @@ spider = [
 ]
 
 [package.metadata]
-requires-dist = []
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=9.1.1" }]


### PR DESCRIPTION
## 数据刷新

按 MAINTENANCE.md 第一节执行 `sync-lessons` + `validate-lessons --all`。

### 同步结果
- **2026-fall**: 2917 门课，校验零失败（scheduled 2513 == raw_schedule_non_empty 2513）
- **2026-summer**: 89 门课，校验零失败（scheduled 64 == raw_schedule_non_empty 64）

### updates.json 追加条目
- 2026-fall: added=96, removed=13, modified=194
- 2026-summer: modified=1

### 验证
- [x] revision 四处一致（index.json == courses.json == updates.json currentRevision == 最新 entry）
- [x] validate-lessons --all 通过
- [x] pnpm test 457 通过
- [x] 纯数据更新，无前端联动，不改 APP_RELEASES